### PR TITLE
Prevent tests from accumulating thousands of files and directories

### DIFF
--- a/rai/node/testing.cpp
+++ b/rai/node/testing.cpp
@@ -1,5 +1,6 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <cstdlib>
 #include <rai/node/common.hpp>
 #include <rai/node/testing.hpp>
 
@@ -49,6 +50,14 @@ rai::system::~system ()
 	for (auto & i : nodes)
 	{
 		i->stop ();
+	}
+
+	// Clean up tmp directories created by the tests. Since it's sometimes useful to
+	// see log files after test failures, an environment variable is supported to
+	// retain the files.
+	if (std::getenv ("TEST_KEEP_TMPDIRS") == nullptr)
+	{
+		rai::remove_temporary_directories ();
 	}
 }
 

--- a/rai/node/utility.hpp
+++ b/rai/node/utility.hpp
@@ -24,8 +24,11 @@ using bufferstream = boost::iostreams::stream_buffer<boost::iostreams::basic_arr
 using vectorstream = boost::iostreams::stream_buffer<boost::iostreams::back_insert_device<std::vector<uint8_t>>>;
 // OS-specific way of finding a path to a home directory.
 boost::filesystem::path working_path ();
-// Get a unique path within the home directory, used for testing
+// Get a unique path within the home directory, used for testing.
+// Any directories created at this location will be removed when a test finishes.
 boost::filesystem::path unique_path ();
+// Remove all unique tmp directories created by the process. The list of unique paths are returned.
+std::vector<boost::filesystem::path> remove_temporary_directories ();
 // C++ stream are absolutely horrible so I need this helper function to do the most basic operation of creating a file if it doesn't exist or truncating it.
 void open_or_create (std::fstream &, std::string const &);
 // Reads a json object from the stream and if was changed, write the object back to the stream


### PR DESCRIPTION
My RaiBlocksTest directory has accumulated tens of thousands of tmp directories and files, totaling 1GB+. Each test run produce hundreds of files using `rai::unique_path`

This PR removes any tmpdirs and lockfiles produced by a test (in the `system` destructor)

The same way you can use environment variables to pick tests (GTEST_FILTER), you can use an environment variable (TEST_KEEP_TMPDIRS=1) to retain the directories, e.g. to view log files when there are test failures.