### PR TITLE
Stateblock Canary Check Cleanup

### DIFF
--- a/rai/common.hpp
+++ b/rai/common.hpp
@@ -223,7 +223,6 @@ enum class process_result
 	unreceivable, // Source block doesn't exist or has already been received
 	gap_previous, // Block marked as previous is unknown
 	gap_source, // Block marked as source is unknown
-	state_block_disabled, // Awaiting state block canary block
 	not_receive_from_send, // Receive does not have a send source
 	account_mismatch, // Account number in open block doesn't match send destination
 	opened_burn_account, // The impossible happened, someone found the private key associated with the public key '0'.

--- a/rai/core_test/ledger.cpp
+++ b/rai/core_test/ledger.cpp
@@ -1502,7 +1502,7 @@ TEST (ledger, send_open_receive_rollback)
 	rai::block_store store (init, rai::unique_path ());
 	ASSERT_TRUE (!init);
 	rai::stat stats;
-	rai::ledger ledger (store, stats, 0);
+	rai::ledger ledger (store, stats);
 	rai::transaction transaction (store.environment, nullptr, true);
 	rai::genesis genesis;
 	genesis.initialize (transaction, store);
@@ -1560,7 +1560,7 @@ TEST (ledger, bootstrap_rep_weight)
 	rai::block_store store (init, rai::unique_path ());
 	ASSERT_TRUE (!init);
 	rai::stat stats;
-	rai::ledger ledger (store, stats, 40);
+	rai::ledger ledger (store, stats);
 	rai::account_info info1;
 	rai::keypair key2;
 	rai::genesis genesis;
@@ -2275,26 +2275,3 @@ TEST (ledger, state_receive_change_rollback)
 	ASSERT_EQ (0, ledger.weight (transaction, rep.pub));
 }
 
-TEST (ledger, state_canary_blocks)
-{
-	bool init (false);
-	rai::block_store store (init, rai::unique_path ());
-	ASSERT_TRUE (!init);
-	rai::genesis genesis;
-	rai::send_block parse_canary (genesis.hash (), rai::test_genesis_key.pub, rai::genesis_amount, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0);
-	rai::send_block generate_canary (parse_canary.hash (), rai::test_genesis_key.pub, rai::genesis_amount, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0);
-	rai::stat stats;
-	rai::ledger ledger (store, stats, parse_canary.hash (), generate_canary.hash ());
-	rai::transaction transaction (store.environment, nullptr, true);
-	genesis.initialize (transaction, store);
-	rai::state_block state (rai::test_genesis_key.pub, genesis.hash (), rai::test_genesis_key.pub, rai::genesis_amount - rai::Gxrb_ratio, rai::test_genesis_key.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0);
-	ASSERT_FALSE (ledger.state_block_parsing_enabled (transaction));
-	ASSERT_FALSE (ledger.state_block_generation_enabled (transaction));
-	ASSERT_EQ (rai::process_result::state_block_disabled, ledger.process (transaction, state).code);
-	ASSERT_EQ (rai::process_result::progress, ledger.process (transaction, parse_canary).code);
-	ASSERT_TRUE (ledger.state_block_parsing_enabled (transaction));
-	ASSERT_FALSE (ledger.state_block_generation_enabled (transaction));
-	ASSERT_EQ (rai::process_result::progress, ledger.process (transaction, generate_canary).code);
-	ASSERT_TRUE (ledger.state_block_parsing_enabled (transaction));
-	ASSERT_TRUE (ledger.state_block_generation_enabled (transaction));
-}

--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -27,23 +27,6 @@ TEST (node, block_store_path_failure)
 	node->stop ();
 }
 
-TEST (node, state_canaries)
-{
-	rai::node_init init;
-	auto service (boost::make_shared<boost::asio::io_service> ());
-	rai::alarm alarm (*service);
-	auto path (rai::unique_path ());
-	rai::node_config config;
-	config.logging.init (path);
-	rai::work_pool work (std::numeric_limits<unsigned>::max (), nullptr);
-	config.state_block_parse_canary = 10;
-	config.state_block_generate_canary = 20;
-	auto node (std::make_shared<rai::node> (init, *service, path, alarm, config, work));
-	ASSERT_EQ (rai::block_hash (10), node->ledger.state_block_parse_canary);
-	ASSERT_EQ (rai::block_hash (20), node->ledger.state_block_generate_canary);
-	node->stop ();
-}
-
 TEST (node, password_fanout)
 {
 	rai::node_init init;

--- a/rai/core_test/wallet.cpp
+++ b/rai/core_test/wallet.cpp
@@ -950,26 +950,3 @@ TEST (wallet, password_race_corrupt_seed)
 		}
 	}
 }
-
-TEST (wallet, state_implicit_generate)
-{
-	rai::system system (24000, 1);
-	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
-	rai::genesis genesis;
-	system.nodes[0]->ledger.state_block_parse_canary = genesis.hash ();
-	{
-		rai::transaction transaction (system.nodes[0]->store.environment, nullptr, true);
-		ASSERT_FALSE (system.wallet (0)->should_generate_state_block (transaction, genesis.hash ()));
-		rai::state_block block (rai::test_genesis_key.pub, genesis.hash (), rai::test_genesis_key.pub, rai::genesis_amount - rai::Gxrb_ratio, rai::test_genesis_key.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0);
-		ASSERT_EQ (rai::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
-		ASSERT_TRUE (system.wallet (0)->should_generate_state_block (transaction, block.hash ()));
-	}
-	ASSERT_FALSE (system.wallet (0)->search_pending ());
-	auto iterations (0);
-	while (system.nodes[0]->balance (rai::test_genesis_key.pub) != rai::genesis_amount)
-	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
-	}
-}

--- a/rai/ledger.cpp
+++ b/rai/ledger.cpp
@@ -177,11 +177,7 @@ public:
 
 void ledger_processor::state_block (rai::state_block const & block_a)
 {
-	result.code = ledger.state_block_parsing_enabled (transaction) ? rai::process_result::progress : rai::process_result::state_block_disabled;
-	if (result.code == rai::process_result::progress)
-	{
-		state_block_impl (block_a);
-	}
+	state_block_impl (block_a);
 }
 
 void ledger_processor::state_block_impl (rai::state_block const & block_a)
@@ -505,12 +501,10 @@ bool rai::shared_ptr_block_hash::operator() (std::shared_ptr<rai::block> const &
 	return *lhs == *rhs;
 }
 
-rai::ledger::ledger (rai::block_store & store_a, rai::stat & stat_a, rai::block_hash const & state_block_parse_canary_a, rai::block_hash const & state_block_generate_canary_a) :
+rai::ledger::ledger (rai::block_store & store_a, rai::stat & stat_a) :
 store (store_a),
 stats (stat_a),
-check_bootstrap_weights (true),
-state_block_parse_canary (state_block_parse_canary_a),
-state_block_generate_canary (state_block_generate_canary_a)
+check_bootstrap_weights (true)
 {
 }
 
@@ -792,16 +786,6 @@ void rai::ledger::dump_account_chain (rai::account const & account_a)
 		std::cerr << hash.to_string () << std::endl;
 		hash = block->previous ();
 	}
-}
-
-bool rai::ledger::state_block_parsing_enabled (MDB_txn * transaction_a)
-{
-	return store.block_exists (transaction_a, state_block_parse_canary);
-}
-
-bool rai::ledger::state_block_generation_enabled (MDB_txn * transaction_a)
-{
-	return state_block_parsing_enabled (transaction_a) && store.block_exists (transaction_a, state_block_generate_canary);
 }
 
 void rai::ledger::checksum_update (MDB_txn * transaction_a, rai::block_hash const & hash_a)

--- a/rai/ledger.hpp
+++ b/rai/ledger.hpp
@@ -17,7 +17,7 @@ using tally_t = std::map<rai::uint128_t, std::shared_ptr<rai::block>, std::great
 class ledger
 {
 public:
-	ledger (rai::block_store &, rai::stat &, rai::block_hash const & = 0, rai::block_hash const & = 0);
+	ledger (rai::block_store &, rai::stat &);
 	std::pair<rai::uint128_t, std::shared_ptr<rai::block>> winner (MDB_txn *, rai::votes const & votes_a);
 	// Map of weight -> associated block, ordered greatest to least
 	rai::tally_t tally (MDB_txn *, rai::votes const &);
@@ -45,8 +45,6 @@ public:
 	void checksum_update (MDB_txn *, rai::block_hash const &);
 	rai::checksum checksum (MDB_txn *, rai::account const &, rai::account const &);
 	void dump_account_chain (rai::account const &);
-	bool state_block_parsing_enabled (MDB_txn *);
-	bool state_block_generation_enabled (MDB_txn *);
 	static rai::uint128_t const unit;
 	rai::block_store & store;
 	rai::stat & stats;

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1356,16 +1356,6 @@ rai::process_return rai::block_processor::process_receive_one (MDB_txn * transac
 			node.gap_cache.add (transaction_a, block_a);
 			break;
 		}
-		case rai::process_result::state_block_disabled:
-		{
-			if (node.config.logging.ledger_logging ())
-			{
-				BOOST_LOG (node.log) << boost::str (boost::format ("State blocks are disabled: %1%") % hash.to_string ());
-			}
-			node.store.unchecked_put (transaction_a, node.ledger.state_block_parse_canary, block_a);
-			node.gap_cache.add (transaction_a, block_a);
-			break;
-		}
 		case rai::process_result::old:
 		{
 			if (node.config.logging.ledger_duplicate_logging ())
@@ -1477,7 +1467,7 @@ alarm (alarm_a),
 work (work_a),
 store (init_a.block_store_init, application_path_a / "data.ldb", config_a.lmdb_max_dbs),
 gap_cache (*this),
-ledger (store, stats, config.state_block_parse_canary, config.state_block_generate_canary),
+ledger (store, stats),
 active (*this),
 network (*this, config.peering_port),
 bootstrap_initiator (*this),

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -2624,11 +2624,6 @@ void rai::rpc_handler::process ()
 					error_response (response, "Gap source block");
 					break;
 				}
-				case rai::process_result::state_block_disabled:
-				{
-					error_response (response, "State blocks are disabled");
-					break;
-				}
 				case rai::process_result::old:
 				{
 					error_response (response, "Old block");

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -867,25 +867,11 @@ std::shared_ptr<rai::block> rai::wallet::receive_action (rai::block const & send
 					{
 						std::shared_ptr<rai::block> rep_block = node.ledger.store.block_get (transaction, info.rep_block);
 						assert (rep_block != nullptr);
-						if (should_generate_state_block (transaction, info.head))
-						{
-							block.reset (new rai::state_block (account, info.head, rep_block->representative (), info.balance.number () + pending_info.amount.number (), hash, prv, account, cached_work));
-						}
-						else
-						{
-							block.reset (new rai::receive_block (info.head, hash, prv, account, cached_work));
-						}
+						block.reset (new rai::state_block (account, info.head, rep_block->representative (), info.balance.number () + pending_info.amount.number (), hash, prv, account, cached_work));
 					}
 					else
 					{
-						if (node.ledger.state_block_generation_enabled (transaction))
-						{
-							block.reset (new rai::state_block (account, 0, representative_a, pending_info.amount, hash, prv, account, cached_work));
-						}
-						else
-						{
-							block.reset (new rai::open_block (hash, representative_a, account, prv, account, cached_work));
-						}
+						block.reset (new rai::state_block (account, 0, representative_a, pending_info.amount, hash, prv, account, cached_work));
 					}
 				}
 				else
@@ -942,14 +928,7 @@ std::shared_ptr<rai::block> rai::wallet::change_action (rai::account const & sou
 				assert (!error2);
 				uint64_t cached_work (0);
 				store.work_get (transaction, source_a, cached_work);
-				if (should_generate_state_block (transaction, info.head))
-				{
-					block.reset (new rai::state_block (source_a, info.head, representative_a, info.balance, 0, prv, source_a, cached_work));
-				}
-				else
-				{
-					block.reset (new rai::change_block (info.head, representative_a, prv, source_a, cached_work));
-				}
+				block.reset (new rai::state_block (source_a, info.head, representative_a, info.balance, 0, prv, source_a, cached_work));
 			}
 		}
 	}
@@ -1020,14 +999,7 @@ std::shared_ptr<rai::block> rai::wallet::send_action (rai::account const & sourc
 						assert (rep_block != nullptr);
 						uint64_t cached_work (0);
 						store.work_get (transaction, source_a, cached_work);
-						if (should_generate_state_block (transaction, info.head))
-						{
-							block.reset (new rai::state_block (source_a, info.head, rep_block->representative (), balance - amount_a, account_a, prv, source_a, cached_work));
-						}
-						else
-						{
-							block.reset (new rai::send_block (info.head, account_a, balance - amount_a, prv, source_a, cached_work));
-						}
+						block.reset (new rai::state_block (source_a, info.head, rep_block->representative (), balance - amount_a, account_a, prv, source_a, cached_work));
 						if (id_mdb_val)
 						{
 							auto status (mdb_put (transaction, node.wallets.send_action_ids, *id_mdb_val, rai::mdb_val (block->hash ()), 0));
@@ -1056,14 +1028,6 @@ std::shared_ptr<rai::block> rai::wallet::send_action (rai::account const & sourc
 		}
 	}
 	return block;
-}
-
-bool rai::wallet::should_generate_state_block (MDB_txn * transaction_a, rai::block_hash const & hash_a)
-{
-	auto head (node.store.block_get (transaction_a, hash_a));
-	assert (head != nullptr);
-	auto is_state (dynamic_cast<rai::state_block *> (head.get ()) != nullptr);
-	return is_state || node.ledger.state_block_generation_enabled (transaction_a);
 }
 
 bool rai::wallet::change_sync (rai::account const & source_a, rai::account const & representative_a)

--- a/rai/slow_test/node.cpp
+++ b/rai/slow_test/node.cpp
@@ -34,39 +34,6 @@ TEST (system, generate_mass_activity_long)
 	runner.join ();
 }
 
-TEST (system, generate_mass_activity_state_block_enable)
-{
-	rai::system system (24000, 1);
-	rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
-	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
-	system.nodes[0]->alarm.add (std::chrono::steady_clock::now () + std::chrono::minutes (1), [&system]() {
-		std::cerr << boost::str (boost::format ("Enabling state block parsing\n"));
-		rai::transaction transaction (system.nodes[0]->store.environment, nullptr, true);
-		ASSERT_FALSE (system.nodes[0]->ledger.state_block_parsing_enabled (transaction));
-		rai::genesis genesis;
-		system.nodes[0]->ledger.state_block_parse_canary = genesis.hash ();
-		ASSERT_TRUE (system.nodes[0]->ledger.state_block_parsing_enabled (transaction));
-	});
-	system.nodes[0]->alarm.add (std::chrono::steady_clock::now () + std::chrono::minutes (2), [&system]() {
-		std::cerr << boost::str (boost::format ("Enabling state block generation\n"));
-		rai::transaction transaction (system.nodes[0]->store.environment, nullptr, true);
-		ASSERT_FALSE (system.nodes[0]->ledger.state_block_generation_enabled (transaction));
-		rai::genesis genesis;
-		system.nodes[0]->ledger.state_block_generate_canary = genesis.hash ();
-		ASSERT_TRUE (system.nodes[0]->ledger.state_block_generation_enabled (transaction));
-	});
-	size_t count (1000000000);
-	system.generate_mass_activity (count, *system.nodes[0]);
-	size_t accounts (0);
-	rai::transaction transaction (system.nodes[0]->store.environment, nullptr, false);
-	for (auto i (system.nodes[0]->store.latest_begin (transaction)), n (system.nodes[0]->store.latest_end ()); i != n; ++i)
-	{
-		++accounts;
-	}
-	system.stop ();
-	runner.join ();
-}
-
 TEST (system, receive_while_synchronizing)
 {
 	std::vector<std::thread> threads;


### PR DESCRIPTION
Stateblocks are now being parsed and generated, Canary blocks no longer matter since only nodes that understand them are still on the network