### PR TITLE
Add an RPC to request and track votes, along with a callback

### DIFF
--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -1460,3 +1460,18 @@ TEST (node, bootstrap_connection_scaling)
 	ASSERT_EQ (1, attempt->target_connections (0));
 	ASSERT_EQ (1, attempt->target_connections (50000));
 }
+
+TEST (node, online_reps)
+{
+	rai::system system (24000, 2);
+	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
+	ASSERT_TRUE (system.nodes[1]->online_reps.online_stake ().is_zero ());
+	system.wallet (0)->send_action (rai::test_genesis_key.pub, rai::test_genesis_key.pub, rai::Gxrb_ratio);
+	auto iterations (0);
+	while (system.nodes[1]->online_reps.online_stake ().is_zero ())
+	{
+		system.poll ();
+		++iterations;
+		ASSERT_LT (iterations, 200);
+	}
+}

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -3436,5 +3436,5 @@ TEST (rpc, online_reps)
 	auto item (representatives.begin ());
 	ASSERT_NE (representatives.end (), item);
 	ASSERT_EQ (rai::test_genesis_key.pub.to_account (), item->first);
-	system.nodes [1]->stop ();
+	system.nodes[1]->stop ();
 }

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -3408,3 +3408,33 @@ TEST (rpc, wallet_add_watch)
 	ASSERT_TRUE (success.empty ());
 	ASSERT_TRUE (system.wallet (0)->exists (rai::test_genesis_key.pub));
 }
+
+TEST (rpc, online_reps)
+{
+	rai::system system (24000, 2);
+	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
+	ASSERT_TRUE (system.nodes[1]->online_reps.online_stake ().is_zero ());
+	system.wallet (0)->send_action (rai::test_genesis_key.pub, rai::test_genesis_key.pub, rai::Gxrb_ratio);
+	auto iterations (0);
+	while (system.nodes[1]->online_reps.online_stake ().is_zero ())
+	{
+		system.poll ();
+		++iterations;
+		ASSERT_LT (iterations, 200);
+	}
+	rai::rpc rpc (system.service, *system.nodes[1], rai::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "representatives_online");
+	test_response response (request, rpc, system.service);
+	while (response.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	auto representatives (response.json.get_child ("representatives"));
+	auto item (representatives.begin ());
+	ASSERT_NE (representatives.end (), item);
+	ASSERT_EQ (rai::test_genesis_key.pub.to_account (), item->first);
+	system.nodes [1]->stop ();
+}

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -993,7 +993,8 @@ void rai::bootstrap_attempt::try_resolve_fork (MDB_txn * transaction_a, std::sha
 		std::shared_ptr<rai::block> ledger_block (node->ledger.forked_block (transaction_a, *block_a));
 		if (ledger_block)
 		{
-			node->active.start (transaction_a, ledger_block, [this_w, block_a](std::shared_ptr<rai::block>, bool resolved) {
+			node->active.start (transaction_a, ledger_block, boost::none, [this_w, block_a](std::shared_ptr<rai::block>, rai::election_result result) {
+				auto resolved (result.exceeded_min_threshold);
 				if (auto this_l = this_w.lock ())
 				{
 					if (resolved)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2506,10 +2506,10 @@ rai::uint128_t rai::online_reps::online_stake ()
 	return online_stake_total;
 }
 
-std::deque<rai::account> rai::online_reps::list()
+std::deque<rai::account> rai::online_reps::list ()
 {
 	std::deque<rai::account> result;
-	std::lock_guard <std::mutex> lock (mutex);
+	std::lock_guard<std::mutex> lock (mutex);
 	for (auto i (reps.begin ()), n (reps.end ()); i != n; ++i)
 	{
 		result.push_back (i->representative);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2506,6 +2506,17 @@ rai::uint128_t rai::online_reps::online_stake ()
 	return online_stake_total;
 }
 
+std::deque<rai::account> rai::online_reps::list()
+{
+	std::deque<rai::account> result;
+	std::lock_guard <std::mutex> lock (mutex);
+	for (auto i (reps.begin ()), n (reps.end ()); i != n; ++i)
+	{
+		result.push_back (i->representative);
+	}
+	return result;
+}
+
 std::unordered_set<rai::endpoint> rai::peer_container::random_set (size_t count_a)
 {
 	std::unordered_set<rai::endpoint> result;

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -31,6 +31,7 @@ std::chrono::minutes constexpr rai::node::backup_interval;
 int constexpr rai::port_mapping::mapping_timeout;
 int constexpr rai::port_mapping::check_timeout;
 unsigned constexpr rai::active_transactions::announce_interval_ms;
+unsigned constexpr rai::active_transactions::election_history_size;
 
 rai::message_statistics::message_statistics () :
 keepalive (0),
@@ -412,67 +413,70 @@ void rai::network::receive_action (boost::system::error_code const & error, size
 	{
 		if (!rai::reserved_address (remote) && remote != endpoint ())
 		{
-			network_message_visitor visitor (node, remote);
-			rai::message_parser parser (visitor, node.work);
-			parser.deserialize_buffer (buffer.data (), size_a);
-			if (parser.status != rai::message_parser::parse_status::success)
+			if (!packet_filter || !packet_filter (buffer.data (), size_a))
 			{
-				++error_count;
+				network_message_visitor visitor (node, remote);
+				rai::message_parser parser (visitor, node.work);
+				parser.deserialize_buffer (buffer.data (), size_a);
+				if (parser.status != rai::message_parser::parse_status::success)
+				{
+					++error_count;
 
-				if (parser.status == rai::message_parser::parse_status::insufficient_work)
-				{
-					if (node.config.logging.insufficient_work_logging ())
+					if (parser.status == rai::message_parser::parse_status::insufficient_work)
 					{
-						BOOST_LOG (node.log) << "Insufficient work in message";
-					}
+						if (node.config.logging.insufficient_work_logging ())
+						{
+							BOOST_LOG (node.log) << "Insufficient work in message";
+						}
 
-					++insufficient_work_count;
-				}
-				else if (parser.status == rai::message_parser::parse_status::invalid_message_type)
-				{
-					if (node.config.logging.network_logging ())
-					{
-						BOOST_LOG (node.log) << "Invalid message type in message";
+						++insufficient_work_count;
 					}
-				}
-				else if (parser.status == rai::message_parser::parse_status::invalid_header)
-				{
-					if (node.config.logging.network_logging ())
+					else if (parser.status == rai::message_parser::parse_status::invalid_message_type)
 					{
-						BOOST_LOG (node.log) << "Invalid header in message";
+						if (node.config.logging.network_logging ())
+						{
+							BOOST_LOG (node.log) << "Invalid message type in message";
+						}
 					}
-				}
-				else if (parser.status == rai::message_parser::parse_status::invalid_keepalive_message)
-				{
-					if (node.config.logging.network_logging ())
+					else if (parser.status == rai::message_parser::parse_status::invalid_header)
 					{
-						BOOST_LOG (node.log) << "Invalid keepalive message";
+						if (node.config.logging.network_logging ())
+						{
+							BOOST_LOG (node.log) << "Invalid header in message";
+						}
 					}
-				}
-				else if (parser.status == rai::message_parser::parse_status::invalid_publish_message)
-				{
-					if (node.config.logging.network_logging ())
+					else if (parser.status == rai::message_parser::parse_status::invalid_keepalive_message)
 					{
-						BOOST_LOG (node.log) << "Invalid publish message";
+						if (node.config.logging.network_logging ())
+						{
+							BOOST_LOG (node.log) << "Invalid keepalive message";
+						}
 					}
-				}
-				else if (parser.status == rai::message_parser::parse_status::invalid_confirm_req_message)
-				{
-					if (node.config.logging.network_logging ())
+					else if (parser.status == rai::message_parser::parse_status::invalid_publish_message)
 					{
-						BOOST_LOG (node.log) << "Invalid confirm_req message";
+						if (node.config.logging.network_logging ())
+						{
+							BOOST_LOG (node.log) << "Invalid publish message";
+						}
 					}
-				}
-				else if (parser.status == rai::message_parser::parse_status::invalid_confirm_ack_message)
-				{
-					if (node.config.logging.network_logging ())
+					else if (parser.status == rai::message_parser::parse_status::invalid_confirm_req_message)
 					{
-						BOOST_LOG (node.log) << "Invalid confirm_ack message";
+						if (node.config.logging.network_logging ())
+						{
+							BOOST_LOG (node.log) << "Invalid confirm_req message";
+						}
 					}
-				}
-				else
-				{
-					BOOST_LOG (node.log) << "Could not deserialize buffer";
+					else if (parser.status == rai::message_parser::parse_status::invalid_confirm_ack_message)
+					{
+						if (node.config.logging.network_logging ())
+						{
+							BOOST_LOG (node.log) << "Invalid confirm_ack message";
+						}
+					}
+					else
+					{
+						BOOST_LOG (node.log) << "Could not deserialize buffer";
+					}
 				}
 			}
 		}
@@ -801,7 +805,9 @@ bootstrap_connections_max (64),
 callback_port (0),
 lmdb_max_dbs (128),
 state_block_parse_canary (0),
-state_block_generate_canary (0)
+state_block_generate_canary (0),
+vote_callback_min_rep_percent (1.0),
+confirmation_rep_percent (60.0)
 {
 	switch (rai::rai_network)
 	{
@@ -835,7 +841,7 @@ state_block_generate_canary (0)
 
 void rai::node_config::serialize_json (boost::property_tree::ptree & tree_a) const
 {
-	tree_a.put ("version", "10");
+	tree_a.put ("version", "11");
 	tree_a.put ("peering_port", std::to_string (peering_port));
 	tree_a.put ("bootstrap_fraction_numerator", std::to_string (bootstrap_fraction_numerator));
 	tree_a.put ("receive_minimum", receive_minimum.to_string_dec ());
@@ -875,10 +881,17 @@ void rai::node_config::serialize_json (boost::property_tree::ptree & tree_a) con
 	tree_a.put ("bootstrap_connections_max", bootstrap_connections_max);
 	tree_a.put ("callback_address", callback_address);
 	tree_a.put ("callback_port", std::to_string (callback_port));
-	tree_a.put ("callback_target", callback_target);
 	tree_a.put ("lmdb_max_dbs", lmdb_max_dbs);
 	tree_a.put ("state_block_parse_canary", state_block_parse_canary.to_string ());
 	tree_a.put ("state_block_generate_canary", state_block_generate_canary.to_string ());
+	boost::property_tree::ptree callback_targets_l;
+	for (auto it : callback_targets)
+	{
+		callback_targets_l.put (it.first, it.second);
+	}
+	tree_a.add_child ("callback_targets", callback_targets_l);
+	tree_a.put ("vote_callback_min_rep_percent", vote_callback_min_rep_percent);
+	tree_a.put ("confirmation_rep_percent", confirmation_rep_percent);
 }
 
 bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptree & tree_a)
@@ -959,6 +972,25 @@ bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptr
 			tree_a.put ("version", "10");
 			result = true;
 		case 10:
+		{
+			std::string callback_target (tree_a.get<std::string> ("callback_target"));
+			boost::property_tree::ptree callback_target_map = tree_a.get_child ("callback_targets", boost::property_tree::ptree ());
+			if (!callback_target.empty ())
+			{
+				if (callback_target_map.get ("block_confirmed", "").empty ())
+				{
+					callback_target_map.put ("block_confirmed", callback_target);
+				}
+			}
+			tree_a.erase ("callback_target");
+			tree_a.add_child ("callback_targets", callback_target_map);
+			tree_a.put ("vote_callback_min_rep_percent", "1");
+			tree_a.put ("confirmation_rep_percent", "60");
+			tree_a.erase ("version");
+			tree_a.put ("version", "11");
+			result = true;
+		}
+		case 11:
 			break;
 		default:
 			throw std::runtime_error ("Unknown node_config version");
@@ -1029,8 +1061,13 @@ bool rai::node_config::deserialize_json (bool & upgraded_a, boost::property_tree
 		auto bootstrap_connections_max_l (tree_a.get<std::string> ("bootstrap_connections_max"));
 		callback_address = tree_a.get<std::string> ("callback_address");
 		auto callback_port_l (tree_a.get<std::string> ("callback_port"));
-		callback_target = tree_a.get<std::string> ("callback_target");
 		auto lmdb_max_dbs_l = tree_a.get<std::string> ("lmdb_max_dbs");
+		for (auto it : tree_a.get_child ("callback_targets"))
+		{
+			callback_targets.insert (std::make_pair (it.first, it.second.get<std::string> ("")));
+		}
+		vote_callback_min_rep_percent = tree_a.get<double> ("vote_callback_min_rep_percent");
+		confirmation_rep_percent = tree_a.get<double> ("confirmation_rep_percent");
 		result |= parse_port (callback_port_l, callback_port);
 		auto state_block_parse_canary_l = tree_a.get<std::string> ("state_block_parse_canary");
 		auto state_block_generate_canary_l = tree_a.get<std::string> ("state_block_generate_canary");
@@ -1217,14 +1254,20 @@ void rai::block_processor::process_blocks ()
 	}
 }
 
-void rai::block_processor::process_receive_many (rai::block_processor_item const & item_a)
+void rai::block_processor::process_receive_many (rai::block_processor_item const & item_a, std::function<void(rai::account, rai::amount)> const & callback)
 {
 	std::deque<rai::block_processor_item> blocks_processing;
 	blocks_processing.push_back (item_a);
-	process_receive_many (blocks_processing);
+	std::shared_ptr<rai::block> item_block (item_a.block);
+	process_receive_many (blocks_processing, [item_block, callback](std::shared_ptr<rai::block> block, rai::account account, rai::amount amount) {
+		if (item_block == block)
+		{
+			callback (account, amount);
+		}
+	});
 }
 
-void rai::block_processor::process_receive_many (std::deque<rai::block_processor_item> & blocks_processing)
+void rai::block_processor::process_receive_many (std::deque<rai::block_processor_item> & blocks_processing, std::function<void(std::shared_ptr<rai::block>, rai::account, rai::amount)> const & callback)
 {
 	while (!blocks_processing.empty ())
 	{
@@ -1273,6 +1316,7 @@ void rai::block_processor::process_receive_many (std::deque<rai::block_processor
 		}
 		for (auto & i : progress)
 		{
+			callback (i.first, i.second.account, i.second.amount);
 			node.observers.blocks (i.first, i.second);
 			if (i.second.amount > 0)
 			{
@@ -1418,6 +1462,97 @@ rai::process_return rai::block_processor::process_receive_one (MDB_txn * transac
 	return result;
 }
 
+namespace
+{
+void trigger_callback (std::shared_ptr<rai::node> node_a, const char * callback_type_a, const boost::property_tree::ptree event)
+{
+	std::stringstream ostream;
+	boost::property_tree::write_json (ostream, event);
+	ostream.flush ();
+	auto body (std::make_shared<std::string> (ostream.str ()));
+	auto address (node_a->config.callback_address);
+	auto port (node_a->config.callback_port);
+	auto target (std::make_shared<std::string> (node_a->config.callback_targets[callback_type_a]));
+	if (target->empty ())
+		return;
+	auto resolver (std::make_shared<boost::asio::ip::tcp::resolver> (node_a->service));
+	resolver->async_resolve (boost::asio::ip::tcp::resolver::query (address, std::to_string (port)), [node_a, address, port, target, body, resolver](boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
+		if (!ec)
+		{
+			for (auto i (i_a), n (boost::asio::ip::tcp::resolver::iterator{}); i != n; ++i)
+			{
+				auto sock (std::make_shared<boost::asio::ip::tcp::socket> (node_a->service));
+				sock->async_connect (i->endpoint (), [node_a, target, body, sock, address, port](boost::system::error_code const & ec) {
+					if (!ec)
+					{
+						auto req (std::make_shared<boost::beast::http::request<boost::beast::http::string_body>> ());
+						req->method (boost::beast::http::verb::post);
+						req->target (*target);
+						req->version (11);
+						req->insert (boost::beast::http::field::host, address);
+						req->insert (boost::beast::http::field::content_type, "application/json");
+						req->body () = *body;
+						//req->prepare (*req);
+						//boost::beast::http::prepare(req);
+						req->prepare_payload ();
+						boost::beast::http::async_write (*sock, *req, [node_a, sock, address, port, req](boost::system::error_code const & ec, size_t bytes_transferred) {
+							if (!ec)
+							{
+								auto sb (std::make_shared<boost::beast::flat_buffer> ());
+								auto resp (std::make_shared<boost::beast::http::response<boost::beast::http::string_body>> ());
+								boost::beast::http::async_read (*sock, *sb, *resp, [node_a, sb, resp, sock, address, port](boost::system::error_code const & ec, size_t bytes_transferred) {
+									if (!ec)
+									{
+										if (resp->result () == boost::beast::http::status::ok)
+										{
+										}
+										else
+										{
+											if (node_a->config.logging.callback_logging ())
+											{
+												BOOST_LOG (node_a->log) << boost::str (boost::format ("Callback to %1%:%2% failed with status: %3%") % address % port % resp->result ());
+											}
+										}
+									}
+									else
+									{
+										if (node_a->config.logging.callback_logging ())
+										{
+											BOOST_LOG (node_a->log) << boost::str (boost::format ("Unable complete callback: %1%:%2% %3%") % address % port % ec.message ());
+										}
+									};
+								});
+							}
+							else
+							{
+								if (node_a->config.logging.callback_logging ())
+								{
+									BOOST_LOG (node_a->log) << boost::str (boost::format ("Unable to send callback: %1%:%2% %3%") % address % port % ec.message ());
+								}
+							}
+						});
+					}
+					else
+					{
+						if (node_a->config.logging.callback_logging ())
+						{
+							BOOST_LOG (node_a->log) << boost::str (boost::format ("Unable to connect to callback address: %1%:%2%, %3%") % address % port % ec.message ());
+						}
+					}
+				});
+			}
+		}
+		else
+		{
+			if (node_a->config.logging.callback_logging ())
+			{
+				BOOST_LOG (node_a->log) << boost::str (boost::format ("Error resolving callback: %1%:%2%, %3%") % address % port % ec.message ());
+			}
+		}
+	});
+}
+}
+
 rai::node::node (rai::node_init & init_a, boost::asio::io_service & service_a, uint16_t peering_port_a, boost::filesystem::path const & application_path_a, rai::alarm & alarm_a, rai::logging const & logging_a, rai::work_pool & work_a) :
 node (init_a, service_a, application_path_a, alarm_a, rai::node_config (peering_port_a, logging_a), work_a)
 {
@@ -1458,7 +1593,7 @@ online_reps (*this)
 		if (this->block_arrival.recent (block_a->hash ()))
 		{
 			rai::transaction transaction (store.environment, nullptr, true);
-			active.start (transaction, block_a);
+			active.start (transaction, block_a, std::make_pair (result_a.account, result_a.amount));
 		}
 	});
 	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::process_return const & result_a) {
@@ -1469,98 +1604,33 @@ online_reps (*this)
 				if (!node_l->config.callback_address.empty ())
 				{
 					boost::property_tree::ptree event;
+					event.add ("event", "block_unconfirmed");
 					event.add ("account", result_a.account.to_account ());
 					event.add ("hash", block_a->hash ().to_string ());
 					std::string block_text;
 					block_a->serialize_json (block_text);
 					event.add ("block", block_text);
 					event.add ("amount", result_a.amount.to_string_dec ());
-					if (result_a.state_is_send)
-					{
-						event.add ("is_send", *result_a.state_is_send);
-					}
-					std::stringstream ostream;
-					boost::property_tree::write_json (ostream, event);
-					ostream.flush ();
-					auto body (std::make_shared<std::string> (ostream.str ()));
-					auto address (node_l->config.callback_address);
-					auto port (node_l->config.callback_port);
-					auto target (std::make_shared<std::string> (node_l->config.callback_target));
-					auto resolver (std::make_shared<boost::asio::ip::tcp::resolver> (node_l->service));
-					resolver->async_resolve (boost::asio::ip::tcp::resolver::query (address, std::to_string (port)), [node_l, address, port, target, body, resolver](boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
-						if (!ec)
-						{
-							for (auto i (i_a), n (boost::asio::ip::tcp::resolver::iterator{}); i != n; ++i)
-							{
-								auto sock (std::make_shared<boost::asio::ip::tcp::socket> (node_l->service));
-								sock->async_connect (i->endpoint (), [node_l, target, body, sock, address, port](boost::system::error_code const & ec) {
-									if (!ec)
-									{
-										auto req (std::make_shared<boost::beast::http::request<boost::beast::http::string_body>> ());
-										req->method (boost::beast::http::verb::post);
-										req->target (*target);
-										req->version (11);
-										req->insert (boost::beast::http::field::host, address);
-										req->insert (boost::beast::http::field::content_type, "application/json");
-										req->body () = *body;
-										//req->prepare (*req);
-										//boost::beast::http::prepare(req);
-										req->prepare_payload ();
-										boost::beast::http::async_write (*sock, *req, [node_l, sock, address, port, req](boost::system::error_code const & ec, size_t bytes_transferred) {
-											if (!ec)
-											{
-												auto sb (std::make_shared<boost::beast::flat_buffer> ());
-												auto resp (std::make_shared<boost::beast::http::response<boost::beast::http::string_body>> ());
-												boost::beast::http::async_read (*sock, *sb, *resp, [node_l, sb, resp, sock, address, port](boost::system::error_code const & ec, size_t bytes_transferred) {
-													if (!ec)
-													{
-														if (resp->result () == boost::beast::http::status::ok)
-														{
-														}
-														else
-														{
-															if (node_l->config.logging.callback_logging ())
-															{
-																BOOST_LOG (node_l->log) << boost::str (boost::format ("Callback to %1%:%2% failed with status: %3%") % address % port % resp->result ());
-															}
-														}
-													}
-													else
-													{
-														if (node_l->config.logging.callback_logging ())
-														{
-															BOOST_LOG (node_l->log) << boost::str (boost::format ("Unable complete callback: %1%:%2% %3%") % address % port % ec.message ());
-														}
-													};
-												});
-											}
-											else
-											{
-												if (node_l->config.logging.callback_logging ())
-												{
-													BOOST_LOG (node_l->log) << boost::str (boost::format ("Unable to send callback: %1%:%2% %3%") % address % port % ec.message ());
-												}
-											}
-										});
-									}
-									else
-									{
-										if (node_l->config.logging.callback_logging ())
-										{
-											BOOST_LOG (node_l->log) << boost::str (boost::format ("Unable to connect to callback address: %1%:%2%, %3%") % address % port % ec.message ());
-										}
-									}
-								});
-							}
-						}
-						else
-						{
-							if (node_l->config.logging.callback_logging ())
-							{
-								BOOST_LOG (node_l->log) << boost::str (boost::format ("Error resolving callback: %1%:%2%, %3%") % address % port % ec.message ());
-							}
-						}
-					});
+					trigger_callback (node_l, "block_unconfirmed", event);
+				}
+			});
+		}
+	});
+	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::process_return const & result_a) {
+		std::lock_guard<std::mutex> confirmed_awaiting_process_lock (active.confirmed_awaiting_process_mutex);
+		if (active.confirmed_awaiting_process.erase (block_a->hash ()))
+		{
+			auto node_l (shared_from_this ());
+			background ([node_l, block_a, result_a]() {
+				if (!node_l->config.callback_address.empty ())
+				{
+					boost::property_tree::ptree info;
+					info.put ("event", "block_confirmed");
+					info.put ("block", block_a->to_json ());
+					info.put ("hash", block_a->hash ().to_string ());
+					info.put ("account", result_a.account.to_string ());
+					info.put ("amount", result_a.amount.to_string_dec ());
+					trigger_callback (node_l, "block_confirmed", info);
 				}
 			});
 		}
@@ -1571,6 +1641,48 @@ online_reps (*this)
 	});
 	observers.vote.add ([this](std::shared_ptr<rai::vote> vote_a, rai::endpoint const &) {
 		this->gap_cache.vote (vote_a);
+	});
+	observers.vote.add ([this](std::shared_ptr<rai::vote> vote_a, rai::endpoint const &) {
+		auto node_l (shared_from_this ());
+		background ([node_l, vote_a]() {
+			if (!node_l->config.callback_address.empty ())
+			{
+				rai::transaction transaction (node_l->store.environment, nullptr, false);
+				uint128_t circulating (node_l->ledger.supply (transaction));
+				uint128_t weight (node_l->weight (vote_a->account));
+				double rep_percent = (double)(weight / (circulating / 1000)) / 10.0;
+				if (rep_percent < node_l->config.vote_callback_min_rep_percent)
+					return;
+				boost::property_tree::ptree event;
+				event.add ("event", "vote");
+				std::string account_l;
+				vote_a->account.encode_account (account_l);
+				event.add ("representative", account_l);
+				event.add ("sequence", vote_a->sequence);
+				event.add ("weight", std::string (weight));
+				std::string block_hash_l;
+				vote_a->block->hash ().encode_hex (block_hash_l);
+				event.add ("block", block_hash_l);
+				std::string signature_l;
+				vote_a->signature.encode_hex (signature_l);
+				event.add ("signature", signature_l);
+				election_result result;
+				uint128_t vote_tally;
+				if (!node_l->check_election_results (vote_a->block, result))
+				{
+					event.add ("result_confirmed", result.confirmed);
+					vote_tally = result.tally.number ();
+				}
+				else
+				{
+					event.add ("result_confirmed", false);
+					vote_tally = weight;
+				}
+				event.add ("total_weight_agree", std::string (vote_tally));
+				event.add ("percent_circulating_agree", (double)(vote_tally / (circulating / 1000)) / 10.0);
+				trigger_callback (node_l, "vote", event);
+			}
+		});
 	});
 	observers.vote.add ([this](std::shared_ptr<rai::vote> vote_a, rai::endpoint const &) {
 		this->online_reps.vote (vote_a);
@@ -1706,7 +1818,7 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 	{
 		existing->votes->vote (vote_a);
 		auto winner (node.ledger.winner (transaction, *existing->votes));
-		if (winner.first > bootstrap_threshold (transaction))
+		if (winner.first > bootstrap_threshold ())
 		{
 			auto node_l (node.shared ());
 			auto now (std::chrono::steady_clock::now ());
@@ -1725,9 +1837,9 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 	}
 }
 
-rai::uint128_t rai::gap_cache::bootstrap_threshold (MDB_txn * transaction_a)
+rai::uint128_t rai::gap_cache::bootstrap_threshold ()
 {
-	auto result ((node.ledger.supply (transaction_a) / 256) * node.config.bootstrap_fraction_numerator);
+	auto result ((node.online_reps.online_stake () / 256) * node.config.bootstrap_fraction_numerator);
 	return result;
 }
 
@@ -1927,6 +2039,7 @@ void rai::node::start ()
 	bootstrap.start ();
 	backup_wallet ();
 	active.announce_votes ();
+	online_reps.recalculate_stake ();
 	port_mapping.start ();
 	add_initial_peers ();
 	observers.started ();
@@ -2409,6 +2522,21 @@ void rai::node::process_confirmed (std::shared_ptr<rai::block> confirmed_a)
 	confirmed_a->visit (visitor);
 }
 
+void rai::node::request_confirmation (std::shared_ptr<rai::block> block_a)
+{
+	{
+		rai::transaction transaction (store.environment, nullptr, true);
+		active.start (transaction, block_a, boost::none);
+	}
+	network.broadcast_confirm_req (block_a);
+}
+
+bool rai::node::check_election_results (std::shared_ptr<rai::block> block_a, election_result & result)
+{
+	rai::transaction transaction (store.environment, nullptr, true);
+	return active.check_election_results (transaction, block_a, result);
+}
+
 void rai::node::process_message (rai::message & message_a, rai::endpoint const & sender_a)
 {
 	network_message_visitor visitor (*this, sender_a);
@@ -2872,14 +3000,15 @@ std::shared_ptr<rai::node> rai::node::shared ()
 	return shared_from_this ();
 }
 
-rai::election::election (MDB_txn * transaction_a, rai::node & node_a, std::shared_ptr<rai::block> block_a, std::function<void(std::shared_ptr<rai::block>, bool)> const & confirmation_action_a) :
+rai::election::election (MDB_txn * transaction_a, rai::node & node_a, std::shared_ptr<rai::block> block_a, boost::optional<std::pair<rai::account, rai::amount>> callback_info, std::function<void(std::shared_ptr<rai::block>, rai::election_result)> const & confirmation_action_a) :
 confirmation_action (confirmation_action_a),
 votes (block_a),
 node (node_a),
-last_winner (block_a)
+last_winner (block_a),
+last_winner_callback_info (callback_info),
+finished (false)
 {
 	assert (node_a.store.block_exists (transaction_a, block_a->hash ()));
-	confirmed.clear ();
 	compute_rep_votes (transaction_a);
 }
 
@@ -2901,34 +3030,55 @@ void rai::election::broadcast_winner ()
 	node.network.republish_block (transaction_a, last_winner);
 }
 
-rai::uint128_t rai::election::quorum_threshold (MDB_txn * transaction_a, rai::ledger & ledger_a)
+rai::uint128_t rai::election::quorum_threshold (MDB_txn * transaction_a)
 {
 	// Threshold over which unanimous voting implies confirmation
-	return ledger_a.supply (transaction_a) / 2;
+	auto supply_cap (node.ledger.supply (transaction_a) / 2); // 50% of stake
+	auto online_cap (node.online_reps.online_stake () * 3 / 5); // 60% of online reps
+	return std::min (online_cap, supply_cap);
 }
 
-rai::uint128_t rai::election::minimum_threshold (MDB_txn * transaction_a, rai::ledger & ledger_a)
+rai::uint128_t rai::election::minimum_threshold ()
 {
 	// Minimum number of votes needed to change our ledger, under which we're probably disconnected
-	return ledger_a.supply (transaction_a) / 16;
+	return node.online_reps.online_stake () / 16;
+}
+
+rai::uint128_t rai::election::user_threshold ()
+{
+	// Minimum number of votes needed for the node's user to accept a block as confirmed
+	return ((rai::uint128_t) (node.config.confirmation_rep_percent * 100)) * (node.online_reps.online_stake () / (100 * 100));
 }
 
 void rai::election::confirm_once (MDB_txn * transaction_a)
 {
-	if (!confirmed.test_and_set ())
+	if (!finished.exchange (true))
 	{
 		auto tally_l (node.ledger.tally (transaction_a, votes));
 		assert (tally_l.size () > 0);
 		auto winner (tally_l.begin ());
 		auto block_l (winner->second);
-		auto exceeded_min_threshold = winner->first > minimum_threshold (transaction_a, node.ledger);
+		auto node_l (node.shared ());
+		auto supply (node.ledger.supply (transaction_a));
+		auto exceeded_min_threshold = winner->first > minimum_threshold ();
+		auto exceeded_user_threshold = winner->first > user_threshold ();
 		if (!(*block_l == *last_winner))
 		{
 			if (exceeded_min_threshold)
 			{
-				auto node_l (node.shared ());
-				node.background ([node_l, block_l]() {
-					node_l->block_processor.process_receive_many (rai::block_processor_item (block_l, true));
+				node.background ([exceeded_user_threshold, node_l, block_l]() {
+					node_l->block_processor.process_receive_many (rai::block_processor_item (block_l, true), [exceeded_user_threshold, node_l, block_l](rai::account account, rai::amount amount) {
+						if (exceeded_user_threshold && !node_l->config.callback_address.empty ())
+						{
+							boost::property_tree::ptree info;
+							info.put ("event", "block_confirmed");
+							info.put ("block", block_l->to_json ());
+							info.put ("hash", block_l->hash ().to_string ());
+							info.put ("account", account.to_string ());
+							info.put ("amount", amount.to_string_dec ());
+							trigger_callback (node_l, "block_confirmed", info);
+						}
+					});
 				});
 				last_winner = block_l;
 			}
@@ -2937,21 +3087,49 @@ void rai::election::confirm_once (MDB_txn * transaction_a)
 				BOOST_LOG (node.log) << boost::str (boost::format ("Retaining block %1%") % last_winner->hash ().to_string ());
 			}
 		}
+		else if (exceeded_user_threshold && (bool)last_winner_callback_info)
+		{
+			boost::property_tree::ptree info;
+			info.put ("event", "block_confirmed");
+			info.put ("block", last_winner->to_json ());
+			info.put ("hash", last_winner->hash ().to_string ());
+			info.put ("account", last_winner_callback_info->first.to_string ());
+			info.put ("amount", last_winner_callback_info->second.to_string_dec ());
+			trigger_callback (node.shared (), "block_confirmed", info);
+		}
+		rai::election_result result;
+		result.winner = last_winner->hash ();
+		result.tally = winner->first;
+		result.exceeded_min_threshold = exceeded_min_threshold;
+		result.confirmed = exceeded_user_threshold;
 		auto winner_l (last_winner);
-		auto node_l (node.shared ());
 		auto confirmation_action_l (confirmation_action);
-		node.background ([winner_l, confirmation_action_l, node_l, exceeded_min_threshold]() {
+		node.background ([node_l, confirmation_action_l, winner_l, result]() {
 			node_l->process_confirmed (winner_l);
-			confirmation_action_l (winner_l, exceeded_min_threshold);
+			confirmation_action_l (winner_l, result);
 		});
 	}
+}
+
+void rai::election::get_progress (MDB_txn * transaction_a, rai::election_result & result)
+{
+	auto tally_l (node.ledger.tally (transaction_a, votes));
+	assert (tally_l.size () > 0);
+	auto results (tally_l.begin ());
+	result.winner = results->second->hash ();
+	result.tally = rai::amount (results->first);
+	auto supply (node.ledger.supply (transaction_a));
+	result.exceeded_min_threshold = results->first > minimum_threshold ();
+	result.confirmed = finished.load () && results->first > user_threshold ();
 }
 
 bool rai::election::have_quorum (MDB_txn * transaction_a)
 {
 	auto tally_l (node.ledger.tally (transaction_a, votes));
 	assert (tally_l.size () > 0);
-	auto result (tally_l.begin ()->first > quorum_threshold (transaction_a, node.ledger));
+	auto result (tally_l.begin ()->first > quorum_threshold (transaction_a));
+	// We should make sure we get the votes required by the user threshold before ending the election.
+	result = result && (tally_l.begin ()->first > user_threshold ());
 	return result;
 }
 
@@ -3053,6 +3231,9 @@ void rai::active_transactions::announce_votes ()
 				i->election->confirm_cutoff (transaction);
 				auto root_l (i->election->votes.id);
 				inactive.push_back (root_l);
+				election_result result;
+				election_l->get_progress (transaction, result);
+				add_election_history (root_l, result);
 			}
 			else
 			{
@@ -3094,17 +3275,67 @@ void rai::active_transactions::stop ()
 	roots.clear ();
 }
 
-bool rai::active_transactions::start (MDB_txn * transaction_a, std::shared_ptr<rai::block> block_a, std::function<void(std::shared_ptr<rai::block>, bool)> const & confirmation_action_a)
+bool rai::active_transactions::start (MDB_txn * transaction_a, std::shared_ptr<rai::block> block_a, boost::optional<std::pair<rai::account, rai::amount>> callback_info, std::function<void(std::shared_ptr<rai::block>, rai::election_result)> const & confirmation_action_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
 	auto root (block_a->root ());
 	auto existing (roots.find (root));
 	if (existing == roots.end ())
 	{
-		auto election (std::make_shared<rai::election> (transaction_a, node, block_a, confirmation_action_a));
+		auto election (std::make_shared<rai::election> (transaction_a, node, block_a, callback_info, confirmation_action_a));
 		roots.insert (rai::conflict_info{ root, election, 0 });
 	}
 	return existing != roots.end ();
+}
+
+bool rai::active_transactions::check_election_results (MDB_txn * transaction_a, std::shared_ptr<rai::block> block_a, rai::election_result & result)
+{
+	std::lock_guard<std::mutex> lock (mutex);
+	auto root (block_a->root ());
+	auto existing (roots.find (root));
+	bool failed = true;
+
+	if (existing != roots.end ())
+	{
+		existing->election->get_progress (transaction_a, result);
+		failed = false;
+	}
+	else
+	{
+		auto historical (election_history.get<1> ().find (root));
+		if (historical != election_history.get<1> ().end ())
+		{
+			result = historical->result;
+			failed = false;
+		}
+	}
+
+	if (failed || result.winner != block_a->hash ())
+	{
+		// Just to avoid any possible confusion, if a different block won the election,be very clear that
+		// this particular request was not "confirmed", even though the winning block was confirmed.
+		result.confirmed = false;
+	}
+
+	return failed;
+}
+
+void rai::active_transactions::add_election_history (const rai::block_hash & root, const election_result & result)
+{
+	// The mutex MUST be held by the caller.
+	rai::election_history history;
+	history.root = root;
+	history.result = result;
+	auto existing_history (election_history.get<1> ().find (root));
+	if (existing_history != election_history.get<1> ().end ())
+	{
+		election_history.get<1> ().erase (existing_history);
+	}
+	election_history.insert (election_history.get<0> ().end (), history);
+	if (election_history.size () > election_history_size)
+	{
+		election_history.erase (election_history.get<0> ().begin ());
+	}
 }
 
 // Validate a vote and apply it to the current election if one exists

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -310,6 +310,7 @@ public:
 	void vote (std::shared_ptr<rai::vote> const &);
 	void recalculate_stake ();
 	rai::uint128_t online_stake ();
+	std::deque<rai::account> list();
 	boost::multi_index_container<
 	rai::rep_last_heard_info,
 	boost::multi_index::indexed_by<

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -310,7 +310,7 @@ public:
 	void vote (std::shared_ptr<rai::vote> const &);
 	void recalculate_stake ();
 	rai::uint128_t online_stake ();
-	std::deque<rai::account> list();
+	std::deque<rai::account> list ();
 	boost::multi_index_container<
 	rai::rep_last_heard_info,
 	boost::multi_index::indexed_by<

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -297,6 +297,31 @@ public:
 	arrival;
 	std::mutex mutex;
 };
+class rep_last_heard_info
+{
+public:
+	std::chrono::steady_clock::time_point last_heard;
+	rai::account representative;
+};
+class online_reps
+{
+public:
+	online_reps (rai::node &);
+	void vote (std::shared_ptr<rai::vote> const &);
+	void recalculate_stake ();
+	rai::uint128_t online_stake ();
+	boost::multi_index_container<
+	rai::rep_last_heard_info,
+	boost::multi_index::indexed_by<
+	boost::multi_index::ordered_non_unique<boost::multi_index::member<rai::rep_last_heard_info, std::chrono::steady_clock::time_point, &rai::rep_last_heard_info::last_heard>>,
+	boost::multi_index::hashed_unique<boost::multi_index::member<rai::rep_last_heard_info, rai::account, &rai::rep_last_heard_info::representative>>>>
+	reps;
+
+private:
+	rai::uint128_t online_stake_total;
+	std::mutex mutex;
+	rai::node & node;
+};
 class network
 {
 public:
@@ -536,6 +561,7 @@ public:
 	rai::block_processor block_processor;
 	std::thread block_processor_thread;
 	rai::block_arrival block_arrival;
+	rai::online_reps online_reps;
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;
 	static std::chrono::seconds constexpr period = std::chrono::seconds (60);

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -36,13 +36,21 @@ namespace program_options
 namespace rai
 {
 class node;
+class election_result
+{
+public:
+	rai::block_hash winner;
+	rai::amount tally;
+	bool exceeded_min_threshold;
+	bool confirmed;
+};
 class election : public std::enable_shared_from_this<rai::election>
 {
-	std::function<void(std::shared_ptr<rai::block>, bool)> confirmation_action;
+	std::function<void(std::shared_ptr<rai::block>, election_result)> confirmation_action;
 	void confirm_once (MDB_txn *);
 
 public:
-	election (MDB_txn *, rai::node &, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>, bool)> const &);
+	election (MDB_txn *, rai::node &, std::shared_ptr<rai::block>, boost::optional<std::pair<rai::account, rai::amount>>, std::function<void(std::shared_ptr<rai::block>, election_result)> const &);
 	bool vote (std::shared_ptr<rai::vote>);
 	// Check if we have vote quorum
 	bool have_quorum (MDB_txn *);
@@ -54,13 +62,17 @@ public:
 	void confirm_if_quorum (MDB_txn *);
 	// Confirmation method 2, settling time
 	void confirm_cutoff (MDB_txn *);
-	rai::uint128_t quorum_threshold (MDB_txn *, rai::ledger &);
-	rai::uint128_t minimum_threshold (MDB_txn *, rai::ledger &);
+	// Get the current tally and winner.
+	void get_progress (MDB_txn *, election_result & result);
+	rai::uint128_t quorum_threshold (MDB_txn *);
+	rai::uint128_t minimum_threshold ();
+	rai::uint128_t user_threshold ();
 	rai::votes votes;
 	rai::node & node;
 	std::unordered_map<rai::account, std::pair<std::chrono::steady_clock::time_point, uint64_t>> last_votes;
 	std::shared_ptr<rai::block> last_winner;
-	std::atomic_flag confirmed;
+	boost::optional<std::pair<rai::account, rai::amount>> last_winner_callback_info;
+	std::atomic<bool> finished;
 };
 class conflict_info
 {
@@ -70,6 +82,12 @@ public:
 	// Number of announcements in a row for this fork
 	unsigned announcements;
 };
+class election_history
+{
+public:
+	rai::block_hash root;
+	rai::election_result result;
+};
 // Core class for determining consensus
 // Holds all active blocks i.e. recently added blocks that need confirmation
 class active_transactions
@@ -78,7 +96,8 @@ public:
 	active_transactions (rai::node &);
 	// Start an election for a block
 	// Call action with confirmed block, may be different than what we started with
-	bool start (MDB_txn *, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
+	// The 3rd argument specifies information about the block for the callback, or none if the block is not new
+	bool start (MDB_txn *, std::shared_ptr<rai::block>, boost::optional<std::pair<rai::account, rai::amount>> = boost::none, std::function<void(std::shared_ptr<rai::block>, election_result)> const & = [](std::shared_ptr<rai::block>, election_result) {});
 	// If this returns true, the vote is a replay
 	// If this returns false, the vote may or may not be a replay
 	bool vote (std::shared_ptr<rai::vote>);
@@ -87,18 +106,29 @@ public:
 	void announce_votes ();
 	std::deque<std::shared_ptr<rai::block>> list_blocks ();
 	void stop ();
+	bool check_election_results (MDB_txn *, std::shared_ptr<rai::block>, election_result & result);
+	void add_election_history (const rai::block_hash & root, const election_result & result);
 	boost::multi_index_container<
 	rai::conflict_info,
 	boost::multi_index::indexed_by<
 	boost::multi_index::ordered_unique<boost::multi_index::member<rai::conflict_info, rai::block_hash, &rai::conflict_info::root>>>>
 	roots;
+	boost::multi_index_container<
+	rai::election_history,
+	boost::multi_index::indexed_by<
+	boost::multi_index::sequenced<>,
+	boost::multi_index::hashed_unique<boost::multi_index::member<rai::election_history, rai::block_hash, &rai::election_history::root>>>>
+	election_history;
 	rai::node & node;
 	std::mutex mutex;
+	std::map<rai::block_hash, std::chrono::steady_clock::time_point> confirmed_awaiting_process;
+	std::mutex confirmed_awaiting_process_mutex;
 	// Maximum number of conflicts to vote on per interval, lowest root hash first
 	static unsigned constexpr announcements_per_interval = 32;
 	// After this many successive vote announcements, block is confirmed
 	static unsigned constexpr contiguous_announcements = 4;
 	static unsigned constexpr announce_interval_ms = (rai::rai_network == rai::rai_networks::rai_test_network) ? 10 : 16000;
+	static unsigned constexpr election_history_size = 2048;
 };
 class operation
 {
@@ -133,7 +163,7 @@ public:
 	gap_cache (rai::node &);
 	void add (MDB_txn *, std::shared_ptr<rai::block>);
 	void vote (std::shared_ptr<rai::vote>);
-	rai::uint128_t bootstrap_threshold (MDB_txn *);
+	rai::uint128_t bootstrap_threshold ();
 	void purge_old ();
 	boost::multi_index_container<
 	rai::gap_information,
@@ -355,6 +385,7 @@ public:
 	uint64_t error_count;
 	rai::message_statistics incoming;
 	rai::message_statistics outgoing;
+	std::function<bool(uint8_t *, size_t)> packet_filter;
 	static uint16_t const node_port = rai::rai_network == rai::rai_networks::rai_live_network ? 7075 : 54000;
 };
 class logging
@@ -433,10 +464,12 @@ public:
 	unsigned bootstrap_connections_max;
 	std::string callback_address;
 	uint16_t callback_port;
-	std::string callback_target;
 	int lmdb_max_dbs;
 	rai::block_hash state_block_parse_canary;
 	rai::block_hash state_block_generate_canary;
+	std::map<std::string, std::string> callback_targets;
+	double vote_callback_min_rep_percent;
+	double confirmation_rep_percent;
 	static std::chrono::seconds constexpr keepalive_period = std::chrono::seconds (60);
 	static std::chrono::seconds constexpr keepalive_cutoff = keepalive_period * 5;
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);
@@ -487,8 +520,8 @@ public:
 	void stop ();
 	void flush ();
 	void add (rai::block_processor_item const &);
-	void process_receive_many (rai::block_processor_item const &);
-	void process_receive_many (std::deque<rai::block_processor_item> &);
+	void process_receive_many (rai::block_processor_item const &, std::function<void(rai::account, rai::amount)> const & = [](rai::account, rai::amount) {});
+	void process_receive_many (std::deque<rai::block_processor_item> &, std::function<void(std::shared_ptr<rai::block>, rai::account, rai::amount)> const & = [](std::shared_ptr<rai::block>, rai::account, rai::amount) {});
 	rai::process_return process_receive_one (MDB_txn *, std::shared_ptr<rai::block>);
 	void process_blocks ();
 
@@ -518,6 +551,8 @@ public:
 	void stop ();
 	std::shared_ptr<rai::node> shared ();
 	int store_version ();
+	void request_confirmation (std::shared_ptr<rai::block>);
+	bool check_election_results (std::shared_ptr<rai::block>, election_result & result);
 	void process_confirmed (std::shared_ptr<rai::block>);
 	void process_message (rai::message &, rai::endpoint const &);
 	void process_active (std::shared_ptr<rai::block>);

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -2811,6 +2811,19 @@ void rai::rpc_handler::representatives ()
 	response (response_l);
 }
 
+void rai::rpc_handler::representatives_online()
+{
+	boost::property_tree::ptree response_l;
+	boost::property_tree::ptree representatives;
+	auto reps (node.online_reps.list ());
+	for (auto & i : reps)
+	{
+		representatives.put (i.to_account (), "");
+	}
+	response_l.add_child ("representatives", representatives);
+	response (response_l);
+}
+
 void rai::rpc_handler::republish ()
 {
 	uint64_t count (1024U);
@@ -4685,6 +4698,10 @@ void rai::rpc_handler::process_request ()
 		else if (action == "representatives")
 		{
 			representatives ();
+		}
+		else if (action == "representatives_online")
+		{
+			representatives_online ();
 		}
 		else if (action == "republish")
 		{

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -2811,7 +2811,7 @@ void rai::rpc_handler::representatives ()
 	response (response_l);
 }
 
-void rai::rpc_handler::representatives_online()
+void rai::rpc_handler::representatives_online ()
 {
 	boost::property_tree::ptree response_l;
 	boost::property_tree::ptree representatives;

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -2992,6 +2992,67 @@ void rai::rpc_handler::search_pending_all ()
 	}
 }
 
+void rai::rpc_handler::request_confirmation ()
+{
+	std::string hash_text (request.get<std::string> ("hash"));
+	rai::block_hash hash_l;
+	if (!hash_l.decode_hex (hash_text))
+	{
+		rai::transaction transaction (node.store.environment, nullptr, false);
+		auto block_l (node.store.block_get (transaction, hash_l));
+		if (block_l != nullptr)
+		{
+			node.request_confirmation (std::shared_ptr<rai::block> (move (block_l)));
+			boost::property_tree::ptree response_l;
+			response_l.put ("success", "");
+			response (response_l);
+		}
+		else
+		{
+			error_response (response, "Block not found");
+		}
+	}
+	else
+	{
+		error_response (response, "Invalid block hash");
+	}
+}
+
+void rai::rpc_handler::check_election_results ()
+{
+	std::string hash_text (request.get<std::string> ("hash"));
+	rai::block_hash hash_l;
+	if (!hash_l.decode_hex (hash_text))
+	{
+		rai::transaction transaction (node.store.environment, nullptr, false);
+		auto block_l (node.store.block_get (transaction, hash_l));
+		if (block_l != nullptr)
+		{
+			rai::election_result result;
+			if (!node.check_election_results (std::shared_ptr<rai::block> (move (block_l)), result))
+			{
+				boost::property_tree::ptree response_l;
+				response_l.put ("confirmed", result.confirmed);
+				response_l.put ("tally", std::string (result.tally.number ()));
+				response_l.put ("percent_circulating_approved", (double)(result.tally.number () / (node.ledger.supply (transaction) / 1000)) / 10.0);
+				response (response_l);
+			}
+			else
+			{
+				error_response (response, "Election not found");
+			}
+		}
+		else
+		{
+			error_response (response, "Block not found");
+		}
+	}
+	else
+	{
+		error_response (response, "Invalid block hash");
+	}
+}
+
 void rai::rpc_handler::send ()
 {
 	if (rpc.config.enable_control)
@@ -4387,7 +4448,6 @@ void rai::rpc_connection::read ()
 				auto start (std::chrono::steady_clock::now ());
 				auto version (this_l->request.version ());
 				auto response_handler ([this_l, version, start](boost::property_tree::ptree const & tree_a) {
-
 					std::stringstream ostream;
 					boost::property_tree::write_json (ostream, tree_a);
 					ostream.flush ();
@@ -4714,6 +4774,14 @@ void rai::rpc_handler::process_request ()
 		else if (action == "search_pending_all")
 		{
 			search_pending_all ();
+		}
+		else if (action == "request_confirmation")
+		{
+			request_confirmation ();
+		}
+		else if (action == "check_election_results")
+		{
+			check_election_results ();
 		}
 		else if (action == "send")
 		{

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -173,6 +173,7 @@ public:
 	void receive_minimum ();
 	void receive_minimum_set ();
 	void representatives ();
+	void representatives_online ();
 	void republish ();
 	void search_pending ();
 	void search_pending_all ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -177,6 +177,8 @@ public:
 	void republish ();
 	void search_pending ();
 	void search_pending_all ();
+	void request_confirmation ();
+	void check_election_results ();
 	void send ();
 	void stop ();
 	void successors ();

--- a/rai/node/rpc_secure.cpp
+++ b/rai/node/rpc_secure.cpp
@@ -159,14 +159,12 @@ void rai::rpc_connection_secure::read ()
 					auto body (ostream.str ());
 					this_l->write_result (body, version);
 					boost::beast::http::async_write (this_l->stream, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
-
 						// Perform the SSL shutdown
 						this_l->stream.async_shutdown (
 						std::bind (
 						&rai::rpc_connection_secure::on_shutdown,
 						this_l,
 						std::placeholders::_1));
-
 					});
 
 					if (this_l->node->config.logging.log_rpc ())

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -10,6 +10,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <future>
+#include <set>
 
 #include <ed25519-donna/ed25519.h>
 
@@ -1210,9 +1211,12 @@ public:
 						std::shared_ptr<rai::block> block_l (wallet->node.store.block_get (transaction, info.head));
 						wallet->node.background ([this_l, account, block_l] {
 							rai::transaction transaction (this_l->wallet->node.store.environment, nullptr, true);
-							this_l->wallet->node.active.start (transaction, block_l, [this_l, account](std::shared_ptr<rai::block>, bool) {
+							this_l->wallet->node.active.start (transaction, block_l, boost::none, [this_l, account](std::shared_ptr<rai::block> confirmed_block, rai::election_result result) {
 								// If there were any forks for this account they've been rolled back and we can receive anything remaining from this account
-								this_l->receive_all (account);
+								if (result.confirmed)
+								{
+									this_l->receive_all (account, confirmed_block->hash ());
+								}
 							});
 							this_l->wallet->node.network.broadcast_confirm_req (block_l);
 						});
@@ -1227,37 +1231,59 @@ public:
 		}
 		BOOST_LOG (wallet->node.log) << "Pending block search phase complete";
 	}
-	void receive_all (rai::account const & account_a)
+	void receive_all (rai::account const & account_a, rai::block_hash const & confirmed_block)
 	{
 		BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Account %1% confirmed, receiving all blocks") % account_a.to_account ());
 		rai::transaction transaction (wallet->node.store.environment, nullptr, false);
-		auto representative (wallet->store.representative (transaction));
-		for (auto i (wallet->node.store.pending_begin (transaction)), n (wallet->node.store.pending_end ()); i != n; ++i)
+		auto error (false);
+		rai::account_info acct_info;
+		error = wallet->node.store.account_get (transaction, account_a, acct_info);
+		std::set<rai::block_hash> ignore_blocks;
+		if (!error)
 		{
-			rai::pending_key key (i->first);
-			rai::pending_info pending (i->second);
-			if (pending.source == account_a)
+			rai::block_hash head_block (acct_info.head);
+			while (head_block != confirmed_block && !head_block.is_zero ())
 			{
-				if (wallet->store.exists (transaction, key.account))
+				ignore_blocks.insert (head_block);
+				auto block (wallet->node.store.block_get (transaction, head_block));
+				head_block = block->previous ();
+			}
+			if (head_block.is_zero ())
+			{
+				// confirmed_block doesn't exist in the account chain
+				error = true;
+			}
+		}
+		if (!error)
+		{
+			auto representative (wallet->store.representative (transaction));
+			for (auto i (wallet->node.store.pending_begin (transaction)), n (wallet->node.store.pending_end ()); i != n; ++i)
+			{
+				rai::pending_key key (i->first);
+				rai::pending_info pending (i->second);
+				if (pending.source == account_a && ignore_blocks.find (key.hash) == ignore_blocks.end ())
 				{
-					if (wallet->store.valid_password (transaction))
+					if (wallet->store.exists (transaction, key.account))
 					{
-						rai::pending_key key (i->first);
-						std::shared_ptr<rai::block> block (wallet->node.store.block_get (transaction, key.hash));
-						auto wallet_l (wallet);
-						auto amount (pending.amount.number ());
-						BOOST_LOG (wallet_l->node.log) << boost::str (boost::format ("Receiving block: %1%") % block->hash ().to_string ());
-						wallet_l->receive_async (block, representative, amount, [wallet_l, block](std::shared_ptr<rai::block> block_a) {
-							if (block_a == nullptr)
-							{
-								BOOST_LOG (wallet_l->node.log) << boost::str (boost::format ("Error receiving block %1%") % block->hash ().to_string ());
-							}
-						},
-						true);
-					}
-					else
-					{
-						BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Unable to fetch key for: %1%, stopping pending search") % key.account.to_account ());
+						if (wallet->store.valid_password (transaction))
+						{
+							rai::pending_key key (i->first);
+							std::shared_ptr<rai::block> block (wallet->node.store.block_get (transaction, key.hash));
+							auto wallet_l (wallet);
+							auto amount (pending.amount.number ());
+							BOOST_LOG (wallet_l->node.log) << boost::str (boost::format ("Receiving block: %1%") % block->hash ().to_string ());
+							wallet_l->receive_async (block, representative, amount, [wallet_l, block](std::shared_ptr<rai::block> block_a) {
+								if (block_a == nullptr)
+								{
+									BOOST_LOG (wallet_l->node.log) << boost::str (boost::format ("Error receiving block %1%") % block->hash ().to_string ());
+								}
+							},
+							true);
+						}
+						else
+						{
+							BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Unable to fetch key for: %1%, stopping pending search") % key.account.to_account ());
+						}
 					}
 				}
 			}


### PR DESCRIPTION
I rebased #362 then added a callback. The original commit is the same thing as in #362, and the next commit is my changes.

Unfortunately callbacks aren't currently tested, and I'm not 100% sure how to setup the infrastructure for that. I might look into it later.