### PR TITLE
Rename Doxygen name to Nano

### DIFF
--- a/doxygen.config
+++ b/doxygen.config
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "RaiBlocks"
+PROJECT_NAME           = "Nano"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version


### PR DESCRIPTION
For now, pushing docs to https://nanoapi.github.io/doxygen