### PR TITLE
Add RPC send ID for idempotency

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -2933,21 +2933,25 @@ void rai::rpc_handler::send ()
 									}
 								}
 							}
+							boost::optional<std::string> send_id (request.get_optional<std::string> ("id"));
 							if (balance >= amount.number ())
 							{
 								auto rpc_l (shared_from_this ());
 								auto response_a (response);
 								existing->second->send_async (source, destination, amount.number (), [response_a](std::shared_ptr<rai::block> block_a) {
-									rai::uint256_union hash (0);
 									if (block_a != nullptr)
 									{
-										hash = block_a->hash ();
+										rai::uint256_union hash (block_a->hash ());
+										boost::property_tree::ptree response_l;
+										response_l.put ("block", hash.to_string ());
+										response_a (response_l);
 									}
-									boost::property_tree::ptree response_l;
-									response_l.put ("block", hash.to_string ());
-									response_a (response_l);
+									else
+									{
+										error_response (response_a, "Error generating block");
+									}
 								},
-								work == 0);
+								work == 0, send_id);
 							}
 							else
 							{

--- a/rai/node/wallet.hpp
+++ b/rai/node/wallet.hpp
@@ -123,7 +123,7 @@ class wallet : public std::enable_shared_from_this<rai::wallet>
 public:
 	std::shared_ptr<rai::block> change_action (rai::account const &, rai::account const &, bool = true);
 	std::shared_ptr<rai::block> receive_action (rai::send_block const &, rai::account const &, rai::uint128_union const &, bool = true);
-	std::shared_ptr<rai::block> send_action (rai::account const &, rai::account const &, rai::uint128_t const &, bool = true);
+	std::shared_ptr<rai::block> send_action (rai::account const &, rai::account const &, rai::uint128_t const &, bool = true, boost::optional<std::string> = {});
 	wallet (bool &, rai::transaction &, rai::node &, std::string const &);
 	wallet (bool &, rai::transaction &, rai::node &, std::string const &, std::string const &);
 	void enter_initial_password ();
@@ -141,7 +141,7 @@ public:
 	bool receive_sync (std::shared_ptr<rai::block>, rai::account const &, rai::uint128_t const &);
 	void receive_async (std::shared_ptr<rai::block>, rai::account const &, rai::uint128_t const &, std::function<void(std::shared_ptr<rai::block>)> const &, bool = true);
 	rai::block_hash send_sync (rai::account const &, rai::account const &, rai::uint128_t const &);
-	void send_async (rai::account const &, rai::account const &, rai::uint128_t const &, std::function<void(std::shared_ptr<rai::block>)> const &, bool = true);
+	void send_async (rai::account const &, rai::account const &, rai::uint128_t const &, std::function<void(std::shared_ptr<rai::block>)> const &, bool = true, boost::optional<std::string> = {});
 	void work_generate (rai::account const &, rai::block_hash const &);
 	void work_update (MDB_txn *, rai::account const &, rai::block_hash const &, uint64_t);
 	uint64_t work_fetch (MDB_txn *, rai::account const &, rai::block_hash const &);
@@ -176,6 +176,7 @@ public:
 	std::condition_variable condition;
 	rai::kdf kdf;
 	MDB_dbi handle;
+	MDB_dbi send_action_ids;
 	rai::node & node;
 	bool stopped;
 	std::thread thread;


### PR DESCRIPTION
Probably needs some more discussion.

Note that currently, send IDs are per wallet. If we decide to keep that behavior, it should be documented.