### PR TITLE
Fixed 'account' field for state send subtype in 'account_history' RPC call

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1731,7 +1731,7 @@ public:
 			{
 				tree.put ("type", "send");
 			}
-			tree.put ("account", block_a.hashables.account.to_account ());
+			tree.put ("account", block_a.hashables.link.to_account ());
 			tree.put ("amount", (previous_balance - balance).convert_to<std::string> ());
 		}
 		else


### PR DESCRIPTION
Resolves issue #818