### PR TITLE
Statistics pane under Advanced in Qt wallet

### DIFF
--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -1,7 +1,10 @@
 #include <rai/qt/qt.hpp>
 
+#include <boost/foreach.hpp>
 #include <boost/property_tree/json_parser.hpp>
-
+#include <boost/property_tree/ptree.hpp>
+#include <cmath>
+#include <iomanip>
 #include <sstream>
 
 namespace
@@ -717,6 +720,88 @@ wallet (wallet_a)
 	});
 }
 
+rai_qt::stats_viewer::stats_viewer (rai_qt::wallet & wallet_a) :
+window (new QWidget),
+layout (new QVBoxLayout),
+model (new QStandardItemModel),
+view (new QTableView),
+refresh (new QPushButton ("Refresh")),
+back (new QPushButton ("Back")),
+wallet (wallet_a)
+{
+	model->setHorizontalHeaderItem (0, new QStandardItem ("Last updated"));
+	model->setHorizontalHeaderItem (1, new QStandardItem ("Type"));
+	model->setHorizontalHeaderItem (2, new QStandardItem ("Detail"));
+	model->setHorizontalHeaderItem (3, new QStandardItem ("Direction"));
+	model->setHorizontalHeaderItem (4, new QStandardItem ("Value"));
+	view->setModel (model);
+	view->setEditTriggers (QAbstractItemView::NoEditTriggers);
+	view->verticalHeader ()->hide ();
+	view->horizontalHeader ()->setStretchLastSection (true);
+	layout->setContentsMargins (0, 0, 0, 0);
+	layout->addWidget (view);
+	layout->addWidget (refresh);
+	layout->addWidget (back);
+	window->setLayout (layout);
+
+	QObject::connect (back, &QPushButton::released, [this]() {
+		this->wallet.pop_main_stack ();
+	});
+	QObject::connect (refresh, &QPushButton::released, [this]() {
+		refresh_stats ();
+	});
+
+	refresh_stats ();
+}
+
+void rai_qt::stats_viewer::refresh_stats ()
+{
+	model->removeRows (0, model->rowCount ());
+
+	auto sink = wallet.node.stats.log_sink_json ();
+	wallet.node.stats.log_counters (*sink);
+	auto json = static_cast<boost::property_tree::ptree *> (sink->to_object ());
+	if (json)
+	{
+		// Format the stat data to make totals and values easier to read
+		BOOST_FOREACH (const boost::property_tree::ptree::value_type & child, json->get_child ("entries"))
+		{
+			auto time = child.second.get<std::string> ("time");
+			auto type = child.second.get<std::string> ("type");
+			auto detail = child.second.get<std::string> ("detail");
+			auto dir = child.second.get<std::string> ("dir");
+			auto value = child.second.get<std::string> ("value", "0");
+
+			if (detail == "all")
+			{
+				detail = "total";
+			}
+
+			if (type == "traffic")
+			{
+				const std::vector<std::string> units = { " bytes", " KB", " MB", " GB", " TB", " PB" };
+				double bytes = std::stod (value);
+				auto index = std::min (units.size () - 1, static_cast<size_t> (std::floor (std::log2 (bytes) / 10)));
+				std::string unit = units[index];
+				bytes /= std::pow (1024, index);
+
+				std::stringstream numstream;
+				numstream << std::fixed << std::setprecision (2) << bytes;
+				value = numstream.str () + unit;
+			}
+
+			QList<QStandardItem *> items;
+			items.push_back (new QStandardItem (QString (time.c_str ())));
+			items.push_back (new QStandardItem (QString (type.c_str ())));
+			items.push_back (new QStandardItem (QString (detail.c_str ())));
+			items.push_back (new QStandardItem (QString (dir.c_str ())));
+			items.push_back (new QStandardItem (QString (value.c_str ())));
+
+			model->appendRow (items);
+		}
+	}
+}
+
 rai_qt::status::status (rai_qt::wallet & wallet_a) :
 wallet (wallet_a)
 {
@@ -846,6 +931,7 @@ block_creation (*this),
 block_entry (*this),
 block_viewer (*this),
 account_viewer (*this),
+stats_viewer (*this),
 import (*this),
 application (application_a),
 status (new QLabel),
@@ -908,7 +994,7 @@ active_status (*this)
 	client_layout->setSpacing (0);
 	client_layout->setContentsMargins (0, 0, 0, 0);
 	client_window->setLayout (client_layout);
-	client_window->resize (320, 480);
+	client_window->resize (500, 620);
 	client_window->setStyleSheet ("\
 		QLineEdit { padding: 3px; } \
 	");
@@ -1543,6 +1629,7 @@ create_block (new QPushButton ("Create Block")),
 enter_block (new QPushButton ("Enter Block")),
 block_viewer (new QPushButton ("Block Viewer")),
 account_viewer (new QPushButton ("Account Viewer")),
+stats_viewer (new QPushButton ("Node Statistics")),
 scale_window (new QWidget),
 scale_layout (new QHBoxLayout),
 scale_label (new QLabel ("Scale:")),
@@ -1619,6 +1706,7 @@ wallet (wallet_a)
 	layout->addWidget (enter_block);
 	layout->addWidget (block_viewer);
 	layout->addWidget (account_viewer);
+	layout->addWidget (stats_viewer);
 	layout->addWidget (scale_window);
 	layout->addStretch ();
 	layout->addWidget (back);
@@ -1701,6 +1789,11 @@ wallet (wallet_a)
 	QObject::connect (account_viewer, &QPushButton::released, [this]() {
 		this->wallet.push_main_stack (this->wallet.account_viewer.window);
 	});
+	QObject::connect (stats_viewer, &QPushButton::released, [this]() {
+		this->wallet.push_main_stack (this->wallet.stats_viewer.window);
+		this->wallet.stats_viewer.refresh_stats ();
+	});
+
 	bootstrap->setToolTip ("Multi-connection bootstrap to random peers");
 	search_for_receivables->setToolTip ("Search for pending blocks");
 	create_block->setToolTip ("Create block in JSON format");
@@ -1742,6 +1835,11 @@ void rai_qt::advanced_actions::refresh_ledger ()
 		items.push_back (new QStandardItem (QString (block_hash.c_str ())));
 		ledger_model->appendRow (items);
 	}
+}
+
+void rai_qt::advanced_actions::refresh_stats ()
+{
+	wallet.stats_viewer.refresh_stats ();
 }
 
 rai_qt::block_entry::block_entry (rai_qt::wallet & wallet_a) :

--- a/rai/qt/qt.hpp
+++ b/rai/qt/qt.hpp
@@ -61,6 +61,7 @@ public:
 	QPushButton * enter_block;
 	QPushButton * block_viewer;
 	QPushButton * account_viewer;
+	QPushButton * stats_viewer;
 	QWidget * scale_window;
 	QHBoxLayout * scale_layout;
 	QLabel * scale_label;
@@ -92,6 +93,7 @@ public:
 private:
 	void refresh_ledger ();
 	void refresh_peers ();
+	void refresh_stats ();
 };
 class block_entry
 {
@@ -255,6 +257,19 @@ public:
 	rai::account account;
 	rai_qt::wallet & wallet;
 };
+class stats_viewer
+{
+public:
+	stats_viewer (rai_qt::wallet &);
+	QWidget * window;
+	QVBoxLayout * layout;
+	QPushButton * refresh;
+	QStandardItemModel * model;
+	QTableView * view;
+	QPushButton * back;
+	rai_qt::wallet & wallet;
+	void refresh_stats ();
+};
 enum class status_types
 {
 	not_a_status,
@@ -302,6 +317,7 @@ public:
 	rai_qt::block_entry block_entry;
 	rai_qt::block_viewer block_viewer;
 	rai_qt::account_viewer account_viewer;
+	rai_qt::stats_viewer stats_viewer;
 	rai_qt::import import;
 
 	QApplication & application;


### PR DESCRIPTION
Since we have stats we might as well show them (not everyone runs with RPC on). 

meltingice on Discord and possibly others are looking into graphing these stats on their web frontends, so I won't bother doing any Qt graphs for this.

<img width="519" alt="stats-qt" src="https://user-images.githubusercontent.com/34946442/39951494-db5db308-558a-11e8-844a-d7e0996735cd.png">
