### PR TITLE
Hardening receive_all

### DIFF
--- a/rai/ledger.cpp
+++ b/rai/ledger.cpp
@@ -849,6 +849,16 @@ void rai::ledger::change_latest (MDB_txn * transaction_a, rai::account const & a
 	}
 }
 
+bool rai::ledger::is_successor (MDB_txn * transaction_a, rai::uint256_union const & start_a, rai::uint256_union const & end_a)
+{
+	rai::block_hash hash (start_a);
+	while (!hash.is_zero () && hash != end_a)
+	{
+		hash = store.block_successor (transaction_a, hash);
+	}
+	return hash == end_a;
+}
+
 std::unique_ptr<rai::block> rai::ledger::successor (MDB_txn * transaction_a, rai::uint256_union const & root_a)
 {
 	rai::block_hash successor (0);

--- a/rai/ledger.hpp
+++ b/rai/ledger.hpp
@@ -26,6 +26,7 @@ public:
 	rai::uint128_t account_balance (MDB_txn *, rai::account const &);
 	rai::uint128_t account_pending (MDB_txn *, rai::account const &);
 	rai::uint128_t weight (MDB_txn *, rai::account const &);
+	bool is_successor (MDB_txn *, rai::block_hash const &, rai::block_hash const &);
 	std::unique_ptr<rai::block> successor (MDB_txn *, rai::block_hash const &);
 	std::unique_ptr<rai::block> forked_block (MDB_txn *, rai::block const &);
 	rai::block_hash latest (MDB_txn *, rai::account const &);

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1232,9 +1232,9 @@ public:
 							rai::transaction transaction (this_l->wallet->node.store.environment, nullptr, true);
 							this_l->wallet->node.active.start (transaction, block_l, [this_l, account, hash](std::shared_ptr<rai::block> winner_l, bool confirmed) {
 								// If there were any forks for this account they've been rolled back and we can receive anything remaining from this account
-								if (confirmed && winner_l->hash () == hash)
+								if (confirmed && this_l->wallet->node.ledger.block_exists (winner_l->hash ()))
 								{
-									this_l->receive_all (account, hash);
+									this_l->receive_all (account, winner_l->hash ());
 								}
 								else
 								{

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1230,9 +1230,9 @@ public:
 						wallet->node.background ([this_l, account, block_l] {
 							rai::block_hash hash (block_l->hash ());
 							rai::transaction transaction (this_l->wallet->node.store.environment, nullptr, true);
-							this_l->wallet->node.active.start (transaction, block_l, [this_l, account, hash](std::shared_ptr<rai::block> winner_l, bool comfirmed) {
+							this_l->wallet->node.active.start (transaction, block_l, [this_l, account, hash](std::shared_ptr<rai::block> winner_l, bool confirmed) {
 								// If there were any forks for this account they've been rolled back and we can receive anything remaining from this account
-								if (comfirmed && winner_l->hash () == hash)
+								if (confirmed && winner_l->hash () == hash)
 								{
 									this_l->receive_all (account, hash);
 								}

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1228,10 +1228,11 @@ public:
 						auto this_l (shared_from_this ());
 						std::shared_ptr<rai::block> block_l (wallet->node.store.block_get (transaction, info.head));
 						wallet->node.background ([this_l, account, block_l] {
+							rai::block_hash hash (block_l->hash ());
 							rai::transaction transaction (this_l->wallet->node.store.environment, nullptr, true);
-							this_l->wallet->node.active.start (transaction, block_l, [this_l, account](std::shared_ptr<rai::block>, bool) {
+							this_l->wallet->node.active.start (transaction, block_l, [this_l, account, hash](std::shared_ptr<rai::block>, bool) {
 								// If there were any forks for this account they've been rolled back and we can receive anything remaining from this account
-								this_l->receive_all (account);
+								this_l->receive_all (account, hash);
 							});
 							this_l->wallet->node.network.broadcast_confirm_req (block_l);
 						});
@@ -1246,16 +1247,16 @@ public:
 		}
 		BOOST_LOG (wallet->node.log) << "Pending block search phase complete";
 	}
-	void receive_all (rai::account const & account_a)
+	void receive_all (rai::account const & account_a, rai::block_hash const & head_a)
 	{
-		BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Account %1% confirmed, receiving all blocks") % account_a.to_account ());
+		BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Account %1% confirmed, receiving all blocks before %2%") % account_a.to_account () % head_a.to_string ());
 		rai::transaction transaction (wallet->node.store.environment, nullptr, false);
 		auto representative (wallet->store.representative (transaction));
 		for (auto i (wallet->node.store.pending_begin (transaction)), n (wallet->node.store.pending_end ()); i != n; ++i)
 		{
 			rai::pending_key key (i->first);
 			rai::pending_info pending (i->second);
-			if (pending.source == account_a)
+			if (pending.source == account_a && !wallet->node.ledger.is_successor (transaction, head_a, key.hash))
 			{
 				if (wallet->store.exists (transaction, key.account))
 				{


### PR DESCRIPTION
- check minimum confirmation threshold
- check winner to be required account head
- don't receive possible successors of confirmed account head