### PR TITLE
Remove unused code

### DIFF
--- a/rai/blockstore.cpp
+++ b/rai/blockstore.cpp
@@ -781,35 +781,6 @@ rai::block_counts rai::block_store::block_count (MDB_txn * transaction_a)
 	return result;
 }
 
-std::unordered_multimap<rai::block_hash, rai::block_hash> rai::block_store::block_dependencies (MDB_txn * transaction_a)
-{
-	std::unordered_multimap<rai::block_hash, rai::block_hash> result;
-	// For every block type
-	for (auto type : { rai::block_type::send, rai::block_type::receive, rai::block_type::open, rai::block_type::change })
-	{
-		auto db (block_database (type));
-		// For every block in that type's table
-		for (auto i (rai::store_iterator (transaction_a, db)), n (rai::store_iterator (nullptr)); i != n; ++i)
-		{
-			rai::block_hash hash (i->first.uint256 ());
-			auto block (block_get (transaction_a, hash));
-			if (type != rai::block_type::open)
-			{
-				auto previous (block->previous ());
-				assert (!previous.is_zero ());
-				result.insert (std::make_pair (previous, hash));
-			}
-			if (type == rai::block_type::open || type == rai::block_type::receive)
-			{
-				auto source (block->source ());
-				assert (!source.is_zero ());
-				result.insert (std::make_pair (source, hash));
-			}
-		}
-	}
-	return result;
-}
-
 void rai::block_store::account_del (MDB_txn * transaction_a, rai::account const & account_a)
 {
 	auto status (mdb_del (transaction_a, accounts, rai::mdb_val (account_a), nullptr));

--- a/rai/blockstore.hpp
+++ b/rai/blockstore.hpp
@@ -60,7 +60,6 @@ public:
 	void block_del (MDB_txn *, rai::block_hash const &);
 	bool block_exists (MDB_txn *, rai::block_hash const &);
 	rai::block_counts block_count (MDB_txn *);
-	std::unordered_multimap<rai::block_hash, rai::block_hash> block_dependencies (MDB_txn *);
 
 	void frontier_put (MDB_txn *, rai::block_hash const &, rai::account const &);
 	rai::account frontier_get (MDB_txn *, rai::block_hash const &);

--- a/rai/common.cpp
+++ b/rai/common.cpp
@@ -409,56 +409,6 @@ std::string rai::vote::to_json () const
 	return stream.str ();
 }
 
-namespace
-{
-class root_visitor : public rai::block_visitor
-{
-public:
-	root_visitor (rai::block_store & store_a) :
-	store (store_a)
-	{
-	}
-	virtual ~root_visitor () = default;
-	void send_block (rai::send_block const & block_a) override
-	{
-		result = block_a.previous ();
-	}
-	void receive_block (rai::receive_block const & block_a) override
-	{
-		result = block_a.previous ();
-	}
-	// Open blocks have no previous () so we use the account number
-	void open_block (rai::open_block const & block_a) override
-	{
-		rai::transaction transaction (store.environment, nullptr, false);
-		auto hash (block_a.source ());
-		auto source (store.block_get (transaction, hash));
-		if (source != nullptr)
-		{
-			auto send (dynamic_cast<rai::send_block *> (source.get ()));
-			if (send != nullptr)
-			{
-				result = send->hashables.destination;
-			}
-			else
-			{
-				result.clear ();
-			}
-		}
-		else
-		{
-			result.clear ();
-		}
-	}
-	void change_block (rai::change_block const & block_a) override
-	{
-		result = block_a.previous ();
-	}
-	rai::block_store & store;
-	rai::block_hash result;
-};
-} // namespace
-
 rai::amount_visitor::amount_visitor (MDB_txn * transaction_a, rai::block_store & store_a) :
 transaction (transaction_a),
 store (store_a)


### PR DESCRIPTION
Removes `root_visitor` and `block_dependencies`. Both would not support ublocks and are unused.