### PR TITLE
Convert dynamic casts to static casts

### DIFF
--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -2,6 +2,17 @@
 
 #include <boost/endian/conversion.hpp>
 
+/** Compare blocks, first by type, then content. This is an optimization over dynamic_cast, which is very slow on some platforms. */
+namespace
+{
+template <typename T>
+bool blocks_equal (T const & first, rai::block const & second)
+{
+	static_assert (std::is_base_of<rai::block, T>::value, "Input parameter is not a block type");
+	return (first.type () == second.type ()) && (static_cast<T const &> (second)) == first;
+}
+}
+
 std::string rai::to_string_hex (uint64_t value_a)
 {
 	std::stringstream stream;
@@ -263,13 +274,7 @@ hashables (error_a, tree_a)
 
 bool rai::send_block::operator== (rai::block const & other_a) const
 {
-	auto other_l (dynamic_cast<rai::send_block const *> (&other_a));
-	auto result (other_l != nullptr);
-	if (result)
-	{
-		result = *this == *other_l;
-	}
-	return result;
+	return blocks_equal (*this, other_a);
 }
 
 bool rai::send_block::valid_predecessor (rai::block const & block_a) const
@@ -547,13 +552,7 @@ rai::block_type rai::open_block::type () const
 
 bool rai::open_block::operator== (rai::block const & other_a) const
 {
-	auto other_l (dynamic_cast<rai::open_block const *> (&other_a));
-	auto result (other_l != nullptr);
-	if (result)
-	{
-		result = *this == *other_l;
-	}
-	return result;
+	return blocks_equal (*this, other_a);
 }
 
 bool rai::open_block::operator== (rai::open_block const & other_a) const
@@ -776,13 +775,7 @@ rai::block_type rai::change_block::type () const
 
 bool rai::change_block::operator== (rai::block const & other_a) const
 {
-	auto other_l (dynamic_cast<rai::change_block const *> (&other_a));
-	auto result (other_l != nullptr);
-	if (result)
-	{
-		result = *this == *other_l;
-	}
-	return result;
+	return blocks_equal (*this, other_a);
 }
 
 bool rai::change_block::operator== (rai::change_block const & other_a) const
@@ -1094,13 +1087,7 @@ rai::block_type rai::state_block::type () const
 
 bool rai::state_block::operator== (rai::block const & other_a) const
 {
-	auto other_l (dynamic_cast<rai::state_block const *> (&other_a));
-	auto result (other_l != nullptr);
-	if (result)
-	{
-		result = *this == *other_l;
-	}
-	return result;
+	return blocks_equal (*this, other_a);
 }
 
 bool rai::state_block::operator== (rai::state_block const & other_a) const
@@ -1417,13 +1404,7 @@ void rai::receive_block::block_work_set (uint64_t work_a)
 
 bool rai::receive_block::operator== (rai::block const & other_a) const
 {
-	auto other_l (dynamic_cast<rai::receive_block const *> (&other_a));
-	auto result (other_l != nullptr);
-	if (result)
-	{
-		result = *this == *other_l;
-	}
-	return result;
+	return blocks_equal (*this, other_a);
 }
 
 bool rai::receive_block::valid_predecessor (rai::block const & block_a) const


### PR DESCRIPTION
dynamic_cast's as used in block comparisons show up in the profiler in a significant way, and it's probably even worse on msvc (which lowers to a mess of string comparisons)

This converts the dyncasts to type()-check + static_cast, which doesn't show up in the profiler at all.

Dynamic casts are used elsewhere too, but in less perf' critical paths, so they can be dealt with later.