### PR TITLE
Update macOS BundleName

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nano_wallet</string>
 	<key>CFBundleName</key>
-	<string>RaiBlocks</string>
+	<string>Nano</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
When ran on macOS, the App name (in the top left of the screen) still says 'Raiblocks'. This patch changes that to 'Nano'.