### PR TITLE
Build of Boost Cleanup

### DIFF
--- a/ci/bootstrap_boost.sh
+++ b/ci/bootstrap_boost.sh
@@ -3,6 +3,15 @@
 set -o nounset
 set -o xtrace
 
+bootstrapArgs=()
+while getopts 'm' OPT; do
+	case "${OPT}" in
+		m)
+			bootstrapArgs+=('--with-libraries=atomic,chrono,thread,log,date_time,filesystem,program_options,regex')
+			;;
+	esac
+done
+
 BOOST_BASENAME=boost_1_66_0
 BOOST_ROOT=${BOOST_ROOT-/usr/local/boost}
 BOOST_URL=https://downloads.sourceforge.net/project/boost/boost/1.66.0/${BOOST_BASENAME}.tar.bz2
@@ -20,7 +29,7 @@ mv "${BOOST_ARCHIVE}.new" "${BOOST_ARCHIVE}"
 
 tar xf "${BOOST_ARCHIVE}"
 cd ${BOOST_BASENAME}
-./bootstrap.sh
+./bootstrap.sh "${bootstrapArgs[@]}"
 ./b2 -d0 --prefix=${BOOST_ROOT} link=static install
 cd ..
 rm -rf ${BOOST_BASENAME}

--- a/ci/bootstrap_boost.sh
+++ b/ci/bootstrap_boost.sh
@@ -6,13 +6,23 @@ set -o xtrace
 BOOST_BASENAME=boost_1_66_0
 BOOST_ROOT=${BOOST_ROOT-/usr/local/boost}
 BOOST_URL=https://downloads.sourceforge.net/project/boost/boost/1.66.0/${BOOST_BASENAME}.tar.bz2
+BOOST_ARCHIVE="${BOOST_BASENAME}.tar.bz2"
+BOOST_ARCHIVE_SHA256='5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9'
 
-wget --quiet -O ${BOOST_BASENAME}.tar.gz "${BOOST_URL}"
-tar xf ${BOOST_BASENAME}.tar.gz
+wget --quiet -O "${BOOST_ARCHIVE}.new" "${BOOST_URL}"
+checkHash="$(openssl dgst -sha256 "${BOOST_ARCHIVE}.new" | sed 's@^.*= *@@')"
+if [ "${checkHash}" != "${BOOST_ARCHIVE_SHA256}" ]; then
+	echo "Checksum mismatch.  Expected ${BOOST_ARCHIVE_SHA256}, got ${checkHash}" >&2
+
+	exit 1
+fi
+mv "${BOOST_ARCHIVE}.new" "${BOOST_ARCHIVE}"
+
+tar xf "${BOOST_ARCHIVE}"
 cd ${BOOST_BASENAME}
 ./bootstrap.sh
 ./b2 -d0 --prefix=${BOOST_ROOT} link=static install
 cd ..
 rm -rf ${BOOST_BASENAME}
-rm -f ${BOOST_BASENAME}.tar.gz
+rm -f "${BOOST_ARCHIVE}"
 mkdir -p app

--- a/ci/bootstrap_boost.sh
+++ b/ci/bootstrap_boost.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o unset
+set -o nounset
 set -o xtrace
 
 BOOST_BASENAME=boost_1_66_0

--- a/ci/bootstrap_boost.sh
+++ b/ci/bootstrap_boost.sh
@@ -35,4 +35,3 @@ cd ${BOOST_BASENAME}
 cd ..
 rm -rf ${BOOST_BASENAME}
 rm -f "${BOOST_ARCHIVE}"
-mkdir -p app

--- a/ci/bootstrap_boost.sh
+++ b/ci/bootstrap_boost.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -o nounset
+set -o errexit
 set -o xtrace
 
 bootstrapArgs=()


### PR DESCRIPTION
There were a few things the "bootstrap_boost.sh" script did not do well, this cleans them up.  This includes checking the checksum of the downloaded tarball, allowing for a minimal build of Boost, and cleanup some incorrect bash options.