### PR TITLE
Fix docker boost url

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 ENV BOOST_BASENAME=boost_1_66_0 \
-    BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.66.0/boost_1_66_0.tar.gz/download
+    BOOST_URL=https://netix.dl.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.gz
 
 RUN apt-get update -qq && apt-get install -yqq \
     build-essential \

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ENV BOOST_BASENAME=boost_1_66_0 \
     BOOST_ROOT=/tmp/boost_install  \
-    BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.66.0/boost_1_66_0.tar.gz/download
+    BOOST_URL=https://netix.dl.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.gz
 
 RUN apt-get update -qq && apt-get install -yqq \
     build-essential \


### PR DESCRIPTION
The old one is now redirecting to an HTML page, causing the build to fail.