### PR TITLE
Remove unneeded peers.insert after peers.contacted

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -337,7 +337,6 @@ public:
 		}
 		node.stats.inc (rai::stat::type::message, rai::stat::detail::publish, rai::stat::dir::in);
 		node.peers.contacted (sender, message_a.version_using);
-		node.peers.insert (sender, message_a.version_using);
 		node.process_active (message_a.block);
 	}
 	void confirm_req (rai::confirm_req const & message_a) override
@@ -348,7 +347,6 @@ public:
 		}
 		node.stats.inc (rai::stat::type::message, rai::stat::detail::confirm_req, rai::stat::dir::in);
 		node.peers.contacted (sender, message_a.version_using);
-		node.peers.insert (sender, message_a.version_using);
 		node.process_active (message_a.block);
 		rai::transaction transaction_a (node.store.environment, nullptr, false);
 		auto successor (node.ledger.successor (transaction_a, message_a.block->root ()));
@@ -365,7 +363,6 @@ public:
 		}
 		node.stats.inc (rai::stat::type::message, rai::stat::detail::confirm_ack, rai::stat::dir::in);
 		node.peers.contacted (sender, message_a.version_using);
-		node.peers.insert (sender, message_a.version_using);
 		node.process_active (message_a.vote->block);
 		node.vote_processor.vote (message_a.vote, sender);
 	}


### PR DESCRIPTION
`insert` is already called from within `peers.contacted`, so there should be no need to call it again.