### PR TITLE
Properly version (tag) docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,10 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ci/build-travis.sh "/usr/local/opt/qt5/lib/cmake/Qt5"; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then docker run -v $TRAVIS_BUILD_DIR:/workspace nanocurrency/nano-ci /bin/bash -c "cd /workspace && ASAN=${ASAN} TSAN=${TSAN} ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"; fi
 
-after_script:
-  - if [ -n "$ONE_TIME_TESTS" ] && [ -n "$DOCKER_PASSWORD" ] && [ "$TRAVIS_BRANCH" = "master" ]; then ci/deploy-docker.sh; fi
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: ci/deploy-docker.sh
+  on:
+    all_branches: true
+    condition: -n "$ONE_TIME_TESTS"

--- a/ci/deploy-docker.sh
+++ b/ci/deploy-docker.sh
@@ -8,6 +8,20 @@ docker login -u nanocurrency -p "$DOCKER_PASSWORD"
 # We push this just so it can be a cache next time
 "$scripts"/custom-timeout.sh 30 docker push nanocurrency/nano-ci
 
-# We don't need to build this unless we're deploying it
+tags=()
+if [ -n "$TRAVIS_BRANCH" ]; then
+    tags+=("$TRAVIS_BRANCH")
+elif [ -n "$TRAVIS_TAG" ]; then
+    tags+=("$TRAVIS_TAG" latest)
+fi
+
 ci/build-docker-image.sh docker/node/Dockerfile nanocurrency/nano
-"$scripts"/custom-timeout.sh 30 docker push nanocurrency/nano
+for tag in "${tags[@]}"; do
+    # Sanitize docker tag
+    # https://docs.docker.com/engine/reference/commandline/tag/
+    tag="$(printf '%s' "$tag" | tr -c '[a-z][A-Z][0-9]_.-' -)"
+    if [ "$tag" != "latest" ]; then
+        docker tag nanocurrency/nano nanocurrency/nano:"$tag"
+    fi
+    "$scripts"/custom-timeout.sh 30 docker push nanocurrency/nano:"$tag"
+done


### PR DESCRIPTION
Now, the docker tag `latest` (the default) will refer to the latest commit tagged in git (effectively the latest release).

You can see a test run of this on my fork here: https://travis-ci.org/PlasmaPower/raiblocks/builds/345122239