### PR TITLE
Minor RPC block_create changes

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1208,16 +1208,23 @@ void rai::rpc_handler::block_create ()
 				previous = node.ledger.latest (transaction, pub);
 				balance = node.ledger.account_balance (transaction, pub);
 			}
+			// Check for incorrect account key
+			if (account_text.is_initialized ())
+			{
+				if (account != pub)
+				{
+					error_response (response, "Incorrect key for given account");
+				}
+			}
 			if (type == "state")
 			{
-				if (!account.is_zero () && previous_text.is_initialized () && !representative.is_zero () && !balance.is_zero () && link_text.is_initialized ())
+				if (previous_text.is_initialized () && !representative.is_zero () && !balance.is_zero () && link_text.is_initialized ())
 				{
 					if (work == 0)
 					{
 						work = node.generate_work (previous.is_zero () ? pub : previous);
 					}
-
-					rai::state_block state (account, previous, representative, balance, link, prv, pub, work);
+					rai::state_block state (pub, previous, representative, balance, link, prv, pub, work);
 					boost::property_tree::ptree response_l;
 					response_l.put ("hash", state.hash ().to_string ());
 					std::string contents;
@@ -1227,7 +1234,7 @@ void rai::rpc_handler::block_create ()
 				}
 				else
 				{
-					error_response (response, "Account, previous, representative, balance, and link are required");
+					error_response (response, "Previous, representative, final balance and link are required");
 				}
 			}
 			else if (type == "open")

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1125,7 +1125,6 @@ void rai::rpc_handler::block_create ()
 		prv.data.clear ();
 		rai::uint256_union previous (0);
 		rai::uint128_union balance (0);
-		rai::uint256_union link (0);
 		if (wallet != 0 && account != 0)
 		{
 			auto existing (node.wallets.items.find (wallet));
@@ -1184,6 +1183,7 @@ void rai::rpc_handler::block_create ()
 				error_response (response, "Bad balance number");
 			}
 		}
+		rai::uint256_union link (0);
 		boost::optional<std::string> link_text (request.get_optional<std::string> ("link"));
 		if (link_text.is_initialized ())
 		{
@@ -1196,6 +1196,11 @@ void rai::rpc_handler::block_create ()
 					error_response (response, "Bad link number");
 				}
 			}
+		}
+		else
+		{
+			// Retrieve link from source or destination
+			link = source.is_zero () ? destination : source;
 		}
 		if (prv.data != 0)
 		{
@@ -1218,7 +1223,7 @@ void rai::rpc_handler::block_create ()
 			}
 			if (type == "state")
 			{
-				if (previous_text.is_initialized () && !representative.is_zero () && !balance.is_zero () && link_text.is_initialized ())
+				if (previous_text.is_initialized () && !representative.is_zero () && !balance.is_zero () && !link.is_zero ())
 				{
 					if (work == 0)
 					{
@@ -1234,7 +1239,7 @@ void rai::rpc_handler::block_create ()
 				}
 				else
 				{
-					error_response (response, "Previous, representative, final balance and link are required");
+					error_response (response, "Previous, representative, final balance and link (source or destination) are required");
 				}
 			}
 			else if (type == "open")

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1232,7 +1232,7 @@ void rai::rpc_handler::block_create ()
 			}
 			if (type == "state")
 			{
-				if (previous_text.is_initialized () && !representative.is_zero () && !balance.is_zero () && !link.is_zero ())
+				if (previous_text.is_initialized () && !representative.is_zero () && !balance.is_zero () && (!link.is_zero () || link_text.is_initialized ()))
 				{
 					if (work == 0)
 					{

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1213,6 +1213,15 @@ void rai::rpc_handler::block_create ()
 				previous = node.ledger.latest (transaction, pub);
 				balance = node.ledger.account_balance (transaction, pub);
 			}
+			// Double check current balance if previous block is specified
+			else if (previous_text.is_initialized () && balance_text.is_initialized () && type == "send")
+			{
+				rai::transaction transaction (node.store.environment, nullptr, false);
+				if (node.store.block_exists (transaction, previous) && node.store.block_balance (transaction, previous) != balance.number ())
+				{
+					error_response (response, "Balance mismatch for previous block");
+				}
+			}
 			// Check for incorrect account key
 			if (account_text.is_initialized ())
 			{

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1201,6 +1201,13 @@ void rai::rpc_handler::block_create ()
 		{
 			rai::uint256_union pub;
 			ed25519_publickey (prv.data.bytes.data (), pub.bytes.data ());
+			// Fetching account balance & previous for send blocks (if aren't given directly)
+			if (!previous_text.is_initialized () && !balance_text.is_initialized ())
+			{
+				rai::transaction transaction (node.store.environment, nullptr, false);
+				previous = node.ledger.latest (transaction, pub);
+				balance = node.ledger.account_balance (transaction, pub);
+			}
 			if (type == "state")
 			{
 				if (!account.is_zero () && previous_text.is_initialized () && !representative.is_zero () && !balance.is_zero () && link_text.is_initialized ())


### PR DESCRIPTION
Fetching account balance & previous for send blocks if aren't given directly
Double check current balance if previous block is specified (as some users can acidentally mess it)

Account field is not required for state blocks as it has private/public key
If there is no link in request for state blocks use source or destination