### PR TITLE
optional use_peers param to generate_work rpc

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -4228,23 +4228,40 @@ void rai::rpc_handler::work_generate ()
 	if (rpc.config.enable_control)
 	{
 		std::string hash_text (request.get<std::string> ("hash"));
+	    bool use_peers (request.get_optional<bool> ("use_peers") == true);
 		rai::block_hash hash;
 		auto error (hash.decode_hex (hash_text));
 		if (!error)
 		{
 			auto rpc_l (shared_from_this ());
-			node.work.generate (hash, [rpc_l](boost::optional<uint64_t> const & work_a) {
-				if (work_a)
-				{
-					boost::property_tree::ptree response_l;
-					response_l.put ("work", rai::to_string_hex (work_a.value ()));
-					rpc_l->response (response_l);
-				}
-				else
-				{
-					error_response (rpc_l->response, "Cancelled");
-				}
-			});
+			if (!use_peers) {
+				node.work.generate (hash, [rpc_l](boost::optional<uint64_t> const & work_a) {
+					if (work_a)
+					{
+						boost::property_tree::ptree response_l;
+						response_l.put ("work", rai::to_string_hex (work_a.value ()));
+						rpc_l->response (response_l);
+					}
+					else
+					{
+						error_response (rpc_l->response, "Cancelled");
+					}
+				});
+			} else {
+				node.generate_work (hash, [rpc_l](boost::optional<uint64_t> const & work_a) {
+					if (work_a)
+					{
+						boost::property_tree::ptree response_l;
+						response_l.put ("work", rai::to_string_hex (work_a.value ()));
+						rpc_l->response (response_l);
+					}
+					else
+					{
+						error_response (rpc_l->response, "Cancelled");
+					}
+				});
+			}
+
 		}
 		else
 		{


### PR DESCRIPTION
To make the pregeneration of work using multiple work peers easier I added the use_peers option to generate_work. With this light wallets (for example) can easily switch their node to use the multiple work peers configured in the node instead of having to query each work-node.

I added this as rpc parameter instead of a config option as proposed in #855 to not change the RPC behaviour if the config is changed.

I think this PR is pretty interesting for Canoe and Nanovault which both use work_generate to pregenerate the work and thought about adding multiple work peers. Also the default behaviour (not using work peers with that rpc) was pretty unexpected for multiple people I told about this.