### PR TITLE
Change frontier_count to count accounts table vs frontiers table

### DIFF
--- a/rai/blockstore.cpp
+++ b/rai/blockstore.cpp
@@ -896,7 +896,7 @@ void rai::block_store::frontier_del (MDB_txn * transaction_a, rai::block_hash co
 size_t rai::block_store::frontier_count (MDB_txn * transaction_a)
 {
 	MDB_stat frontier_stats;
-	auto status (mdb_stat (transaction_a, frontiers, &frontier_stats));
+	auto status (mdb_stat (transaction_a, accounts, &frontier_stats));
 	assert (status == 0);
 	auto result (frontier_stats.ms_entries);
 	return result;

--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -528,7 +528,7 @@ TEST (node_config, serialization)
 	config1.bootstrap_fraction_numerator = 10;
 	config1.receive_minimum = 10;
 	config1.online_weight_minimum = 10;
-	config1.online_weight_quorom = 10;
+	config1.online_weight_quorum = 10;
 	config1.password_fanout = 10;
 	config1.enable_voting = false;
 	config1.callback_address = "test";
@@ -547,7 +547,7 @@ TEST (node_config, serialization)
 	ASSERT_NE (config2.peering_port, config1.peering_port);
 	ASSERT_NE (config2.logging.node_lifetime_tracing_value, config1.logging.node_lifetime_tracing_value);
 	ASSERT_NE (config2.online_weight_minimum, config1.online_weight_minimum);
-	ASSERT_NE (config2.online_weight_quorom, config1.online_weight_quorom);
+	ASSERT_NE (config2.online_weight_quorum, config1.online_weight_quorum);
 	ASSERT_NE (config2.password_fanout, config1.password_fanout);
 	ASSERT_NE (config2.enable_voting, config1.enable_voting);
 	ASSERT_NE (config2.callback_address, config1.callback_address);
@@ -564,7 +564,7 @@ TEST (node_config, serialization)
 	ASSERT_EQ (config2.peering_port, config1.peering_port);
 	ASSERT_EQ (config2.logging.node_lifetime_tracing_value, config1.logging.node_lifetime_tracing_value);
 	ASSERT_EQ (config2.online_weight_minimum, config1.online_weight_minimum);
-	ASSERT_EQ (config2.online_weight_quorom, config1.online_weight_quorom);
+	ASSERT_EQ (config2.online_weight_quorum, config1.online_weight_quorum);
 	ASSERT_EQ (config2.password_fanout, config1.password_fanout);
 	ASSERT_EQ (config2.enable_voting, config1.enable_voting);
 	ASSERT_EQ (config2.callback_address, config1.callback_address);
@@ -1587,7 +1587,7 @@ TEST (node, confirm_quorum)
 	rai::genesis genesis;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.nodes[0]->ledger.state_block_parse_canary = genesis.hash ();
-	// Put greater than online_weight_minimum in pending so quorom can't be reached
+	// Put greater than online_weight_minimum in pending so quorum can't be reached
 	auto send1 (std::make_shared<rai::state_block> (rai::test_genesis_key.pub, genesis.hash (), rai::test_genesis_key.pub, rai::Gxrb_ratio, rai::test_genesis_key.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.nodes[0]->generate_work (genesis.hash ())));
 	{
 		rai::transaction transaction (system.nodes[0]->store.environment, nullptr, true);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -958,12 +958,14 @@ bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptr
 			tree_a.put ("version", "11");
 			result = true;
 		case 11:
-			auto online_weight_quorum_l (tree_a.get<std::string> ("online_weight_quorom"));
-			tree_a.erase ("online_weight_quorom");
-			tree_a.put ("online_weight_quorum", online_weight_quorum_l);
-			tree_a.erase ("version");
-			tree_a.put ("version", "12");
-			result = true;
+			{
+				auto online_weight_quorum_l (tree_a.get<std::string> ("online_weight_quorom"));
+				tree_a.erase ("online_weight_quorom");
+				tree_a.put ("online_weight_quorum", online_weight_quorum_l);
+				tree_a.erase ("version");
+				tree_a.put ("version", "12");
+				result = true;
+			}
 		case 12:
 			break;
 		default:

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -782,7 +782,7 @@ logging (logging_a),
 bootstrap_fraction_numerator (1),
 receive_minimum (rai::xrb_ratio),
 online_weight_minimum (60000 * rai::Gxrb_ratio),
-online_weight_quorom (50),
+online_weight_quorum (50),
 password_fanout (1024),
 io_threads (std::max<unsigned> (4, std::thread::hardware_concurrency ())),
 work_threads (std::max<unsigned> (4, std::thread::hardware_concurrency ())),
@@ -858,7 +858,7 @@ void rai::node_config::serialize_json (boost::property_tree::ptree & tree_a) con
 	}
 	tree_a.add_child ("preconfigured_representatives", preconfigured_representatives_l);
 	tree_a.put ("online_weight_minimum", online_weight_minimum.to_string_dec ());
-	tree_a.put ("online_weight_quorom", std::to_string (online_weight_quorom));
+	tree_a.put ("online_weight_quorum", std::to_string (online_weight_quorum));
 	tree_a.put ("password_fanout", std::to_string (password_fanout));
 	tree_a.put ("io_threads", std::to_string (io_threads));
 	tree_a.put ("work_threads", std::to_string (work_threads));
@@ -952,7 +952,7 @@ bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptr
 			result = true;
 		case 10:
 			tree_a.put ("online_weight_minimum", online_weight_minimum.to_string_dec ());
-			tree_a.put ("online_weight_quorom", std::to_string (online_weight_quorom));
+			tree_a.put ("online_weight_quorum", std::to_string (online_weight_quorum));
 			tree_a.erase ("inactive_supply");
 			tree_a.erase ("version");
 			tree_a.put ("version", "11");
@@ -1025,7 +1025,7 @@ bool rai::node_config::deserialize_json (bool & upgraded_a, boost::property_tree
 			result |= stat_config.deserialize_json (stat_config_l.get ());
 		}
 		auto online_weight_minimum_l (tree_a.get<std::string> ("online_weight_minimum"));
-		auto online_weight_quorom_l (tree_a.get<std::string> ("online_weight_quorom"));
+		auto online_weight_quorum_l (tree_a.get<std::string> ("online_weight_quorum"));
 		auto password_fanout_l (tree_a.get<std::string> ("password_fanout"));
 		auto io_threads_l (tree_a.get<std::string> ("io_threads"));
 		auto work_threads_l (tree_a.get<std::string> ("work_threads"));
@@ -1049,12 +1049,12 @@ bool rai::node_config::deserialize_json (bool & upgraded_a, boost::property_tree
 			bootstrap_connections = std::stoul (bootstrap_connections_l);
 			bootstrap_connections_max = std::stoul (bootstrap_connections_max_l);
 			lmdb_max_dbs = std::stoi (lmdb_max_dbs_l);
-			online_weight_quorom = std::stoul (online_weight_quorom_l);
+			online_weight_quorum = std::stoul (online_weight_quorum_l);
 			result |= peering_port > std::numeric_limits<uint16_t>::max ();
 			result |= logging.deserialize_json (upgraded_a, logging_l);
 			result |= receive_minimum.decode_dec (receive_minimum_l);
 			result |= online_weight_minimum.decode_dec (online_weight_minimum_l);
-			result |= online_weight_quorom > 100;
+			result |= online_weight_quorum > 100;
 			result |= password_fanout < 16;
 			result |= password_fanout > 1024 * 1024;
 			result |= io_threads == 0;
@@ -2407,7 +2407,7 @@ void rai::node::block_confirm (std::shared_ptr<rai::block> block_a)
 
 rai::uint128_t rai::node::delta ()
 {
-	auto result ((online_reps.online_stake () / 100) * config.online_weight_quorom);
+	auto result ((online_reps.online_stake () / 100) * config.online_weight_quorum);
 	return result;
 }
 

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -952,12 +952,19 @@ bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptr
 			result = true;
 		case 10:
 			tree_a.put ("online_weight_minimum", online_weight_minimum.to_string_dec ());
-			tree_a.put ("online_weight_quorum", std::to_string (online_weight_quorum));
+			tree_a.put ("online_weight_quorom", std::to_string (online_weight_quorum));
 			tree_a.erase ("inactive_supply");
 			tree_a.erase ("version");
 			tree_a.put ("version", "11");
 			result = true;
 		case 11:
+			auto online_weight_quorum_l (tree_a.get<std::string> ("online_weight_quorom"));
+			tree_a.erase ("online_weight_quorom");
+			tree_a.put ("online_weight_quorum", online_weight_quorum_l);
+			tree_a.erase ("version");
+			tree_a.put ("version", "12");
+			result = true;
+		case 12:
 			break;
 		default:
 			throw std::runtime_error ("Unknown node_config version");

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -433,7 +433,7 @@ public:
 	unsigned bootstrap_fraction_numerator;
 	rai::amount receive_minimum;
 	rai::amount online_weight_minimum;
-	unsigned online_weight_quorom;
+	unsigned online_weight_quorum;
 	unsigned password_fanout;
 	unsigned io_threads;
 	unsigned work_threads;


### PR DESCRIPTION
When calling the frontier_count RPC, it only counts accounts that have been opened via legacy blocks. This is because the frontiers table doesn't include state blocks (via @PlasmaPower). Changing this RPC call to count the accounts table seems to fix the issue.

This bug was originally discovered via Banano. There the RPC returns "1" because only 1 account (genesis) was created via legacy blocks, which is what originally tipped me off about this issue.

I'm not sure what the future of the frontiers table is like, so I leave that up to the core devs here. This simply fixes the count issue.