### PR TITLE
Add is_send to utx block callbacks

### DIFF
--- a/rai/common.hpp
+++ b/rai/common.hpp
@@ -234,6 +234,7 @@ public:
 	rai::account account;
 	rai::amount amount;
 	rai::account pending_account;
+	boost::optional<bool> utx_is_send;
 };
 enum class tally_result
 {

--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -1032,7 +1032,7 @@ TEST (node, coherent_observer)
 {
 	rai::system system (24000, 1);
 	auto & node1 (*system.nodes[0]);
-	node1.observers.blocks.add ([&node1](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const &) {
+	node1.observers.blocks.add ([&node1](std::shared_ptr<rai::block> block_a, rai::process_return const &) {
 		rai::transaction transaction (node1.store.environment, nullptr, false);
 		ASSERT_TRUE (node1.store.block_exists (transaction, block_a->hash ()));
 	});

--- a/rai/ledger.cpp
+++ b/rai/ledger.cpp
@@ -206,6 +206,7 @@ void ledger_processor::utx_block (rai::utx_block const & block_a)
 				// Account does not yet exists
 				result.code = block_a.previous ().is_zero () ? rai::process_result::progress : rai::process_result::gap_previous; // Does the first block in an account yield 0 for previous() ? (Unambigious)
 			}
+			result.utx_is_send = is_send;
 			if (result.code == rai::process_result::progress)
 			{
 				if (!is_send)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1201,7 +1201,7 @@ void rai::block_processor::process_receive_many (std::deque<rai::block_processor
 		}
 		for (auto & i : progress)
 		{
-			node.observers.blocks (i.first, i.second.account, i.second.amount);
+			node.observers.blocks (i.first, i.second);
 			if (i.second.amount > 0)
 			{
 				node.observers.account_balance (i.second.account, false);
@@ -1393,27 +1393,31 @@ block_processor_thread ([this]() { this->block_processor.process_blocks (); })
 	peers.disconnect_observer = [this]() {
 		observers.disconnect ();
 	};
-	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a) {
+	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::process_return const & result_a) {
 		if (this->block_arrival.recent (block_a->hash ()))
 		{
 			rai::transaction transaction (store.environment, nullptr, true);
 			active.start (transaction, block_a);
 		}
 	});
-	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a) {
+	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::process_return const & result_a) {
 		if (this->block_arrival.recent (block_a->hash ()))
 		{
 			auto node_l (shared_from_this ());
-			background ([node_l, block_a, account_a, amount_a]() {
+			background ([node_l, block_a, result_a]() {
 				if (!node_l->config.callback_address.empty ())
 				{
 					boost::property_tree::ptree event;
-					event.add ("account", account_a.to_account ());
+					event.add ("account", result_a.account.to_account ());
 					event.add ("hash", block_a->hash ().to_string ());
 					std::string block_text;
 					block_a->serialize_json (block_text);
 					event.add ("block", block_text);
-					event.add ("amount", amount_a.to_string_dec ());
+					event.add ("amount", result_a.amount.to_string_dec ());
+					if (result_a.utx_is_send)
+					{
+						event.add ("is_send", *result_a.utx_is_send);
+					}
 					std::stringstream ostream;
 					boost::property_tree::write_json (ostream, event);
 					ostream.flush ();

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -413,7 +413,7 @@ public:
 class node_observers
 {
 public:
-	rai::observer_set<std::shared_ptr<rai::block>, rai::account const &, rai::amount const &> blocks;
+	rai::observer_set<std::shared_ptr<rai::block>, rai::process_return const &> blocks;
 	rai::observer_set<bool> wallet;
 	rai::observer_set<std::shared_ptr<rai::vote>, rai::endpoint const &> vote;
 	rai::observer_set<rai::account const &, bool> account_balance;

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -141,8 +141,8 @@ void rai::rpc::start ()
 	}
 
 	acceptor.listen ();
-	node.observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const &) {
-		observer_action (account_a);
+	node.observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::process_return const & result_a) {
+		observer_action (result_a.account);
 	});
 
 	accept ();
@@ -2492,7 +2492,7 @@ void rai::rpc_handler::process ()
 			{
 				case rai::process_result::progress:
 				{
-					node.observers.blocks (block_a, result.account, result.amount);
+					node.observers.blocks (block_a, result);
 					boost::property_tree::ptree response_l;
 					response_l.put ("hash", hash.to_string ());
 					response (response_l);

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -1099,17 +1099,17 @@ void rai_qt::wallet::start ()
 			this_l->push_main_stack (this_l->send_blocks_window);
 		}
 	});
-	node.observers.blocks.add ([this_w](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const &) {
+	node.observers.blocks.add ([this_w](std::shared_ptr<rai::block> block_a, rai::process_return const & result_a) {
 		if (auto this_l = this_w.lock ())
 		{
-			this_l->application.postEvent (&this_l->processor, new eventloop_event ([this_w, block_a, account_a]() {
+			this_l->application.postEvent (&this_l->processor, new eventloop_event ([ this_w, block_a, result_a.account ]() {
 				if (auto this_l = this_w.lock ())
 				{
-					if (this_l->wallet_m->exists (account_a))
+					if (this_l->wallet_m->exists (result_a.account))
 					{
 						this_l->accounts.refresh ();
 					}
-					if (account_a == this_l->account)
+					if (result_a.account == this_l->account)
 					{
 						this_l->history.refresh ();
 					}


### PR DESCRIPTION
As part of this, refactors `node.observers.blocks` to use a `process_return` instead of `account` + `amount`.