### PR TITLE
Fix Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
 - cmd: >-
     SET GIT_COMMIT=%APPVEYOR_REPO_COMMIT:~0,3%
 
-    cmake -DRAIBLOCKS_GUI=ON -DQt5_DIR=C:\Qt\5.9.4\msvc2015_64\lib\cmake\Qt5 -DRAIBLOCKS_SIMD_OPTIMIZATIONS=TRUE -DBOOST_INCLUDEDIR=C:/Libraries/boost_1_66_0 -DBOOST_LIBRARYDIR=C:/Libraries/boost_1_66_0/lib64-msvc-14.0 -G "Visual Studio 14 2015 Win64" -DIPHLPAPI_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/iphlpapi.lib" -DWINSOCK2_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/WS2_32.lib" -DGIT_COMMIT=%GIT_COMMIT%
+    cmake -DRAIBLOCKS_GUI=ON -DQt5_DIR=C:\Qt\5.9\msvc2015_64\lib\cmake\Qt5 -DRAIBLOCKS_SIMD_OPTIMIZATIONS=TRUE -DBOOST_INCLUDEDIR=C:/Libraries/boost_1_66_0 -DBOOST_LIBRARYDIR=C:/Libraries/boost_1_66_0/lib64-msvc-14.0 -G "Visual Studio 14 2015 Win64" -DIPHLPAPI_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/iphlpapi.lib" -DWINSOCK2_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/WS2_32.lib" -DGIT_COMMIT=%GIT_COMMIT%
 
 - ps: >-
     $size_t=select-string -path ".\bootstrap_weights.cpp" -Pattern "rai_bootstrap_weights_size"| foreach {$_.Line}


### PR DESCRIPTION
Appveyor dropped support for Qt 5.9.4 and aliased qt 5.9.5 directory, Updated appveyor to use symlinked QT 5.9.5 