### PR TITLE
Make elections when bootstrapping more resilient

### DIFF
--- a/rai/core_test/peer_container.cpp
+++ b/rai/core_test/peer_container.cpp
@@ -133,10 +133,12 @@ TEST (peer_container, rep_weight)
 	peers.insert (endpoint2, rai::protocol_version);
 	peers.insert (endpoint0, rai::protocol_version);
 	peers.insert (endpoint1, rai::protocol_version);
-	peers.rep_response (endpoint0, amount);
+	rai::keypair keypair;
+	peers.rep_response (endpoint0, keypair.pub, amount);
 	auto reps (peers.representatives (1));
 	ASSERT_EQ (1, reps.size ());
 	ASSERT_EQ (100, reps[0].rep_weight.number ());
+	ASSERT_EQ (keypair.pub, reps[0].probable_rep_account);
 	ASSERT_EQ (endpoint0, reps[0].endpoint);
 }
 

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1042,8 +1042,11 @@ void rai::bootstrap_attempt::process_fork (MDB_txn * transaction_a, std::shared_
 				BOOST_LOG (node->log) << boost::str (boost::format ("Resolving fork between our block: %1% and block %2% both with root %3%") % ledger_block->hash ().to_string () % block_a->hash ().to_string () % block_a->root ().to_string ());
 				forks_in_progress.insert (root);
 				forks_attempted.insert (root);
+				std::vector<std::shared_ptr<rai::block>> block_options;
+				block_options.push_back (ledger_block);
+				block_options.push_back (block_a);
 				std::weak_ptr<rai::bootstrap_attempt> this_w (shared_from_this ());
-				node->active.start (transaction_a, ledger_block, [this_w, root](std::shared_ptr<rai::block>, bool resolved) {
+				node->active.start (transaction_a, block_options, [this_w, root](std::shared_ptr<rai::block>, bool resolved) {
 					if (auto this_l = this_w.lock ())
 					{
 						if (resolved)

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1042,11 +1042,8 @@ void rai::bootstrap_attempt::process_fork (MDB_txn * transaction_a, std::shared_
 				BOOST_LOG (node->log) << boost::str (boost::format ("Resolving fork between our block: %1% and block %2% both with root %3%") % ledger_block->hash ().to_string () % block_a->hash ().to_string () % block_a->root ().to_string ());
 				forks_in_progress.insert (root);
 				forks_attempted.insert (root);
-				std::vector<std::shared_ptr<rai::block>> block_options;
-				block_options.push_back (ledger_block);
-				block_options.push_back (block_a);
 				std::weak_ptr<rai::bootstrap_attempt> this_w (shared_from_this ());
-				node->active.start (transaction_a, block_options, true, [this_w, root](std::shared_ptr<rai::block>, bool resolved) {
+				node->active.start (transaction_a, std::make_pair (ledger_block, block_a), [this_w, root](std::shared_ptr<rai::block>, bool resolved) {
 					if (auto this_l = this_w.lock ())
 					{
 						if (resolved)

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1046,7 +1046,7 @@ void rai::bootstrap_attempt::process_fork (MDB_txn * transaction_a, std::shared_
 				block_options.push_back (ledger_block);
 				block_options.push_back (block_a);
 				std::weak_ptr<rai::bootstrap_attempt> this_w (shared_from_this ());
-				node->active.start (transaction_a, block_options, [this_w, root](std::shared_ptr<rai::block>, bool resolved) {
+				node->active.start (transaction_a, block_options, true, [this_w, root](std::shared_ptr<rai::block>, bool resolved) {
 					if (auto this_l = this_w.lock ())
 					{
 						if (resolved)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3200,10 +3200,10 @@ bool rai::active_transactions::start (MDB_txn * transaction_a, std::shared_ptr<r
 {
 	std::vector<std::shared_ptr<rai::block>> blocks;
 	blocks.push_back (block_a);
-	return start (transaction_a, blocks, confirmation_action_a);
+	return start (transaction_a, blocks, false, confirmation_action_a);
 }
 
-bool rai::active_transactions::start (MDB_txn * transaction_a, std::vector<std::shared_ptr<rai::block>> & blocks_a, std::function<void(std::shared_ptr<rai::block>, bool)> const & confirmation_action_a)
+bool rai::active_transactions::start (MDB_txn * transaction_a, std::vector<std::shared_ptr<rai::block>> & blocks_a, bool confirm_req, std::function<void(std::shared_ptr<rai::block>, bool)> const & confirmation_action_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
 	auto primary_block (blocks_a[0]);
@@ -3213,7 +3213,7 @@ bool rai::active_transactions::start (MDB_txn * transaction_a, std::vector<std::
 	{
 		auto election (std::make_shared<rai::election> (transaction_a, node, primary_block, confirmation_action_a));
 		std::vector<std::shared_ptr<rai::block>> confirm_req_options;
-		if (blocks_a.size () > 1)
+		if (confirm_req)
 		{
 			confirm_req_options = blocks_a;
 		}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3175,7 +3175,8 @@ void rai::active_transactions::announce_votes ()
 							}
 						}
 					}
-					node.network.broadcast_confirm_req_base (i->confirm_req_options.first, reps, 0);
+					// broadcast_confirm_req_base modifies reps, so we clone it once to avoid aliasing
+					node.network.broadcast_confirm_req_base (i->confirm_req_options.first, std::make_shared<std::vector<rai::peer_information>> (*reps), 0);
 					node.network.broadcast_confirm_req_base (i->confirm_req_options.second, reps, 0);
 				}
 			}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2672,10 +2672,10 @@ std::vector<rai::peer_information> rai::peer_container::purge_list (std::chrono:
 std::vector<rai::endpoint> rai::peer_container::rep_crawl ()
 {
 	std::vector<rai::endpoint> result;
-	result.reserve (40);
+	result.reserve (10);
 	std::lock_guard<std::mutex> lock (mutex);
 	auto count (0);
-	for (auto i (peers.get<5> ().begin ()), n (peers.get<5> ().end ()); i != n && count < 40; ++i, ++count)
+	for (auto i (peers.get<5> ().begin ()), n (peers.get<5> ().end ()); i != n && count < 10; ++i, ++count)
 	{
 		result.push_back (i->endpoint);
 	};

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3155,7 +3155,7 @@ void rai::active_transactions::announce_votes ()
 							{
 								if (node.config.logging.vote_logging ())
 								{
-									BOOST_LOG (node.log) << rep_acct.to_account () << " did not respond to confirm_req, retrying";
+									BOOST_LOG (node.log) << "Representative did not respond to confirm_req, retrying: " << rep_acct.to_account ();
 								}
 								node.network.send_confirm_req (rep.endpoint, block);
 							}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3120,8 +3120,7 @@ void rai::active_transactions::announce_votes ()
 		{
 			auto election_l (i->election);
 			node.background ([election_l]() { election_l->broadcast_winner (); });
-			unsigned announcements;
-			if (rai::rai_network == rai::rai_networks::rai_test_network && i->announcements >= contiguous_announcements - 1)
+			if (i->announcements >= contiguous_announcements - 1)
 			{
 				// These blocks have reached the confirmation interval for forks
 				i->election->confirm_cutoff (transaction);
@@ -3135,6 +3134,7 @@ void rai::active_transactions::announce_votes ()
 			}
 			else
 			{
+				unsigned announcements;
 				roots.modify (i, [&announcements](rai::conflict_info & info_a) {
 					announcements = ++info_a.announcements;
 				});

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3149,14 +3149,16 @@ void rai::active_transactions::announce_votes ()
 					for (auto rep : node.peers.representatives (10))
 					{
 						auto & rep_votes (i->election->votes.rep_votes);
-						if (rep_votes.find (rep.probable_rep_account) == rep_votes.end ())
+						auto rep_acct (rep.probable_rep_account);
+						if (rep_votes.find (rep_acct) == rep_votes.end ())
 						{
 							for (auto & block : i->confirm_req_options)
 							{
 								auto endpoint (rep.endpoint);
 								std::weak_ptr<rai::node> node_w (node.shared ());
-								node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (n * 100), [node_w, endpoint, block]() {
+								node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (n * 100), [node_w, endpoint, block, rep_acct]() {
 									if (auto node_l = node_w.lock ()) {
+										BOOST_LOG (node_l->log) << rep_acct.to_account () << " did not respond to confirm_req, retrying";
 										node_l->network.send_confirm_req (endpoint, block);
 									}
 								});

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3146,14 +3146,14 @@ void rai::active_transactions::announce_votes ()
 				else if (i->confirm_req_options.second != nullptr)
 				{
 					auto reps (std::make_shared<std::vector<rai::peer_information>> (node.peers.representatives (std::numeric_limits<size_t>::max ())));
-					
+
 					for (auto j (reps->begin ()), m (reps->end ()); j != m; ++j)
 					{
 						auto & rep_votes (i->election->votes.rep_votes);
 						auto rep_acct (j->probable_rep_account);
 						if (rep_votes.find (rep_acct) != rep_votes.end ())
 						{
-							std::swap (j, m);
+							std::swap (*j, reps->back ());
 							reps->pop_back ();
 							m = reps->end ();
 						}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3157,7 +3157,8 @@ void rai::active_transactions::announce_votes ()
 								auto endpoint (rep.endpoint);
 								std::weak_ptr<rai::node> node_w (node.shared ());
 								node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (n * 100), [node_w, endpoint, block, rep_acct]() {
-									if (auto node_l = node_w.lock ()) {
+									if (auto node_l = node_w.lock ())
+									{
 										BOOST_LOG (node_l->log) << rep_acct.to_account () << " did not respond to confirm_req, retrying";
 										node_l->network.send_confirm_req (endpoint, block);
 									}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2046,7 +2046,7 @@ void rai::node::ongoing_rep_crawl ()
 	if (network.on)
 	{
 		std::weak_ptr<rai::node> node_w (shared_from_this ());
-		alarm.add (now + period, [node_w]() {
+		alarm.add (now + std::chrono::seconds (4), [node_w]() {
 			if (auto node_l = node_w.lock ())
 			{
 				node_l->ongoing_rep_crawl ();
@@ -2654,10 +2654,10 @@ std::vector<rai::peer_information> rai::peer_container::purge_list (std::chrono:
 std::vector<rai::endpoint> rai::peer_container::rep_crawl ()
 {
 	std::vector<rai::endpoint> result;
-	result.reserve (8);
+	result.reserve (40);
 	std::lock_guard<std::mutex> lock (mutex);
 	auto count (0);
-	for (auto i (peers.get<5> ().begin ()), n (peers.get<5> ().end ()); i != n && count < 8; ++i, ++count)
+	for (auto i (peers.get<5> ().begin ()), n (peers.get<5> ().end ()); i != n && count < 40; ++i, ++count)
 	{
 		result.push_back (i->endpoint);
 	};

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -86,10 +86,10 @@ public:
 	// Start an election for a block
 	// Call action with confirmed block, may be different than what we started with
 	bool start (MDB_txn *, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
-	// Also supply alternatives to block, to confirm_req reps with
+	// Also supply alternatives to block, to confirm_req reps with if the boolean argument is true
 	// Should only be used for old elections
 	// The first block should be the one in the ledger
-	bool start (MDB_txn *, std::vector<std::shared_ptr<rai::block>> &, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
+	bool start (MDB_txn *, std::vector<std::shared_ptr<rai::block>> &, bool, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
 	// If this returns true, the vote is a replay
 	// If this returns false, the vote may or may not be a replay
 	bool vote (std::shared_ptr<rai::vote>);

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -75,6 +75,7 @@ public:
 	std::shared_ptr<rai::election> election;
 	// Number of announcements in a row for this fork
 	unsigned announcements;
+	std::vector<std::shared_ptr<rai::block>> confirm_req_options;
 };
 // Core class for determining consensus
 // Holds all active blocks i.e. recently added blocks that need confirmation
@@ -85,6 +86,10 @@ public:
 	// Start an election for a block
 	// Call action with confirmed block, may be different than what we started with
 	bool start (MDB_txn *, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
+	// Also supply alternatives to block, to confirm_req reps with
+	// Should only be used for old elections
+	// The first block should be the one in the ledger
+	bool start (MDB_txn *, std::vector<std::shared_ptr<rai::block>> &, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
 	// If this returns true, the vote is a replay
 	// If this returns false, the vote may or may not be a replay
 	bool vote (std::shared_ptr<rai::vote>);
@@ -166,6 +171,7 @@ public:
 	std::chrono::steady_clock::time_point last_rep_request;
 	std::chrono::steady_clock::time_point last_rep_response;
 	rai::amount rep_weight;
+	rai::account probable_rep_account;
 	unsigned network_version;
 };
 class peer_attempt
@@ -200,7 +206,7 @@ public:
 	// Purge any peer where last_contact < time_point and return what was left
 	std::vector<rai::peer_information> purge_list (std::chrono::steady_clock::time_point const &);
 	std::vector<rai::endpoint> rep_crawl ();
-	bool rep_response (rai::endpoint const &, rai::amount const &);
+	bool rep_response (rai::endpoint const &, rai::account const &, rai::amount const &);
 	void rep_request (rai::endpoint const &);
 	// Should we reach out to this endpoint with a keepalive message
 	bool reachout (rai::endpoint const &);

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -75,7 +75,7 @@ public:
 	std::shared_ptr<rai::election> election;
 	// Number of announcements in a row for this fork
 	unsigned announcements;
-	std::vector<std::shared_ptr<rai::block>> confirm_req_options;
+	std::pair<std::shared_ptr<rai::block>, std::shared_ptr<rai::block>> confirm_req_options;
 };
 // Core class for determining consensus
 // Holds all active blocks i.e. recently added blocks that need confirmation
@@ -89,7 +89,7 @@ public:
 	// Also supply alternatives to block, to confirm_req reps with if the boolean argument is true
 	// Should only be used for old elections
 	// The first block should be the one in the ledger
-	bool start (MDB_txn *, std::vector<std::shared_ptr<rai::block>> &, bool, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
+	bool start (MDB_txn *, std::pair<std::shared_ptr<rai::block>, std::shared_ptr<rai::block>>, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
 	// If this returns true, the vote is a replay
 	// If this returns false, the vote may or may not be a replay
 	bool vote (std::shared_ptr<rai::vote>);
@@ -354,6 +354,7 @@ public:
 	void merge_peers (std::array<rai::endpoint, 8> const &);
 	void send_keepalive (rai::endpoint const &);
 	void broadcast_confirm_req (std::shared_ptr<rai::block>);
+	void broadcast_confirm_req_base (std::shared_ptr<rai::block>, std::shared_ptr<std::vector<rai::peer_information>>, unsigned);
 	void send_confirm_req (rai::endpoint const &, std::shared_ptr<rai::block>);
 	void send_buffer (uint8_t const *, size_t, rai::endpoint const &, std::function<void(boost::system::error_code const &, size_t)>);
 	rai::endpoint endpoint ();


### PR DESCRIPTION
This does a two things for elections while bootstrapping:
- Space out the initial `confirm_req`s to reduce packet loss
- Retry `confirm_req`s for big reps if we don't get a response

This also makes rep_crawler more aggressive, so that we have more reps to `confirm_req`.