### PR TITLE
Fixes --wallet_change_seed to add account

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3234,7 +3234,7 @@ bool rai::handle_node_options (boost::program_options::variables_map & vm)
 						if (!key.data.decode_hex (vm["key"].as<std::string> ()))
 						{
 							rai::transaction transaction (wallet->store.environment, nullptr, true);
-							wallet->store.seed_set (transaction, key);
+							wallet->change_seed (transaction, key);
 						}
 						else
 						{

--- a/rai/node/wallet.hpp
+++ b/rai/node/wallet.hpp
@@ -148,6 +148,8 @@ public:
 	void work_ensure (MDB_txn *, rai::account const &);
 	bool search_pending ();
 	void init_free_accounts (MDB_txn *);
+	/** Changes the wallet seed and returns the first account */
+	rai::public_key change_seed (MDB_txn * transaction_a, rai::raw_key const & prv_a);
 	std::unordered_set<rai::account> free_accounts;
 	std::function<void(bool, bool)> lock_observer;
 	rai::wallet_store store;

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -375,7 +375,7 @@ wallet (wallet_a)
 					rai::transaction transaction (this->wallet.wallet_m->store.environment, nullptr, true);
 					if (this->wallet.wallet_m->store.valid_password (transaction))
 					{
-						this->wallet.wallet_m->store.seed_set (transaction, seed_l);
+						this->wallet.account = this->wallet.wallet_m->change_seed (transaction, seed_l);
 						successful = true;
 					}
 					else
@@ -390,28 +390,6 @@ wallet (wallet_a)
 								import_seed->setText ("Import seed");
 							}));
 						});
-					}
-				}
-				if (successful)
-				{
-					rai::transaction transaction (this->wallet.wallet_m->store.environment, nullptr, true);
-					this->wallet.account = this->wallet.wallet_m->deterministic_insert (transaction);
-					auto count (0);
-					for (uint32_t i (1), n (32); i < n; ++i)
-					{
-						rai::raw_key prv;
-						this->wallet.wallet_m->store.deterministic_key (prv, transaction, i);
-						rai::keypair pair (prv.data.to_string ());
-						auto latest (this->wallet.node.ledger.latest (transaction, pair.pub));
-						if (!latest.is_zero ())
-						{
-							count = i;
-							n = i + 32;
-						}
-					}
-					for (uint32_t i (0); i < count; ++i)
-					{
-						this->wallet.account = this->wallet.wallet_m->deterministic_insert (transaction);
 					}
 				}
 				if (successful)


### PR DESCRIPTION
Currently, only seed import from the Qt wallet creates an account. When using --wallet_change_seed, the wallet would display the wrong address until the user manually created accounts.

Node and wallet refactored to share seed-change code.
