### PR TITLE
Improved error handling in message parser

### DIFF
--- a/rai/core_test/message_parser.cpp
+++ b/rai/core_test/message_parser.cpp
@@ -74,14 +74,14 @@ TEST (message_parser, exact_confirm_ack_size)
 		message.serialize (stream);
 	}
 	ASSERT_EQ (0, visitor.confirm_ack_count);
-	ASSERT_FALSE (parser.error);
+	ASSERT_EQ (parser.status, rai::message_parser::parse_status::success);
 	parser.deserialize_confirm_ack (bytes.data (), bytes.size ());
 	ASSERT_EQ (1, visitor.confirm_ack_count);
-	ASSERT_FALSE (parser.error);
+	ASSERT_EQ (parser.status, rai::message_parser::parse_status::success);
 	bytes.push_back (0);
 	parser.deserialize_confirm_ack (bytes.data (), bytes.size ());
 	ASSERT_EQ (1, visitor.confirm_ack_count);
-	ASSERT_TRUE (parser.error);
+	ASSERT_NE (parser.status, rai::message_parser::parse_status::success);
 }
 
 TEST (message_parser, exact_confirm_req_size)
@@ -97,14 +97,14 @@ TEST (message_parser, exact_confirm_req_size)
 		message.serialize (stream);
 	}
 	ASSERT_EQ (0, visitor.confirm_req_count);
-	ASSERT_FALSE (parser.error);
+	ASSERT_EQ (parser.status, rai::message_parser::parse_status::success);
 	parser.deserialize_confirm_req (bytes.data (), bytes.size ());
 	ASSERT_EQ (1, visitor.confirm_req_count);
-	ASSERT_FALSE (parser.error);
+	ASSERT_EQ (parser.status, rai::message_parser::parse_status::success);
 	bytes.push_back (0);
 	parser.deserialize_confirm_req (bytes.data (), bytes.size ());
 	ASSERT_EQ (1, visitor.confirm_req_count);
-	ASSERT_TRUE (parser.error);
+	ASSERT_NE (parser.status, rai::message_parser::parse_status::success);
 }
 
 TEST (message_parser, exact_publish_size)
@@ -120,14 +120,14 @@ TEST (message_parser, exact_publish_size)
 		message.serialize (stream);
 	}
 	ASSERT_EQ (0, visitor.publish_count);
-	ASSERT_FALSE (parser.error);
+	ASSERT_EQ (parser.status, rai::message_parser::parse_status::success);
 	parser.deserialize_publish (bytes.data (), bytes.size ());
 	ASSERT_EQ (1, visitor.publish_count);
-	ASSERT_FALSE (parser.error);
+	ASSERT_EQ (parser.status, rai::message_parser::parse_status::success);
 	bytes.push_back (0);
 	parser.deserialize_publish (bytes.data (), bytes.size ());
 	ASSERT_EQ (1, visitor.publish_count);
-	ASSERT_TRUE (parser.error);
+	ASSERT_NE (parser.status, rai::message_parser::parse_status::success);
 }
 
 TEST (message_parser, exact_keepalive_size)
@@ -142,12 +142,12 @@ TEST (message_parser, exact_keepalive_size)
 		message.serialize (stream);
 	}
 	ASSERT_EQ (0, visitor.keepalive_count);
-	ASSERT_FALSE (parser.error);
+	ASSERT_EQ (parser.status, rai::message_parser::parse_status::success);
 	parser.deserialize_keepalive (bytes.data (), bytes.size ());
 	ASSERT_EQ (1, visitor.keepalive_count);
-	ASSERT_FALSE (parser.error);
+	ASSERT_EQ (parser.status, rai::message_parser::parse_status::success);
 	bytes.push_back (0);
 	parser.deserialize_keepalive (bytes.data (), bytes.size ());
 	ASSERT_EQ (1, visitor.keepalive_count);
-	ASSERT_TRUE (parser.error);
+	ASSERT_NE (parser.status, rai::message_parser::parse_status::success);
 }

--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -130,6 +130,17 @@ class work_pool;
 class message_parser
 {
 public:
+	enum class parse_status
+	{
+		success,
+		insufficient_work,
+		invalid_header,
+		invalid_message_type,
+		invalid_keepalive_message,
+		invalid_publish_message,
+		invalid_confirm_req_message,
+		invalid_confirm_ack_message
+	};
 	message_parser (rai::message_visitor &, rai::work_pool &);
 	void deserialize_buffer (uint8_t const *, size_t);
 	void deserialize_keepalive (uint8_t const *, size_t);
@@ -139,8 +150,7 @@ public:
 	bool at_end (rai::bufferstream &);
 	rai::message_visitor & visitor;
 	rai::work_pool & pool;
-	bool error;
-	bool insufficient_work;
+	parse_status status;
 };
 class keepalive : public message
 {


### PR DESCRIPTION
Communicates errors from message_parser to the node more precisely so errors can be logged.