### PR TITLE
Add ledger functions for ublock compatible info

### DIFF
--- a/rai/ledger.hpp
+++ b/rai/ledger.hpp
@@ -35,6 +35,9 @@ public:
 	bool block_exists (rai::block_hash const &);
 	std::string block_text (char const *);
 	std::string block_text (rai::block_hash const &);
+	bool is_utx_send (MDB_txn *, rai::utx_block const &);
+	rai::block_hash block_destination (MDB_txn *, rai::block const &);
+	rai::block_hash block_source (MDB_txn *, rai::block const &);
 	rai::uint128_t supply (MDB_txn *);
 	rai::process_return process (MDB_txn *, rai::block const &);
 	void rollback (MDB_txn *, rai::block_hash const &);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1246,7 +1246,7 @@ rai::process_return rai::block_processor::process_receive_one (MDB_txn * transac
 			{
 				BOOST_LOG (node.log) << boost::str (boost::format ("Gap source for: %1%") % block_a->hash ().to_string ());
 			}
-			node.store.unchecked_put (transaction_a, block_a->source (), block_a);
+			node.store.unchecked_put (transaction_a, node.ledger.block_source (transaction_a, *block_a), block_a);
 			node.gap_cache.add (transaction_a, block_a);
 			break;
 		}

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1001,18 +1001,17 @@ void rai::rpc_handler::blocks_info ()
 				entry.put ("contents", contents);
 				if (pending)
 				{
-					auto block_l (dynamic_cast<rai::send_block *> (block.get ()));
 					bool exists (false);
-					if (block_l != nullptr)
+					auto destination (node.ledger.block_destination (transaction, *block));
+					if (!destination.is_zero ())
 					{
-						auto destination (block_l->hashables.destination);
 						exists = node.store.pending_exists (transaction, rai::pending_key (destination, hash));
 					}
 					entry.put ("pending", exists ? "1" : "0");
 				}
 				if (source)
 				{
-					rai::block_hash source_hash (block->source ());
+					rai::block_hash source_hash (node.ledger.block_source (transaction, *block));
 					std::unique_ptr<rai::block> block_a (node.store.block_get (transaction, source_hash));
 					if (block_a != nullptr)
 					{
@@ -2227,12 +2226,11 @@ void rai::rpc_handler::pending_exists ()
 		auto block (node.store.block_get (transaction, hash));
 		if (block != nullptr)
 		{
-			auto block_l (dynamic_cast<rai::send_block *> (block.get ()));
 			auto exists (false);
-			if (block_l != nullptr)
+			auto destination (node.ledger.block_destination (transaction, *block));
+			if (!destination.is_zero ())
 			{
-				auto account (block_l->hashables.destination);
-				exists = node.store.pending_exists (transaction, rai::pending_key (account, hash));
+				exists = node.store.pending_exists (transaction, rai::pending_key (destination, hash));
 			}
 			boost::property_tree::ptree response_l;
 			response_l.put ("exists", exists ? "1" : "0");
@@ -2831,7 +2829,7 @@ void rai::rpc_handler::republish ()
 				block = node.store.block_get (transaction, hash);
 				if (sources != 0) // Republish source chain
 				{
-					rai::block_hash source (block->source ());
+					rai::block_hash source (node.ledger.block_source (transaction, *block));
 					std::unique_ptr<rai::block> block_a (node.store.block_get (transaction, source));
 					std::vector<rai::block_hash> hashes;
 					while (block_a != nullptr && hashes.size () < sources)
@@ -2857,10 +2855,9 @@ void rai::rpc_handler::republish ()
 				if (destinations != 0) // Republish destination chain
 				{
 					auto block_b (node.store.block_get (transaction, hash));
-					auto block_s (dynamic_cast<rai::send_block *> (block_b.get ()));
-					if (block_s != nullptr)
+					auto destination (node.ledger.block_destination (transaction, *block_b));
+					if (!destination.is_zero ())
 					{
-						auto destination (block_s->hashables.destination);
 						auto exists (node.store.pending_exists (transaction, rai::pending_key (destination, hash)));
 						if (!exists)
 						{
@@ -2871,7 +2868,7 @@ void rai::rpc_handler::republish ()
 							while (block_d != nullptr && hash != source)
 							{
 								hashes.push_back (previous);
-								source = block_d->source ();
+								source = node.ledger.block_source (transaction, *block_d);
 								previous = block_d->previous ();
 								block_d = node.store.block_get (transaction, previous);
 							}

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -2016,10 +2016,10 @@ void rai_qt::block_creation::create_receive ()
 		auto block_l (wallet.node.store.block_get (transaction, source_l));
 		if (block_l != nullptr)
 		{
-			auto send_block (dynamic_cast<rai::send_block *> (block_l.get ()));
-			if (send_block != nullptr)
+			auto destination (wallet.node.ledger.block_destination (transaction, *block_l));
+			if (!destination.is_zero ())
 			{
-				rai::pending_key pending_key (send_block->hashables.destination, source_l);
+				rai::pending_key pending_key (destination, source_l);
 				rai::pending_info pending;
 				if (!wallet.node.store.pending_get (transaction, pending_key, pending))
 				{
@@ -2140,10 +2140,10 @@ void rai_qt::block_creation::create_open ()
 			auto block_l (wallet.node.store.block_get (transaction, source_l));
 			if (block_l != nullptr)
 			{
-				auto send_block (dynamic_cast<rai::send_block *> (block_l.get ()));
-				if (send_block != nullptr)
+				auto destination (wallet.node.ledger.block_destination (transaction, *block_l));
+				if (!destination.is_zero ())
 				{
-					rai::pending_key pending_key (send_block->hashables.destination, source_l);
+					rai::pending_key pending_key (destination, source_l);
 					rai::pending_info pending;
 					if (!wallet.node.store.pending_get (transaction, pending_key, pending))
 					{


### PR DESCRIPTION
Adds `ledger.block_destination (transaction, block)` and `ledger.block_source (transaction, block)`. Also uses them where old code assumed non-utx blocks.