### PR TITLE
Replace call operator with notify function

### DIFF
--- a/rai/lib/utility.hpp
+++ b/rai/lib/utility.hpp
@@ -18,7 +18,7 @@ public:
 		std::lock_guard<std::mutex> lock (mutex);
 		observers.push_back (observer_a);
 	}
-	void operator() (T... args)
+	void notify (T... args)
 	{
 		std::lock_guard<std::mutex> lock (mutex);
 		for (auto & i : observers)

--- a/rai/lib/work.cpp
+++ b/rai/lib/work.cpp
@@ -68,7 +68,7 @@ void rai::work_pool::loop (uint64_t thread)
 		if (thread == 0)
 		{
 			// Only work thread 0 notifies work observers
-			work_observers (!empty);
+			work_observers.notify (!empty);
 		}
 		if (!empty)
 		{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1223,7 +1223,7 @@ rai::vote_code rai::vote_processor::vote (std::shared_ptr<rai::vote> vote_a, rai
 		switch (result)
 		{
 			case rai::vote_code::vote:
-				node.observers.vote (vote_a, endpoint_a);
+				node.observers.vote.notify (vote_a, endpoint_a);
 			case rai::vote_code::replay:
 				// This tries to assist rep nodes that have lost track of their highest sequence number by replaying our highest known vote back to them
 				// Only do this if the sequence number is significantly different to account for network reordering
@@ -1580,13 +1580,13 @@ online_reps (*this),
 stats (config.stat_config)
 {
 	wallets.observer = [this](bool active) {
-		observers.wallet (active);
+		observers.wallet.notify (active);
 	};
 	peers.peer_observer = [this](rai::endpoint const & endpoint_a) {
-		observers.endpoint (endpoint_a);
+		observers.endpoint.notify (endpoint_a);
 	};
 	peers.disconnect_observer = [this]() {
-		observers.disconnect ();
+		observers.disconnect.notify ();
 	};
 	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a, bool is_state_send_a) {
 		if (this->block_arrival.recent (block_a->hash ()))
@@ -2155,7 +2155,7 @@ void rai::node::start ()
 	online_reps.recalculate_stake ();
 	port_mapping.start ();
 	add_initial_peers ();
-	observers.started ();
+	observers.started.notify ();
 }
 
 void rai::node::stop ()
@@ -2739,13 +2739,13 @@ void rai::node::process_confirmed (std::shared_ptr<rai::block> block_a)
 		{
 			pending_account = send->hashables.destination;
 		}
-		observers.blocks (block_a, account, amount, is_state_send);
+		observers.blocks.notify (block_a, account, amount, is_state_send);
 		if (amount > 0)
 		{
-			observers.account_balance (account, false);
+			observers.account_balance.notify (account, false);
 			if (!pending_account.is_zero ())
 			{
-				observers.account_balance (pending_account, true);
+				observers.account_balance.notify (pending_account, true);
 			}
 		}
 	}

--- a/rai/node/stats.cpp
+++ b/rai/node/stats.cpp
@@ -267,7 +267,7 @@ void rai::stat::update (uint32_t key_a, uint64_t value)
 	// Counters
 	auto old (entry->counter.value);
 	entry->counter.add (value);
-	entry->count_observers (old, entry->counter.value);
+	entry->count_observers.notify (old, entry->counter.value);
 
 	std::chrono::duration<double, std::milli> duration = now - log_last_count_writeout;
 	if (config.log_interval_counters > 0 && duration.count () > config.log_interval_counters)
@@ -294,7 +294,7 @@ void rai::stat::update (uint32_t key_a, uint64_t value)
 			if (entry->sample_observers.observers.size () > 0)
 			{
 				auto snapshot (entry->samples);
-				entry->sample_observers (snapshot);
+				entry->sample_observers.notify (snapshot);
 			}
 
 			// Log sink


### PR DESCRIPTION
I didn't see any downsides in converting observer_set's call operator into a `notify` function. It helps finding call sites (IDE's generally suck at finding operator usage), as well as making the call sites a bit clearer to readers IMO.