### PR TITLE
Reorder lock/transaction to start tx only after successful lock

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1698,8 +1698,8 @@ void rai::gap_cache::add (MDB_txn * transaction_a, std::shared_ptr<rai::block> b
 
 void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 {
-	rai::transaction transaction (node.store.environment, nullptr, false);
 	std::lock_guard<std::mutex> lock (mutex);
+	rai::transaction transaction (node.store.environment, nullptr, false);
 	auto hash (vote_a->block->hash ());
 	auto existing (blocks.get<1> ().find (hash));
 	if (existing != blocks.get<1> ().end ())
@@ -3035,8 +3035,8 @@ bool rai::election::vote (std::shared_ptr<rai::vote> vote_a)
 void rai::active_transactions::announce_votes ()
 {
 	std::vector<rai::block_hash> inactive;
-	rai::transaction transaction (node.store.environment, nullptr, true);
 	std::lock_guard<std::mutex> lock (mutex);
+	rai::transaction transaction (node.store.environment, nullptr, true);
 
 	{
 		size_t announcements (0);

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -716,8 +716,8 @@ node (node_a)
 
 void rai::wallet::enter_initial_password ()
 {
-	rai::transaction transaction (store.environment, nullptr, true);
 	std::lock_guard<std::recursive_mutex> lock (store.mutex);
+	rai::transaction transaction (store.environment, nullptr, true);
 	rai::raw_key password_l;
 	store.password.value (password_l);
 	if (password_l.data.is_zero ())


### PR DESCRIPTION
I measured tx times, and e.g. gap_cache::vote was open for ~30s, probably due to the mutex being locked.