### PR TITLE
Ublocks clang format

### DIFF
--- a/rai/core_test/ledger.cpp
+++ b/rai/core_test/ledger.cpp
@@ -335,7 +335,7 @@ TEST (ledger, receive_rollback)
 	ASSERT_EQ (rai::process_result::progress, ledger.process (transaction, send).code);
 	rai::receive_block receive (send.hash (), send.hash (), rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0);
 	ASSERT_EQ (rai::process_result::progress, ledger.process (transaction, receive).code);
-	ledger.rollback(transaction, receive.hash ());
+	ledger.rollback (transaction, receive.hash ());
 }
 
 TEST (ledger, process_duplicate)


### PR DESCRIPTION
Just fixes a minor whitespace problem so Travis is happy.