### PR TITLE
Simplify and improve performance of search_pending.

### DIFF
--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1213,9 +1213,7 @@ bool rai::wallet::search_pending ()
 						rai::account_info info;
 						auto error (node.store.account_get (transaction, pending.source, info));
 						assert (!error);
-						std::shared_ptr<rai::block> block_l (node.store.block_get (transaction, info.head));
-						node.active.start (block_l);
-						node.network.broadcast_confirm_req (block_l);
+						node.block_confirm (node.store.block_get (transaction, info.head));
 					}
 				}
 			}


### PR DESCRIPTION
Invert loop iteration since the number of accounts in the wallet is likely smaller than the number of pending entries.
Automatic block confirmation already checks if the destination is in a local wallet so we don't need to re-implement this.
Re-searching the pending table for source blocks for the confirmed account can be better implemented in the future with an account dirty flag or queued block insertion.
Since we don't need a callback after confirmation we don't need the search code in its own class.