### PR TITLE
Allow zero balance in block_create for state block sends

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1238,7 +1238,7 @@ void rai::rpc_handler::block_create ()
 			}
 			if (type == "state")
 			{
-				if (previous_text.is_initialized () && !representative.is_zero () && !balance.is_zero () && (!link.is_zero () || link_text.is_initialized ()))
+				if (previous_text.is_initialized () && !representative.is_zero () && (!link.is_zero () || link_text.is_initialized ()))
 				{
 					if (work == 0)
 					{


### PR DESCRIPTION
To be able to send it all.