### PR TITLE
Removing tx dependency

### DIFF
--- a/rai/core_test/conflicts.cpp
+++ b/rai/core_test/conflicts.cpp
@@ -11,10 +11,7 @@ TEST (conflicts, start_stop)
 	ASSERT_EQ (rai::process_result::progress, node1.process (*send1).code);
 	ASSERT_EQ (0, node1.active.roots.size ());
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	ASSERT_EQ (1, node1.active.roots.size ());
 	auto root1 (send1->root ());
 	auto existing1 (node1.active.roots.find (root1));
@@ -33,16 +30,10 @@ TEST (conflicts, add_existing)
 	auto send1 (std::make_shared<rai::send_block> (genesis.hash (), key1.pub, 0, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
 	ASSERT_EQ (rai::process_result::progress, node1.process (*send1).code);
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	rai::keypair key2;
 	auto send2 (std::make_shared<rai::send_block> (genesis.hash (), key2.pub, 0, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send2);
-	}
+	node1.active.start (send2);
 	ASSERT_EQ (1, node1.active.roots.size ());
 	auto vote1 (std::make_shared<rai::vote> (key2.pub, key2.prv, 0, send2));
 	node1.active.vote (vote1);
@@ -62,17 +53,11 @@ TEST (conflicts, add_two)
 	auto send1 (std::make_shared<rai::send_block> (genesis.hash (), key1.pub, 0, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
 	ASSERT_EQ (rai::process_result::progress, node1.process (*send1).code);
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	rai::keypair key2;
 	auto send2 (std::make_shared<rai::send_block> (send1->hash (), key2.pub, 0, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
 	ASSERT_EQ (rai::process_result::progress, node1.process (*send2).code);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send2);
-	}
+	node1.active.start (send2);
 	ASSERT_EQ (2, node1.active.roots.size ());
 }
 

--- a/rai/core_test/ledger.cpp
+++ b/rai/core_test/ledger.cpp
@@ -766,10 +766,7 @@ TEST (votes, check_signature)
 		ASSERT_EQ (rai::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	auto votes1 (node1.active.roots.find (send1->root ())->election);
 	ASSERT_EQ (1, votes1->votes.rep_votes.size ());
 	auto vote1 (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 1, send1));
@@ -792,10 +789,7 @@ TEST (votes, add_one)
 		ASSERT_EQ (rai::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	auto votes1 (node1.active.roots.find (send1->root ())->election);
 	ASSERT_EQ (1, votes1->votes.rep_votes.size ());
 	auto vote1 (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 1, send1));
@@ -824,10 +818,7 @@ TEST (votes, add_two)
 		ASSERT_EQ (rai::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	auto votes1 (node1.active.roots.find (send1->root ())->election);
 	auto vote1 (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 1, send1));
 	votes1->vote (vote1);
@@ -858,10 +849,7 @@ TEST (votes, add_existing)
 		ASSERT_EQ (rai::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	auto votes1 (node1.active.roots.find (send1->root ())->election);
 	auto vote1 (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 1, send1));
 	votes1->vote (vote1);
@@ -898,10 +886,7 @@ TEST (votes, add_old)
 		ASSERT_EQ (rai::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	auto votes1 (node1.active.roots.find (send1->root ())->election);
 	auto vote1 (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 2, send1));
 	node1.vote_processor.vote (vote1, rai::endpoint ());
@@ -933,11 +918,8 @@ TEST (votes, add_old_different_account)
 		ASSERT_EQ (rai::process_result::progress, node1.ledger.process (transaction, *send2).code);
 	}
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-		node1.active.start (transaction, send2);
-	}
+	node1.active.start (send1);
+	node1.active.start (send2);
 	auto votes1 (node1.active.roots.find (send1->root ())->election);
 	auto votes2 (node1.active.roots.find (send2->root ())->election);
 	ASSERT_EQ (1, votes1->votes.rep_votes.size ());
@@ -978,10 +960,7 @@ TEST (votes, add_cooldown)
 		ASSERT_EQ (rai::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, send1);
-	}
+	node1.active.start (send1);
 	auto votes1 (node1.active.roots.find (send1->root ())->election);
 	auto vote1 (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 1, send1));
 	node1.vote_processor.vote (vote1, rai::endpoint ());

--- a/rai/core_test/network.cpp
+++ b/rai/core_test/network.cpp
@@ -266,10 +266,7 @@ TEST (receivable_processor, confirm_insufficient_pos)
 	node1.generate_work (*block1);
 	ASSERT_EQ (rai::process_result::progress, node1.process (*block1).code);
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, block1);
-	}
+	node1.active.start (block1);
 	rai::keypair key1;
 	auto vote (std::make_shared<rai::vote> (key1.pub, key1.prv, 0, block1));
 	rai::confirm_ack con1 (vote);
@@ -285,10 +282,7 @@ TEST (receivable_processor, confirm_sufficient_pos)
 	node1.generate_work (*block1);
 	ASSERT_EQ (rai::process_result::progress, node1.process (*block1).code);
 	auto node_l (system.nodes[0]);
-	{
-		rai::transaction transaction (node1.store.environment, nullptr, true);
-		node1.active.start (transaction, block1);
-	}
+	node1.active.start (block1);
 	auto vote (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 0, block1));
 	rai::confirm_ack con1 (vote);
 	node1.process_message (con1, node1.network.endpoint ());

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -891,7 +891,7 @@ void rai::bootstrap_attempt::process_fork (MDB_txn * transaction_a, std::shared_
 		if (ledger_block)
 		{
 			std::weak_ptr<rai::bootstrap_attempt> this_w (shared_from_this ());
-			if (!node->active.start (transaction_a, std::make_pair (ledger_block, block_a), [this_w, root](std::shared_ptr<rai::block>) {
+			if (!node->active.start (std::make_pair (ledger_block, block_a), [this_w, root](std::shared_ptr<rai::block>) {
 				    if (auto this_l = this_w.lock ())
 				    {
 						rai::transaction transaction (this_l->node->store.environment, nullptr, false);

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -48,7 +48,7 @@ class election : public std::enable_shared_from_this<rai::election>
 	void confirm_once (MDB_txn *);
 
 public:
-	election (MDB_txn *, rai::node &, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>)> const &);
+	election (rai::node &, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>)> const &);
 	bool vote (std::shared_ptr<rai::vote>);
 	// Check if we have vote quorum
 	bool have_quorum (rai::tally_t const &);
@@ -83,11 +83,11 @@ public:
 	active_transactions (rai::node &);
 	// Start an election for a block
 	// Call action with confirmed block, may be different than what we started with
-	bool start (MDB_txn *, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>)> const & = [](std::shared_ptr<rai::block>) {});
+	bool start (std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>)> const & = [](std::shared_ptr<rai::block>) {});
 	// Also supply alternatives to block, to confirm_req reps with if the boolean argument is true
 	// Should only be used for old elections
 	// The first block should be the one in the ledger
-	bool start (MDB_txn *, std::pair<std::shared_ptr<rai::block>, std::shared_ptr<rai::block>>, std::function<void(std::shared_ptr<rai::block>)> const & = [](std::shared_ptr<rai::block>) {});
+	bool start (std::pair<std::shared_ptr<rai::block>, std::shared_ptr<rai::block>>, std::function<void(std::shared_ptr<rai::block>)> const & = [](std::shared_ptr<rai::block>) {});
 	// If this returns true, the vote is a replay
 	// If this returns false, the vote may or may not be a replay
 	bool vote (std::shared_ptr<rai::vote>);

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1228,8 +1228,7 @@ public:
 						auto this_l (shared_from_this ());
 						std::shared_ptr<rai::block> block_l (wallet->node.store.block_get (transaction, info.head));
 						wallet->node.background ([this_l, account, block_l] {
-							rai::transaction transaction (this_l->wallet->node.store.environment, nullptr, true);
-							this_l->wallet->node.active.start (transaction, block_l, [this_l, account](std::shared_ptr<rai::block>) {
+							this_l->wallet->node.active.start (block_l, [this_l, account](std::shared_ptr<rai::block>) {
 								// If there were any forks for this account they've been rolled back and we can receive anything remaining from this account
 								this_l->receive_all (account);
 							});


### PR DESCRIPTION
Rep votes don't need to be computed during election construction since they're always computed before broadcasting the winner.

Removing unused transaction parameters in election and active_transactions.