### PR TITLE
Disable work generation by default for mass creation of accounts

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -722,7 +722,7 @@ void rai::rpc_handler::accounts_create ()
 				auto existing (node.wallets.items.find (wallet));
 				if (existing != node.wallets.items.end ())
 				{
-					const bool generate_work = request.get<bool> ("work", true);
+					const bool generate_work = request.get<bool> ("work", false);
 					boost::property_tree::ptree response_l;
 					boost::property_tree::ptree accounts;
 					for (auto i (0); accounts.size () < count; ++i)


### PR DESCRIPTION
Rationale: for 100+ accounts at once even fastest GPU can't handle it