### PR TITLE
Protocol version constants

### DIFF
--- a/rai/common.hpp
+++ b/rai/common.hpp
@@ -23,6 +23,9 @@ struct hash<rai::uint256_union>
 }
 namespace rai
 {
+const uint8_t protocol_version = 0x07;
+const uint8_t protocol_version_min = 0x01;
+
 class block_store;
 /**
  * Determine the balance as of this block

--- a/rai/core_test/conflicts.cpp
+++ b/rai/core_test/conflicts.cpp
@@ -84,6 +84,6 @@ TEST (votes, contested)
 	ASSERT_FALSE (*block1 == *block2);
 	rai::votes votes (block1);
 	ASSERT_TRUE (votes.uncontested ());
-	votes.rep_votes [rai::test_genesis_key.pub] = block2;
+	votes.rep_votes[rai::test_genesis_key.pub] = block2;
 	ASSERT_FALSE (votes.uncontested ());
 }

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1315,7 +1315,7 @@ void rai::bootstrap_initiator::bootstrap ()
 
 void rai::bootstrap_initiator::bootstrap (rai::endpoint const & endpoint_a)
 {
-	node.peers.insert (endpoint_a, 0x5);
+	node.peers.insert (endpoint_a, rai::protocol_version);
 	std::unique_lock<std::mutex> lock (mutex);
 	if (!stopped)
 	{

--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -10,9 +10,9 @@ size_t constexpr rai::message::bootstrap_server_position;
 std::bitset<16> constexpr rai::message::block_type_mask;
 
 rai::message::message (rai::message_type type_a) :
-version_max (0x07),
-version_using (0x07),
-version_min (0x01),
+version_max (rai::protocol_version),
+version_using (rai::protocol_version),
+version_min (rai::protocol_version_min),
 type (type_a)
 {
 }


### PR DESCRIPTION
There's no "protocol_version_max" since "max" and "using" are always the same in the reference node.