### PR TITLE
Fix frontier_count RPC to include state block opened accounts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
 - cmd: >-
     SET GIT_COMMIT=%APPVEYOR_REPO_COMMIT:~0,3%
 
-    cmake -DRAIBLOCKS_GUI=ON -DQt5_DIR=C:\Qt\5.9.4\msvc2015_64\lib\cmake\Qt5 -DRAIBLOCKS_SIMD_OPTIMIZATIONS=TRUE -DBOOST_INCLUDEDIR=C:/Libraries/boost_1_66_0 -DBOOST_LIBRARYDIR=C:/Libraries/boost_1_66_0/lib64-msvc-14.0 -G "Visual Studio 14 2015 Win64" -DIPHLPAPI_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/iphlpapi.lib" -DWINSOCK2_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/WS2_32.lib" -DGIT_COMMIT=%GIT_COMMIT%
+    cmake -DRAIBLOCKS_GUI=ON -DQt5_DIR=C:\Qt\5.9\msvc2015_64\lib\cmake\Qt5 -DRAIBLOCKS_SIMD_OPTIMIZATIONS=TRUE -DBOOST_INCLUDEDIR=C:/Libraries/boost_1_66_0 -DBOOST_LIBRARYDIR=C:/Libraries/boost_1_66_0/lib64-msvc-14.0 -G "Visual Studio 14 2015 Win64" -DIPHLPAPI_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/iphlpapi.lib" -DWINSOCK2_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/WS2_32.lib" -DGIT_COMMIT=%GIT_COMMIT%
 
 - ps: >-
     $size_t=select-string -path ".\bootstrap_weights.cpp" -Pattern "rai_bootstrap_weights_size"| foreach {$_.Line}

--- a/rai/blockstore.cpp
+++ b/rai/blockstore.cpp
@@ -893,7 +893,7 @@ void rai::block_store::frontier_del (MDB_txn * transaction_a, rai::block_hash co
 	assert (status == 0);
 }
 
-size_t rai::block_store::frontier_count (MDB_txn * transaction_a)
+size_t rai::block_store::account_count (MDB_txn * transaction_a)
 {
 	MDB_stat frontier_stats;
 	auto status (mdb_stat (transaction_a, accounts, &frontier_stats));

--- a/rai/blockstore.hpp
+++ b/rai/blockstore.hpp
@@ -65,12 +65,12 @@ public:
 	void frontier_put (MDB_txn *, rai::block_hash const &, rai::account const &);
 	rai::account frontier_get (MDB_txn *, rai::block_hash const &);
 	void frontier_del (MDB_txn *, rai::block_hash const &);
-	size_t frontier_count (MDB_txn *);
 
 	void account_put (MDB_txn *, rai::account const &, rai::account_info const &);
 	bool account_get (MDB_txn *, rai::account const &, rai::account_info &);
 	void account_del (MDB_txn *, rai::account const &);
 	bool account_exists (MDB_txn *, rai::account const &);
+	size_t account_count (MDB_txn *);
 	rai::store_iterator latest_begin (MDB_txn *, rai::account const &);
 	rai::store_iterator latest_begin (MDB_txn *);
 	rai::store_iterator latest_end ();

--- a/rai/core_test/block_store.cpp
+++ b/rai/core_test/block_store.cpp
@@ -549,16 +549,15 @@ TEST (block_store, block_count)
 	ASSERT_EQ (1, store.block_count (rai::transaction (store.environment, nullptr, false)).sum ());
 }
 
-TEST (block_store, frontier_count)
+TEST (block_store, account_count)
 {
 	bool init (false);
 	rai::block_store store (init, rai::unique_path ());
 	ASSERT_TRUE (!init);
-	ASSERT_EQ (0, store.frontier_count (rai::transaction (store.environment, nullptr, false)));
-	rai::block_hash hash (100);
+	ASSERT_EQ (0, store.account_count (rai::transaction (store.environment, nullptr, false)));
 	rai::account account (200);
-	store.frontier_put (rai::transaction (store.environment, nullptr, true), hash, account);
-	ASSERT_EQ (1, store.frontier_count (rai::transaction (store.environment, nullptr, false)));
+	store.account_put (rai::transaction (store.environment, nullptr, true), account, rai::account_info ());
+	ASSERT_EQ (1, store.account_count (rai::transaction (store.environment, nullptr, false)));
 }
 
 TEST (block_store, sequence_increment)

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -1710,6 +1710,24 @@ TEST (rpc, frontier_count)
 	ASSERT_EQ ("1", response1.json.get<std::string> ("count"));
 }
 
+TEST (rpc, account_count)
+{
+	rai::system system (24000, 1);
+	rai::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "account_count");
+	test_response response1 (request1, rpc, system.service);
+	while (response1.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("1", response1.json.get<std::string> ("count"));
+}
+
 TEST (rpc, available_supply)
 {
 	rai::system system (24000, 1);

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1677,10 +1677,10 @@ void rai::rpc_handler::frontiers ()
 	}
 }
 
-void rai::rpc_handler::frontier_count ()
+void rai::rpc_handler::account_count ()
 {
 	rai::transaction transaction (node.store.environment, nullptr, false);
-	auto size (node.store.frontier_count (transaction));
+	auto size (node.store.account_count (transaction));
 	boost::property_tree::ptree response_l;
 	response_l.put ("count", std::to_string (size));
 	response (response_l);
@@ -4625,6 +4625,10 @@ void rai::rpc_handler::process_request ()
 		{
 			account_block_count ();
 		}
+		else if (action == "account_count")
+		{
+			account_count ();
+		}
 		else if (action == "account_create")
 		{
 			account_create ();
@@ -4763,7 +4767,7 @@ void rai::rpc_handler::process_request ()
 		}
 		else if (action == "frontier_count")
 		{
-			frontier_count ();
+			account_count ();
 		}
 		else if (action == "history")
 		{

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -116,6 +116,7 @@ public:
 	void process_request ();
 	void account_balance ();
 	void account_block_count ();
+	void account_count ();
 	void account_create ();
 	void account_get ();
 	void account_history ();
@@ -149,7 +150,6 @@ public:
 	void delegators_count ();
 	void deterministic_key ();
 	void frontiers ();
-	void frontier_count ();
 	void history ();
 	void keepalive ();
 	void key_create ();

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1128,11 +1128,9 @@ rai::block_hash rai::wallet::send_sync (rai::account const & source_a, rai::acco
 
 void rai::wallet::send_async (rai::account const & source_a, rai::account const & account_a, rai::uint128_t const & amount_a, std::function<void(std::shared_ptr<rai::block>)> const & action_a, bool generate_work_a, boost::optional<std::string> id_a)
 {
-	node.background ([this, source_a, account_a, amount_a, action_a, generate_work_a, id_a]() {
-		this->node.wallets.queue_wallet_action (rai::wallets::high_priority, [this, source_a, account_a, amount_a, action_a, generate_work_a, id_a]() {
-			auto block (send_action (source_a, account_a, amount_a, generate_work_a, id_a));
-			action_a (block);
-		});
+	this->node.wallets.queue_wallet_action (rai::wallets::high_priority, [this, source_a, account_a, amount_a, action_a, generate_work_a, id_a]() {
+		auto block (send_action (source_a, account_a, amount_a, generate_work_a, id_a));
+		action_a (block);
 	});
 }
 

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1184,116 +1184,39 @@ void rai::wallet::work_ensure (MDB_txn * transaction_a, rai::account const & acc
 	}
 }
 
-namespace
-{
-class search_action : public std::enable_shared_from_this<search_action>
-{
-public:
-	search_action (std::shared_ptr<rai::wallet> const & wallet_a, MDB_txn * transaction_a) :
-	wallet (wallet_a)
-	{
-		for (auto i (wallet_a->store.begin (transaction_a)), n (wallet_a->store.end ()); i != n; ++i)
-		{
-			// Don't search pending for watch-only accounts
-			if (!rai::wallet_value (i->second).key.is_zero ())
-			{
-				keys.insert (i->first.uint256 ());
-			}
-		}
-	}
-	void run ()
-	{
-		BOOST_LOG (wallet->node.log) << "Beginning pending block search";
-		rai::transaction transaction (wallet->node.store.environment, nullptr, false);
-		std::unordered_set<rai::account> already_searched;
-		for (auto i (wallet->node.store.pending_begin (transaction)), n (wallet->node.store.pending_end ()); i != n; ++i)
-		{
-			rai::pending_key key (i->first);
-			rai::pending_info pending (i->second);
-			auto existing (keys.find (key.account));
-			if (existing != keys.end ())
-			{
-				auto amount (pending.amount.number ());
-				if (wallet->node.config.receive_minimum.number () <= amount)
-				{
-					rai::account_info info;
-					auto error (wallet->node.store.account_get (transaction, pending.source, info));
-					assert (!error);
-					BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Found a pending block %1% from account %2% with head %3%") % key.hash.to_string () % pending.source.to_account () % info.head.to_string ());
-					auto account (pending.source);
-					if (already_searched.find (account) == already_searched.end ())
-					{
-						auto this_l (shared_from_this ());
-						std::shared_ptr<rai::block> block_l (wallet->node.store.block_get (transaction, info.head));
-						wallet->node.background ([this_l, account, block_l] {
-							this_l->wallet->node.active.start (block_l, [this_l, account](std::shared_ptr<rai::block>) {
-								// If there were any forks for this account they've been rolled back and we can receive anything remaining from this account
-								this_l->receive_all (account);
-							});
-							this_l->wallet->node.network.broadcast_confirm_req (block_l);
-						});
-						already_searched.insert (account);
-					}
-				}
-				else
-				{
-					BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Not receiving block %1% due to minimum receive threshold") % key.hash.to_string ());
-				}
-			}
-		}
-		BOOST_LOG (wallet->node.log) << "Pending block search phase complete";
-	}
-	void receive_all (rai::account const & account_a)
-	{
-		BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Account %1% confirmed, receiving all blocks") % account_a.to_account ());
-		rai::transaction transaction (wallet->node.store.environment, nullptr, false);
-		auto representative (wallet->store.representative (transaction));
-		for (auto i (wallet->node.store.pending_begin (transaction)), n (wallet->node.store.pending_end ()); i != n; ++i)
-		{
-			rai::pending_key key (i->first);
-			rai::pending_info pending (i->second);
-			if (pending.source == account_a)
-			{
-				if (wallet->store.exists (transaction, key.account))
-				{
-					if (wallet->store.valid_password (transaction))
-					{
-						rai::pending_key key (i->first);
-						std::shared_ptr<rai::block> block (wallet->node.store.block_get (transaction, key.hash));
-						auto wallet_l (wallet);
-						auto amount (pending.amount.number ());
-						BOOST_LOG (wallet_l->node.log) << boost::str (boost::format ("Receiving block: %1%") % block->hash ().to_string ());
-						wallet_l->receive_async (block, representative, amount, [wallet_l, block](std::shared_ptr<rai::block> block_a) {
-							if (block_a == nullptr)
-							{
-								BOOST_LOG (wallet_l->node.log) << boost::str (boost::format ("Error receiving block %1%") % block->hash ().to_string ());
-							}
-						},
-						true);
-					}
-					else
-					{
-						BOOST_LOG (wallet->node.log) << boost::str (boost::format ("Unable to fetch key for: %1%, stopping pending search") % key.account.to_account ());
-					}
-				}
-			}
-		}
-	}
-	std::unordered_set<rai::uint256_union> keys;
-	std::shared_ptr<rai::wallet> wallet;
-};
-}
-
 bool rai::wallet::search_pending ()
 {
 	rai::transaction transaction (store.environment, nullptr, false);
 	auto result (!store.valid_password (transaction));
 	if (!result)
 	{
-		auto search (std::make_shared<search_action> (shared_from_this (), transaction));
-		node.background ([search]() {
-			search->run ();
-		});
+		BOOST_LOG (node.log) << "Beginning pending block search";
+		rai::transaction transaction (node.store.environment, nullptr, false);
+		for (auto i (store.begin (transaction)), n (store.end ()); i != n; ++i)
+		{
+			rai::account account (i->first.uint256 ());
+			// Don't search pending for watch-only accounts
+			if (!rai::wallet_value (i->second).key.is_zero ())
+			{
+				for (auto j (node.store.pending_begin (transaction, rai::pending_key (account, 0))), m (node.store.pending_begin (transaction, rai::pending_key (account.number () + 1, 0))); j != m; ++j)
+				{
+					rai::pending_key key (j->first);
+					auto hash (key.hash);
+					rai::pending_info pending (j->second);
+					auto amount (pending.amount.number ());
+					if (node.config.receive_minimum.number () <= amount)
+					{
+						BOOST_LOG (node.log) << boost::str (boost::format ("Found a pending block %1% for account %2%") % hash.to_string () % pending.source.to_account ());
+						auto this_l (shared_from_this ());
+						rai::account_info info;
+						auto error (node.store.account_get (transaction, pending.source, info));
+						assert (!error);
+						node.block_confirm (node.store.block_get (transaction, info.head));
+					}
+				}
+			}
+		}
+		BOOST_LOG (node.log) << "Pending block search phase complete";
 	}
 	else
 	{

--- a/rai/rai_node/entry.cpp
+++ b/rai/rai_node/entry.cpp
@@ -20,7 +20,7 @@ int main (int argc, char * const * argv)
 		("debug_block_count", "Display the number of block")
 		("debug_bootstrap_generate", "Generate bootstrap sequence of blocks")
 		("debug_dump_representatives", "List representatives and weights")
-		("debug_frontier_count", "Display the number of accounts")
+		("debug_account_count", "Display the number of accounts")
 		("debug_mass_activity", "Generates fake debug activity")
 		("debug_profile_generate", "Profile work generation")
 		("debug_opencl", "OpenCL work generation")
@@ -133,11 +133,11 @@ int main (int argc, char * const * argv)
 			std::cout << boost::str (boost::format ("%1% %2% %3%\n") % i->first.to_account () % i->second.convert_to<std::string> () % total.convert_to<std::string> ());
 		}
 	}
-	else if (vm.count ("debug_frontier_count"))
+	else if (vm.count ("debug_account_count"))
 	{
 		rai::inactive_node node (data_path);
 		rai::transaction transaction (node.node->store.environment, nullptr, false);
-		std::cout << boost::str (boost::format ("Frontier count: %1%\n") % node.node->store.frontier_count (transaction));
+		std::cout << boost::str (boost::format ("Frontier count: %1%\n") % node.node->store.account_count (transaction));
 	}
 	else if (vm.count ("debug_mass_activity"))
 	{


### PR DESCRIPTION
When calling the frontier_count RPC, it only counts accounts that have been opened via legacy blocks. This is because the frontiers table doesn't include state blocks (via @PlasmaPower). Changing this RPC call to count the accounts table seems to fix the issue.

This bug was originally discovered via Banano. There the RPC returns "1" because only 1 account (genesis) was created via legacy blocks, which is what originally tipped me off about this issue.

I'm not sure what the future of the frontiers table is like, so I leave that up to the core devs here. This simply fixes the count issue.

**frontier_count before**
```json
{
    "count": "502528"
}
```

**frontier_count after**
```json
{
    "count": "502838"
}
```

This fixes #869.