### PR TITLE
IPC server and protobuf based API framework

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "phc-winner-argon2"]
 	path = phc-winner-argon2
 	url = https://github.com/clemahieu/phc-winner-argon2.git
+[submodule "protobuf-lib"]
+	path = protobuf-lib
+	url = https://github.com/google/protobuf.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,20 @@ find_package (Boost 1.66.0 REQUIRED COMPONENTS filesystem log thread program_opt
 
 add_subdirectory(ed25519-donna)
 
+# Protobuf definitions
+if (WIN32)
+	set (protobuf_BUILD_SHARED_LIBS ON CACHE BOOL "")
+	add_definitions(-DPROTOBUF_USE_DLLS)
+endif ()
+ # Build protobuf
+set (protobuf_BUILD_TESTS OFF)
+add_subdirectory("protobuf-lib/cmake" EXCLUDE_FROM_ALL)
+set (PROTOBUF_LIBRARY "libprotobuf")
+include_directories("protobuf-lib/src")
+
 set (UPNPC_BUILD_SHARED OFF CACHE BOOL "")
 add_subdirectory (miniupnp/miniupnpc)
+
 # FIXME: This fixes miniupnpc include directories without modifying miniupnpc's
 # CMakeLists.txt but should be set there
 set_target_properties(libminiupnpc-static PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
@@ -227,6 +239,27 @@ add_library (blake2
 
 target_compile_definitions(blake2 PRIVATE -D__SSE2__)
 
+# Protobuf library with generated files
+add_library (rai_protobuf api-c/core.pb.cc api-c/core.pb.h api-c/accounts.pb.cc api-c/accounts.pb.h api-c/util.pb.cc api-c/util.pb.h)
+
+# Generate protobuf files into the rai_protobuf library, which will be rebuilt
+# whenever any of the proto files change.
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/api-c)
+
+file(GLOB files "protobuf/*.proto")
+file(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/protobuf/protofiles.txt")
+foreach(file ${files})
+	get_filename_component(protofilename ${file} NAME_WE)
+	file(APPEND "${CMAKE_CURRENT_SOURCE_DIR}/protobuf/protofiles.txt" "${protofilename}\n")
+	# message("Generating protobuf code for: ${protofilename} into ${CMAKE_CURRENT_SOURCE_DIR}")
+
+	add_custom_command(
+		OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/api-c/${protofilename}.pb.cc ${CMAKE_CURRENT_SOURCE_DIR}/api-c/${protofilename}.pb.h
+		COMMAND "$<TARGET_FILE:protoc>" --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/protobuf --cpp_out=${CMAKE_CURRENT_SOURCE_DIR}/api-c ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/${protofilename}.proto
+		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/${protofilename}.proto
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endforeach()
+
 add_subdirectory(rai/secure)
 add_subdirectory(rai/lib)
 add_subdirectory(rai/node)
@@ -268,6 +301,8 @@ if (RAIBLOCKS_GUI)
 	add_library (qt
 		rai/qt/qt.cpp
 		rai/qt/qt.hpp)
+
+	add_dependencies(qt rai_protobuf)
 
 	target_link_libraries(qt
 		secure rai_lib node libminiupnpc-static Qt5::Gui Qt5::Widgets)
@@ -357,6 +392,7 @@ if (RAIBLOCKS_GUI)
 		get_target_property (Qt5WindowsPlugin Qt5::QWindowsIntegrationPlugin LOCATION)
 		get_filename_component (Qt5_bin_DIR ${Qt5_DIR}/../../../bin ABSOLUTE)
 		install (TARGETS nano_wallet DESTINATION .)
+		install (FILES $<TARGET_FILE:${PROTOBUF_LIBRARY}> DESTINATION .)
 		install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${WIN_REDIST} DESTINATION .)
 		install (FILES ${Qt5_bin_DIR}/libGLESv2.dll DESTINATION .)
 		install (FILES ${Qt5_bin_DIR}/Qt5Core.dll DESTINATION .)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 
     git submodule update --init --recursive
 
-    cmake -DRAIBLOCKS_GUI=ON -DACTIVE_NETWORK=%NETWORK% -DQt5_DIR="C:\Qt\5.9\msvc2017_64\lib\cmake\Qt5" -DRAIBLOCKS_SIMD_OPTIMIZATIONS=TRUE -DBoost_COMPILER="-vc141" -DBOOST_ROOT="C:/Libraries/boost_1_66_0" -DBOOST_LIBRARYDIR="C:/Libraries/boost_1_66_0/lib64-msvc-14.1" -G "Visual Studio 15 2017 Win64" -DIPHLPAPI_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/iphlpapi.lib" -DWINSOCK2_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/WS2_32.lib" -DGIT_COMMIT=%GIT_COMMIT%
+    cmake -Dprotobuf_BUILD_TESTS=OFF -DRAIBLOCKS_GUI=ON -DACTIVE_NETWORK=%NETWORK% -DQt5_DIR="C:\Qt\5.9\msvc2017_64\lib\cmake\Qt5" -DRAIBLOCKS_SIMD_OPTIMIZATIONS=TRUE -DBoost_COMPILER="-vc141" -DBOOST_ROOT="C:/Libraries/boost_1_66_0" -DBOOST_LIBRARYDIR="C:/Libraries/boost_1_66_0/lib64-msvc-14.1" -G "Visual Studio 15 2017 Win64" -DIPHLPAPI_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/iphlpapi.lib" -DWINSOCK2_LIBRARY="C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/WS2_32.lib" -DGIT_COMMIT=%GIT_COMMIT%
 
 
 

--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -23,6 +23,7 @@ fi
 
 cmake \
     -G'Unix Makefiles' \
+    -Dprotobuf_BUILD_TESTS=OFF \
     -DACTIVE_NETWORK=rai_test_network \
     -DRAIBLOCKS_TEST=ON \
     -DRAIBLOCKS_GUI=ON \

--- a/ci/clang-format-all.sh
+++ b/ci/clang-format-all.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-find ${REPO_ROOT}/rai -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs clang-format -i
+find ${REPO_ROOT}/rai -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' -o -iname '*.cc' | xargs clang-format -i

--- a/ci/git-clang-format.py
+++ b/ci/git-clang-format.py
@@ -132,7 +132,7 @@ def main():
       'mm',  # ObjC++
       'cc', 'cp', 'cpp', 'c++', 'cxx', 'hpp',  # C++
       # Other languages that clang-format supports
-      'proto', 'protodevel',  # Protocol Buffers
+      #'proto', 'protodevel',  # Protocol Buffers
       'java',  # Java
       'js',  # JavaScript
       'ts',  # TypeScript

--- a/protobuf/accounts.proto
+++ b/protobuf/accounts.proto
@@ -1,0 +1,48 @@
+// Account related messages
+
+syntax = "proto3";
+import "google/protobuf/wrappers.proto";
+
+package nano.api;
+
+
+/** Returns a list of block hashes which have not yet been received by these accounts */
+message req_account_pending
+{
+    /** List of accounts to query */
+    repeated string accounts = 1;
+
+    /** Maximum number of blocks to return */
+    uint64 count = 2;
+
+    /** If true, include source account */
+    bool source = 3;
+
+    /** Optional threshold. Returns a list of pending block hashes with amount more or equal to the threshold. */
+    google.protobuf.StringValue threshold = 4;
+}
+
+/** account_pending result */
+message res_account_pending
+{
+    /** List of accounts, each with a list of pending blocks */
+    repeated account_pending pending = 1;
+}
+
+/** Blocks per account */
+message account_pending
+{
+    /** The account */
+    string account = 1;
+
+    /** List of blocks with details */
+    repeated account_pending_block_info block_info = 2;
+}
+
+/** Information supplied for each account in req_account_pending */
+message account_pending_block_info
+{
+    string hash = 1;
+    string amount = 2;
+    string source = 3;
+}

--- a/protobuf/core.proto
+++ b/protobuf/core.proto
@@ -1,0 +1,100 @@
+// Core messages and enums
+
+syntax = "proto3";
+import "google/protobuf/wrappers.proto";
+
+package nano.api;
+
+// option optimize_for = CODE_SIZE;
+// option cc_enable_arenas = true;
+
+/*
+    Nano Node API protobuf definition
+
+    An up-to-date node will respond with a preamble matching the API
+    version numbers. See https://nanoapi.github.io/PROTOCOL.html for more information.
+*/
+
+/**
+ * API version numbers. As proto3 doesn't have constants, so we use an enum
+ * which allows aliases. VERSION_INVALID is a 0-value placeholder, which
+ * protobuf requires.
+ */
+enum APIVersion
+{
+    option allow_alias = true;
+    VERSION_INVALID = 0;
+    VERSION_MAJOR = 1;
+    VERSION_MINOR = 0;
+}
+
+/**
+ * The enum values must NOT change. The name of the enum must match the
+ * request message name, uppercased, and without the req_ prefix. This naming
+ * standard facilitates dynamic lookup and generic frameworks.
+ */
+enum RequestType
+{
+    INVALID = 0;
+    REGISTER_CALLBACK = 1;
+
+    // core.proto message types
+    PING = 2;
+
+    // accounts.proto message types
+    ACCOUNT_PENDING = 100;
+
+    // util.proto message types
+    ADDRESS_VALID = 1000;
+}
+
+/**
+ * Request header.
+ * This is serialized before the actual request to tell the node what message to expect next.
+ * Other request meta data may be added in the future.
+ */
+message request
+{
+    /** Request type */
+    RequestType type = 1;
+}
+
+/**
+ * Response header.
+ * This is serialized before the actual response.
+ */
+message response
+{
+    /**
+     * For which request type is this a response? This flag allows future support for clients
+     * issuing multiple concurrent requests, as well as callback messages.
+     *
+     * This may not be set if error_code is non-zero.
+     */
+    RequestType type = 1;
+
+    /**
+     * If non-zero, an error has occurred.
+     */
+    sint32 error_code = 2;
+
+    /** Error message. Only set if error_code is non-zero. */
+    string error_message = 3;
+
+    /** Error category name. Only set if error_code is non-zero. */
+    string error_category = 4;
+}
+
+/** Send ping to the node */
+message req_ping
+{
+    /** Ping ID. The node will respond with the same ID. */
+    uint32 id = 1;
+}
+
+/** Ping response */
+message res_ping
+{
+    /** The same ID as sent in the ping request */
+    uint32 id = 1;
+}

--- a/protobuf/google/protobuf/wrappers.proto
+++ b/protobuf/google/protobuf/wrappers.proto
@@ -1,0 +1,118 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Wrappers for primitive (non-message) types. These types are useful
+// for embedding primitives in the `google.protobuf.Any` type and for places
+// where we need to distinguish between the absence of a primitive
+// typed field and its default value.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
+option go_package = "github.com/golang/protobuf/ptypes/wrappers";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "WrappersProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+
+// Wrapper message for `double`.
+//
+// The JSON representation for `DoubleValue` is JSON number.
+message DoubleValue {
+  // The double value.
+  double value = 1;
+}
+
+// Wrapper message for `float`.
+//
+// The JSON representation for `FloatValue` is JSON number.
+message FloatValue {
+  // The float value.
+  float value = 1;
+}
+
+// Wrapper message for `int64`.
+//
+// The JSON representation for `Int64Value` is JSON string.
+message Int64Value {
+  // The int64 value.
+  int64 value = 1;
+}
+
+// Wrapper message for `uint64`.
+//
+// The JSON representation for `UInt64Value` is JSON string.
+message UInt64Value {
+  // The uint64 value.
+  uint64 value = 1;
+}
+
+// Wrapper message for `int32`.
+//
+// The JSON representation for `Int32Value` is JSON number.
+message Int32Value {
+  // The int32 value.
+  int32 value = 1;
+}
+
+// Wrapper message for `uint32`.
+//
+// The JSON representation for `UInt32Value` is JSON number.
+message UInt32Value {
+  // The uint32 value.
+  uint32 value = 1;
+}
+
+// Wrapper message for `bool`.
+//
+// The JSON representation for `BoolValue` is JSON `true` and `false`.
+message BoolValue {
+  // The bool value.
+  bool value = 1;
+}
+
+// Wrapper message for `string`.
+//
+// The JSON representation for `StringValue` is JSON string.
+message StringValue {
+  // The string value.
+  string value = 1;
+}
+
+// Wrapper message for `bytes`.
+//
+// The JSON representation for `BytesValue` is JSON string.
+message BytesValue {
+  // The bytes value.
+  bytes value = 1;
+}

--- a/protobuf/protobuf-doc.sh
+++ b/protobuf/protobuf-doc.sh
@@ -1,0 +1,6 @@
+# Run from project root, e.g. protobuf/protobuf-doc.sh
+# NOTE: protoc-gen-doc must be on the path
+# NOTE: The output is ../nanoapi.github.com/protobuf - clone nanoapi.github.com as a sibling to this repo or adjust paths.
+
+mkdir -p doc
+protoc  --plugin=protoc-gen-doc=`which protoc-gen-doc` --proto_path=protobuf --doc_opt=html,index.html --doc_out=../nanoapi.github.io/protobuf core.proto

--- a/protobuf/protofiles.txt
+++ b/protobuf/protofiles.txt
@@ -1,0 +1,3 @@
+accounts
+core
+util

--- a/protobuf/util.proto
+++ b/protobuf/util.proto
@@ -1,0 +1,19 @@
+// Utilities, such as address verification, signing and conversion
+
+syntax = "proto3";
+
+package nano.api;
+
+/** Check if the supplied address is correct */
+message req_address_valid {
+    /** Address to check, such as xrb_... and nano_...  */
+    string address = 1;
+}
+
+/** Result of address validation */
+message res_address_valid {
+    /** True if the address is valid */
+    bool valid = 1;
+    /** The reason the address is invalid. May be empty. */
+    string reason = 2;
+}

--- a/rai/core_test/CMakeLists.txt
+++ b/rai/core_test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable (core_test
 	testutil.hpp
+	api.cpp
 	block.cpp
 	block_store.cpp
 	interface.cpp
@@ -25,4 +26,4 @@ target_compile_definitions(core_test
 		PRIVATE
 			-DRAIBLOCKS_VERSION_MAJOR=${CPACK_PACKAGE_VERSION_MAJOR}
 			-DRAIBLOCKS_VERSION_MINOR=${CPACK_PACKAGE_VERSION_MINOR})
-target_link_libraries (core_test node secure gtest_main gtest libminiupnpc-static Boost::boost)
+target_link_libraries (core_test node secure gtest_main gtest libminiupnpc-static Boost::boost ${PROTOBUF_LIBRARY})

--- a/rai/core_test/api.cpp
+++ b/rai/core_test/api.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+#include <rai/lib/interface.h>
+#include <rai/node/api.hpp>
+#include <rai/node/testing.hpp>
+
+TEST (api, address_valid)
+{
+	rai::inactive_node node;
+	nano::api::api_handler handler (*node.node);
+
+	nano::api::req_address_valid request;
+	request.set_address ("xrb_invalid");
+	auto response = handler.request (request);
+	ASSERT_EQ (response.value ()->valid (), false);
+
+	request.set_address ("xrb_1111111111111111111111111111111111111111111111111111hifc8npp");
+	response = handler.request (request);
+	ASSERT_EQ (response.value ()->valid (), true);
+
+	request.set_address ("nano_1111111111111111111111111111111111111111111111111111hifc8npp");
+	response = handler.request (request);
+	ASSERT_EQ (response.value ()->valid (), true);
+}
+
+TEST (api, ping)
+{
+	rai::inactive_node node;
+	nano::api::api_handler handler (*node.node);
+
+	nano::api::req_ping ping;
+	ping.set_id (12345);
+	auto pong = handler.request (ping);
+	ASSERT_EQ (pong.value ()->id (), 12345);
+}
+
+TEST (api, account_pending)
+{
+	rai::system system (24000, 1);
+	rai::keypair key1;
+	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
+	auto block1 (system.wallet (0)->send_action (rai::test_genesis_key.pub, key1.pub, 100));
+
+	nano::api::api_handler handler (*system.nodes[0]);
+
+	// Query with count and a single account
+	nano::api::req_account_pending pending;
+	pending.set_count (100);
+	pending.add_accounts (key1.pub.to_account ());
+
+	auto res = handler.request (pending);
+	ASSERT_EQ (1, res.value ()->pending_size ());
+	ASSERT_EQ (1, res.value ()->pending (0).block_info_size ());
+	ASSERT_EQ (block1->hash (), res.value ()->pending (0).block_info (0).hash ());
+
+	// Rerun query with source. Make sure we get back the correct amount and a valid source address.
+	pending.set_source (true);
+	res = handler.request (pending);
+	ASSERT_EQ ("100", res.value ()->pending (0).block_info (0).amount ());
+	ASSERT_EQ (0, xrb_valid_address (res.value ()->pending (0).block_info (0).source ().c_str ()));
+
+	// Rerun with too-large threshold
+	pending.mutable_threshold ()->set_value ("200");
+	res = handler.request (pending);
+	ASSERT_EQ (0, res.value ()->pending (0).block_info_size ());
+}

--- a/rai/node/CMakeLists.txt
+++ b/rai/node/CMakeLists.txt
@@ -18,10 +18,15 @@ add_library (node
 	${platform_sources}
 	${secure_rpc_sources}
 	bootstrap.cpp
-	bootstrap.hpp
+	bootstrap.hpp	
 	cli.hpp
 	cli.cpp
 	common.cpp
+	common.hpp
+	ipc.hpp
+	ipc.cpp
+	api.cpp
+	api.hpp
 	lmdb.cpp
 	lmdb.hpp
 	logging.cpp
@@ -48,10 +53,12 @@ add_library (node
 	voting.cpp
 	working.hpp
 	xorshift.hpp)
+add_dependencies(node rai_protobuf)
 
 target_link_libraries (node
 	secure
 	rai_lib
+	rai_protobuf
 	libminiupnpc-static
 	argon2
 	lmdb
@@ -62,6 +69,7 @@ target_link_libraries (node
 	Boost::system
 	Boost::thread
 	Boost::boost
+	${PROTOBUF_LIBRARY}
 	${CMAKE_DL_LIBS}
 	)
 

--- a/rai/node/api.cpp
+++ b/rai/node/api.cpp
@@ -1,0 +1,139 @@
+#include <rai/lib/interface.h>
+#include <rai/node/api.hpp>
+#include <rai/node/node.hpp>
+
+using RequestType = nano::api::RequestType;
+
+/** RPC specific errors messages */
+std::string nano::error_api_messages::message (int ev) const
+{
+	switch (static_cast<nano::error_api> (ev))
+	{
+		case nano::error_api::generic:
+			return "Unknown error";
+		case nano::error_api::bad_threshold_number:
+			return "Bad threshold number";
+		case nano::error_api::control_disabled:
+			return "Control is disabled";
+		case nano::error_api::invalid_count_limit:
+			return "Invalid count limit";
+		case nano::error_api::invalid_offset:
+			return "Invalid offset";
+		case nano::error_api::invalid_sources_number:
+			return "Invalid sources number";
+		case nano::error_api::invalid_starting_account:
+			return "Invalid starting account";
+		case nano::error_api::invalid_destinations_number:
+			return "Invalid destinations number";
+		case nano::error_api::unsupport_message:
+			return "Unsupported message";
+	}
+
+	return "Invalid error error";
+}
+
+nano::api::api_handler::api_handler (rai::node & node_a) :
+node (node_a)
+{
+}
+
+auto nano::api::api_handler::request (nano::api::req_account_pending request_a) -> maybe_unique_ptr<nano::api::res_account_pending>
+{
+	std::error_code ec;
+	auto res = std::make_unique<nano::api::res_account_pending> ();
+
+	rai::uint128_union threshold (0);
+	if (request_a.has_threshold ())
+	{
+		if (threshold.decode_dec (request_a.threshold ().value ()))
+		{
+			ec = error_api::bad_threshold_number;
+		}
+	}
+
+	if (!ec)
+	{
+		auto transaction (node.store.tx_begin_read ());
+		for (auto & account_text : request_a.accounts ())
+		{
+			rai::uint256_union account;
+			if (!account.decode_account (account_text))
+			{
+				auto pending_account = res->add_pending ();
+				pending_account->set_account (account_text);
+				rai::account end (account.number () + 1);
+				for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))), n (node.store.pending_begin (transaction, rai::pending_key (end, 0))); i != n && pending_account->block_info_size () < request_a.count (); ++i)
+				{
+					rai::pending_info info (i->second);
+					if (info.amount.number () >= threshold.number ())
+					{
+						rai::pending_key key (i->first);
+						auto block_info = pending_account->add_block_info ();
+						block_info->set_hash (key.hash.to_string ());
+						if (request_a.source ())
+						{
+							block_info->set_amount (info.amount.number ().convert_to<std::string> ());
+							block_info->set_source (info.source.to_account ());
+						}
+					}
+				}
+			}
+			else
+			{
+				ec = nano::error_common::bad_account_number;
+				break;
+			}
+		}
+	}
+
+	return either (res, ec);
+}
+
+auto nano::api::api_handler::request (nano::api::req_ping request_a) -> maybe_unique_ptr<nano::api::res_ping>
+{
+	auto res = std::make_unique<nano::api::res_ping> ();
+	res->set_id (request_a.id ());
+	return std::move (res);
+}
+
+auto nano::api::api_handler::request (req_address_valid request_a) -> maybe_unique_ptr<nano::api::res_address_valid>
+{
+	auto res = std::make_unique<nano::api::res_address_valid> ();
+	res->set_valid (xrb_valid_address (request_a.address ().c_str ()) == 0);
+	return std::move (res);
+}
+
+template <typename REQUST_TYPE>
+decltype (auto) nano::api::api_handler::parse_and_request (std::vector<uint8_t> buffer_a)
+{
+	REQUST_TYPE req_obj;
+	req_obj.ParseFromArray (buffer_a.data (), buffer_a.size ());
+	return request (req_obj);
+}
+
+auto nano::api::api_handler::parse (nano::api::RequestType request_type_a, std::vector<uint8_t> buffer_a) -> maybe_unique_ptr<google::protobuf::Message>
+{
+	maybe_unique_ptr<google::protobuf::Message> msg;
+	switch (request_type_a)
+	{
+		case RequestType::PING:
+		{
+			msg = parse_and_request<req_ping> (buffer_a);
+			break;
+		}
+		case RequestType::ACCOUNT_PENDING:
+		{
+			msg = parse_and_request<req_account_pending> (buffer_a);
+			break;
+		}
+		case RequestType::ADDRESS_VALID:
+		{
+			msg = parse_and_request<req_address_valid> (buffer_a);
+			break;
+		}
+		default:
+			return make_unexpected (nano::error_api::unsupport_message);
+	};
+
+	return msg;
+}

--- a/rai/node/api.hpp
+++ b/rai/node/api.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <api-c/accounts.pb.h>
+#include <api-c/core.pb.h>
+#include <api-c/util.pb.h>
+#include <memory>
+#include <rai/lib/errors.hpp>
+
+// Convenience aliases
+template <class T>
+using maybe_unique_ptr = expected<std::unique_ptr<T>, std::error_code>;
+template <class T>
+using maybe_shared_ptr = expected<std::unique_ptr<T>, std::error_code>;
+
+namespace rai
+{
+class node;
+}
+
+namespace nano
+{
+/** API handler errors. Do not change or reuse enum values as these propagate to clients. */
+enum class error_api
+{
+	generic = 1,
+	bad_threshold_number = 2,
+	control_disabled = 3,
+	unsupport_message = 4,
+	invalid_count_limit = 5,
+	invalid_offset = 6,
+	invalid_sources_number = 7,
+	invalid_starting_account = 8,
+	invalid_destinations_number = 9
+};
+
+namespace api
+{
+	/**
+ 	 * Implements the Node API actions
+ 	 */
+	class api_handler
+	{
+	public:
+		api_handler (rai::node & node_a);
+
+		auto parse (nano::api::RequestType query_type_a, std::vector<uint8_t> buffer_a) -> maybe_unique_ptr<google::protobuf::Message>;
+
+		// core messages
+		auto request (req_ping request) -> maybe_unique_ptr<nano::api::res_ping>;
+		auto request (req_account_pending request) -> maybe_unique_ptr<res_account_pending>;
+
+		// util messages
+		auto request (req_address_valid request) -> maybe_unique_ptr<nano::api::res_address_valid>;
+
+	private:
+		rai::node & node;
+		template <typename REQUEST_TYPE>
+		decltype (auto) parse_and_request (std::vector<uint8_t> buffer_a);
+	};
+}
+}
+
+REGISTER_ERROR_CODES (nano, error_api)

--- a/rai/node/ipc.cpp
+++ b/rai/node/ipc.cpp
@@ -1,0 +1,452 @@
+#include <algorithm>
+#include <api-c/core.pb.h>
+#include <boost/array.hpp>
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+#include <boost/endian/conversion.hpp>
+#include <boost/thread/thread_time.hpp>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <rai/node/common.hpp>
+#include <rai/node/ipc.hpp>
+#include <rai/node/node.hpp>
+#include <thread>
+
+using namespace boost::log;
+
+std::string nano::error_ipc_messages::message (int ev) const
+{
+	switch (static_cast<nano::error_ipc> (ev))
+	{
+		case nano::error_ipc::generic:
+			return "Unknown error";
+		case nano::error_ipc::invalid_preamble:
+			return "Invalid preamble";
+	}
+}
+
+bool nano::ipc::ipc_config::deserialize_json (boost::property_tree::ptree & tree_a)
+{
+	bool error = false;
+
+	auto tcp_l (tree_a.get_child_optional ("tcp"));
+	if (tcp_l)
+	{
+		transport_tcp.io_threads = tcp_l->get<size_t> ("io_threads", std::max (4u, std::thread::hardware_concurrency ()));
+		transport_tcp.enabled = tcp_l->get<bool> ("enable", transport_tcp.enabled);
+		transport_tcp.control_enabled = tcp_l->get<bool> ("enable_control", transport_tcp.control_enabled);
+		transport_tcp.address = tcp_l->get<std::string> ("address", transport_tcp.address);
+		transport_tcp.port = tcp_l->get<uint16_t> ("port", transport_tcp.port);
+		transport_tcp.io_timeout = tcp_l->get<size_t> ("io_timeout", transport_tcp.io_timeout);
+	}
+
+	auto domain_l (tree_a.get_child_optional ("local"));
+	if (domain_l)
+	{
+		transport_domain.io_threads = domain_l->get<size_t> ("io_threads", std::max (4u, std::thread::hardware_concurrency ()));
+		transport_domain.enabled = domain_l->get<bool> ("enable", transport_domain.enabled);
+		transport_domain.control_enabled = domain_l->get<bool> ("enable_control", transport_domain.control_enabled);
+		transport_domain.path = domain_l->get<std::string> ("path", transport_domain.path);
+		transport_domain.io_timeout = domain_l->get<size_t> ("io_timeout", transport_domain.io_timeout);
+	}
+
+	return error;
+}
+
+/** A client session that manages its own lifetime */
+template <typename SOCKET_TYPE>
+class session : public std::enable_shared_from_this<session<SOCKET_TYPE>>
+{
+public:
+	session (rai::node & node_a, nano::api::api_handler & handler_a, boost::asio::io_context & io_context_a, nano::ipc::ipc_config_transport & config_transport_a) :
+	node (node_a), handler (handler_a), io_context (io_context_a), socket (io_context_a), writer_strand (io_context_a), io_timer (io_context_a), config_transport (config_transport_a)
+	{
+	}
+
+	~session ()
+	{
+		BOOST_LOG (node.log) << "IPC: session ended";
+	}
+
+	SOCKET_TYPE & get_socket ()
+	{
+		return socket;
+	}
+
+	/**
+	 * Async read of exactly \p size bytes. The callback is called only when all the data is available and
+	 * no error has occurred. On error, the error is logged, the read cycle stops and the session ends. Clients
+	 * are expected to implement reconnect logic.
+	 */
+	void async_read_exactly (void * buff_a, size_t size_a, std::function<void()> fn)
+	{
+		async_read_exactly (buff_a, size_a, config_transport.io_timeout, fn);
+	}
+
+	/**
+	 * Async read of exactly \p size bytes and a specific timeout.
+	 * @see async_read_exactly (void *, size_t, std::function<void()>)
+	 */
+	void async_read_exactly (void * buff_a, size_t size, size_t timeout_seconds, std::function<void()> fn)
+	{
+		timer_start (timeout_seconds);
+		boost::asio::async_read (socket,
+		boost::asio::buffer (buff_a, size),
+		boost::asio::transfer_exactly (size),
+		boost::bind (&session::handle_read_or_error,
+		this->shared_from_this (),
+		fn,
+		boost::asio::placeholders::error,
+		boost::asio::placeholders::bytes_transferred));
+	}
+
+	void handle_read_or_error (std::function<void()> fn, const boost::system::error_code & error, size_t bytes_transferred)
+	{
+		timer_cancel ();
+		if ((boost::asio::error::connection_aborted == error) || (boost::asio::error::connection_reset == error))
+		{
+			BOOST_LOG (node.log) << boost::str (boost::format ("IPC: error reading %1% ") % error.message ());
+		}
+		else if (bytes_transferred > 0)
+		{
+			fn ();
+		}
+	}
+
+	void respond (nano::api::RequestType type, google::protobuf::Message & res)
+	{
+		nano::api::response response_header;
+		response_header.set_type (type);
+		response_header.set_error_code (0);
+		std::string str_response_header;
+		response_header.SerializeToString (&str_response_header);
+
+		std::string response;
+		res.SerializeToString (&response);
+
+		uint32_t size_header = boost::endian::native_to_big ((uint32_t)str_response_header.size ());
+		uint32_t size_response = boost::endian::native_to_big ((uint32_t)response.size ());
+		std::vector<boost::asio::mutable_buffer> bufs = {
+			boost::asio::buffer (preamble, 4),
+			boost::asio::buffer (&size_header, 4),
+			boost::asio::buffer (str_response_header),
+			boost::asio::buffer (&size_response, 4),
+			boost::asio::buffer (response)
+		};
+
+		timer_start (config_transport.io_timeout);
+		boost::asio::async_write (socket, bufs,
+		writer_strand.wrap (
+		boost::bind (
+		&session::handle_write,
+		this->shared_from_this (),
+		boost::asio::placeholders::error,
+		boost::asio::placeholders::bytes_transferred)));
+	}
+
+	void respond_error (nano::api::RequestType type, std::error_code ec, bool close = false)
+	{
+		nano::api::response response_header;
+		response_header.set_type (type);
+		response_header.set_error_code (ec.value ());
+		response_header.set_error_message (ec.message ());
+		response_header.set_error_category (ec.category ().name ());
+		std::string str_response_header;
+		response_header.SerializeToString (&str_response_header);
+
+		uint32_t size_header = boost::endian::native_to_big ((uint32_t)str_response_header.size ());
+
+		std::vector<boost::asio::mutable_buffer> bufs = {
+			boost::asio::buffer (preamble, 4),
+			boost::asio::buffer (&size_header, 4),
+			boost::asio::buffer (str_response_header)
+		};
+
+		timer_start (config_transport.io_timeout);
+		boost::asio::async_write (socket, bufs,
+		writer_strand.wrap (
+		boost::bind (
+		&session::handle_write,
+		this->shared_from_this (),
+		boost::asio::placeholders::error,
+		boost::asio::placeholders::bytes_transferred)));
+	}
+
+	/** Write callback. If no error occurs, the session starts waiting for another request. */
+	void handle_write (const boost::system::error_code & error, size_t bytes_transferred)
+	{
+		timer_cancel ();
+		if (!error)
+		{
+			read_next_request ();
+		}
+		else
+		{
+			BOOST_LOG (node.log) << "IPC: Write failed: " << error.message ();
+		}
+	}
+
+	/** Hand the raw protobuffer over to the API handler which parses and executes the query */
+	void handle_query ()
+	{
+		node.stats.inc (rai::stat::type::api, rai::stat::detail::invocations);
+		auto res = handler.parse (request_header.type (), buffer);
+		if (res)
+		{
+			respond (request_header.type (), *res.value ());
+		}
+		else
+		{
+			respond_error (request_header.type (), res.error ());
+		}
+	}
+
+	/** Async request reader */
+	void read_next_request ()
+	{
+		auto this_l = this->shared_from_this ();
+
+		// Await preamble
+		buffer.resize (4);
+		async_read_exactly (buffer.data (), buffer.size (), std::numeric_limits<size_t>::max (), [this_l]() {
+			if (this_l->buffer[0] != 'N' || this_l->buffer[1] != 0x0)
+			{
+				BOOST_LOG (this_l->node.log) << "IPC: Invalid preamble";
+				this_l->respond_error (nano::api::RequestType::INVALID, nano::error_ipc::invalid_preamble, true);
+			}
+			else
+			{
+				// Size of query header
+				this_l->async_read_exactly (&this_l->buffer_size, 4, [this_l]() {
+					boost::endian::big_to_native_inplace (this_l->buffer_size);
+					this_l->buffer.resize (this_l->buffer_size);
+					// Query header
+					this_l->async_read_exactly (this_l->buffer.data (), this_l->buffer_size, [this_l]() {
+						if (this_l->request_header.ParseFromArray (this_l->buffer.data (), this_l->buffer.size ()))
+						{
+							// Length of query
+							this_l->async_read_exactly (&this_l->buffer_size, 4, [this_l]() {
+								boost::endian::big_to_native_inplace (this_l->buffer_size);
+								this_l->buffer.resize (this_l->buffer_size);
+								// Query
+								this_l->async_read_exactly (this_l->buffer.data (), this_l->buffer_size, [this_l]() {
+									this_l->handle_query ();
+								});
+							});
+						}
+						else
+						{
+							BOOST_LOG (this_l->node.log) << "IPC: Could not parse query header";
+						}
+					});
+				});
+			}
+		});
+	}
+
+	void close ()
+	{
+		socket.shutdown (boost::asio::ip::tcp::socket::shutdown_both);
+		socket.close ();
+	}
+
+protected:
+	/**
+	 * Start IO timer.
+	 * @param sec Seconds to wait. To wait indefinitely, use std::numeric_limits<size_t>::max().
+	 */
+	void timer_start (size_t sec)
+	{
+		if (sec < std::numeric_limits<size_t>::max ())
+		{
+			io_timer.expires_from_now (boost::posix_time::seconds (sec));
+			io_timer.async_wait ([this](const boost::system::error_code & ec) {
+				if (!ec)
+				{
+					this->timer_expired ();
+				}
+			});
+		}
+	}
+
+	void timer_expired (void)
+	{
+		close ();
+		BOOST_LOG (node.log) << "IPC: IO timeout";
+	}
+
+	void timer_cancel (void)
+	{
+		boost::system::error_code ec;
+		this->io_timer.cancel (ec);
+	}
+
+private:
+	rai::node & node;
+	nano::api::api_handler & handler;
+	nano::api::request request_header;
+
+	/**
+	 * IO context from node, or per-transport, depending on configuration.
+	 */
+	boost::asio::io_context & io_context;
+
+	/** A socket of the given asio type */
+	SOCKET_TYPE socket;
+
+	/**
+	 * Allow multiple threads to write simultaniously. This allows for future extensions like
+	 * async callback feeds without locking.
+	 */
+	boost::asio::io_context::strand writer_strand;
+
+	/** Receives the size of header/query payloads */
+	uint32_t buffer_size = 0;
+
+	/** Buffer used to store data received from the client */
+	std::vector<uint8_t> buffer;
+
+	/** IO operation timer */
+	boost::asio::deadline_timer io_timer;
+
+	/** Transport configuration */
+	nano::ipc::ipc_config_transport & config_transport;
+
+	/** Preamble is 'N', encoding, major, minor */
+	uint8_t preamble[4]{ 'N', 0, nano::api::VERSION_MAJOR, nano::api::VERSION_MINOR };
+};
+
+/** Domain and TCP socket transport */
+template <typename ACCEPTOR_TYPE, typename SOCKET_TYPE, typename ENDPOINT_TYPE>
+class socket_transport : public nano::ipc::transport
+{
+public:
+	socket_transport (rai::node & node_a, nano::api::api_handler & handler_a, ENDPOINT_TYPE ep, nano::ipc::ipc_config_transport & config_transport_a, int concurrency) :
+	node (node_a), config_transport (config_transport_a), handler (handler_a)
+	{
+		// Using a per-transport event dispatcher?
+		if (concurrency > 0)
+		{
+			io_context = std::make_unique<boost::asio::io_context> ();
+		}
+
+		boost::asio::socket_base::reuse_address option (true);
+		boost::asio::socket_base::keep_alive option_keepalive (true);
+		acceptor = std::make_unique<ACCEPTOR_TYPE> (context (), ep);
+		acceptor->set_option (option);
+		acceptor->set_option (option_keepalive);
+		accept ();
+
+		// Start serving IO requests. If concurrency is 0, the node's thread pool is used instead.
+		if (concurrency > 0)
+		{
+			runner = std::make_unique<rai::thread_runner> (*io_context, concurrency);
+		}
+	}
+
+	boost::asio::io_context & context () const
+	{
+		return io_context ? *io_context : node.service;
+	}
+
+	void accept ()
+	{
+		std::shared_ptr<session<SOCKET_TYPE>> new_session (new session<SOCKET_TYPE> (node, handler, io_context ? *io_context : node.service, config_transport));
+
+		acceptor->async_accept (new_session->get_socket (),
+		boost::bind (&socket_transport::handle_accept, this, new_session,
+		boost::asio::placeholders::error));
+	}
+
+	void handle_accept (std::shared_ptr<session<SOCKET_TYPE>> new_session, const boost::system::error_code & error)
+	{
+		if (!error)
+		{
+			new_session->read_next_request ();
+		}
+
+		accept ();
+	}
+
+	void stop ()
+	{
+		io_context->stop ();
+
+		if (runner)
+		{
+			runner->join ();
+		}
+	}
+
+private:
+	rai::node & node;
+	nano::ipc::ipc_config_transport & config_transport;
+	nano::api::api_handler & handler;
+	std::unique_ptr<rai::thread_runner> runner;
+	std::unique_ptr<boost::asio::io_context> io_context;
+	std::unique_ptr<ACCEPTOR_TYPE> acceptor;
+};
+
+/** Domain socket file remover */
+class nano::ipc::dsock_file_remover
+{
+public:
+	dsock_file_remover (std::string file) :
+	filename (file)
+	{
+		std::remove (filename.c_str ());
+	}
+	~dsock_file_remover ()
+	{
+		std::remove (filename.c_str ());
+	}
+	std::string filename;
+};
+
+nano::ipc::ipc_server::ipc_server (rai::node & node_a) :
+node (node_a),
+handler (node_a),
+stopped (false)
+{
+	try
+	{
+		if (node_a.config.ipc_config.transport_domain.enabled)
+		{
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+			size_t threads = node_a.config.ipc_config.transport_domain.io_threads;
+			file_remover = std::make_unique<dsock_file_remover> (node_a.config.ipc_config.transport_domain.path);
+			boost::asio::local::stream_protocol::endpoint ep{ node_a.config.ipc_config.transport_domain.path };
+			transports.push_back (std::make_shared<socket_transport<boost::asio::local::stream_protocol::acceptor, boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>> (node_a, handler, ep, node_a.config.ipc_config.transport_domain, threads));
+#else
+			BOOST_LOG (node.log) << "IPC: Domain sockets are not supported on this platform";
+#endif
+		}
+
+		if (node_a.config.ipc_config.transport_tcp.enabled)
+		{
+			size_t threads = node_a.config.ipc_config.transport_tcp.io_threads;
+			transports.push_back (std::make_shared<socket_transport<boost::asio::ip::tcp::acceptor, boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>> (node_a, handler, boost::asio::ip::tcp::endpoint (boost::asio::ip::tcp::v6 (), node_a.config.ipc_config.transport_tcp.port), node_a.config.ipc_config.transport_domain, threads));
+		}
+
+		BOOST_LOG (node.log) << "IPC: server started";
+	}
+	catch (std::runtime_error const & ex)
+	{
+		BOOST_LOG (node.log) << "IPC: " << ex.what ();
+	}
+}
+
+nano::ipc::ipc_server::~ipc_server ()
+{
+	BOOST_LOG (node.log) << "IPC: server stopped";
+}
+
+void nano::ipc::ipc_server::stop ()
+{
+	for (auto & transport : transports)
+	{
+		transport->stop ();
+	}
+	stopped = true;
+}

--- a/rai/node/ipc.hpp
+++ b/rai/node/ipc.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <atomic>
+#include <boost/property_tree/ptree.hpp>
+#include <rai/lib/errors.hpp>
+#include <rai/node/api.hpp>
+#include <string>
+#include <vector>
+
+namespace rai
+{
+class node;
+}
+
+namespace nano
+{
+/** IPC errors. Do not change or reuse enum values as these propagate to clients. */
+enum class error_ipc
+{
+	generic = 1,
+	invalid_preamble = 2,
+};
+
+namespace ipc
+{
+	/** Removes domain socket files on startup and shutdown */
+	class dsock_file_remover;
+
+	/** IPC transport interface */
+	class transport
+	{
+	public:
+		virtual void stop () = 0;
+		virtual ~transport () = default;
+	};
+
+	/** Base class for transport configurations */
+	class ipc_config_transport
+	{
+	public:
+		bool enabled{ false };
+		bool control_enabled{ false };
+		size_t io_timeout{ 15 };
+		size_t io_threads;
+	};
+
+	/** Domain socket specific transport config */
+	class ipc_config_domain_socket : public ipc_config_transport
+	{
+	public:
+		/**
+		 * Default domain socket path for Unix systems. Once we support Windows 10 usocks, this value
+		 * will be conditional on OS.
+		 */
+		std::string path{ "/tmp/nano" };
+	};
+
+	/** TCP specific transport config */
+	class ipc_config_tcp_socket : public ipc_config_transport
+	{
+	public:
+		std::string address{ "::1" };
+		uint16_t port{ 7077 };
+	};
+
+	/** IPC configuration */
+	class ipc_config
+	{
+	public:
+		/** Reads the JSON "ipc" node from the config, if present */
+		bool deserialize_json (boost::property_tree::ptree & tree_a);
+		ipc_config_domain_socket transport_domain;
+		ipc_config_tcp_socket transport_tcp;
+	};
+
+	/** IPC server */
+	class ipc_server
+	{
+	public:
+		ipc_server (rai::node & node);
+		~ipc_server ();
+		void stop ();
+
+	private:
+		rai::node & node;
+		nano::api::api_handler handler;
+		std::atomic<bool> stopped;
+		std::unique_ptr<dsock_file_remover> file_remover;
+		std::vector<std::shared_ptr<nano::ipc::transport>> transports;
+	};
+}
+}
+
+REGISTER_ERROR_CODES (nano, error_ipc)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1278,7 +1278,8 @@ block_processor_thread ([this]() {
 	this->block_processor.process_blocks ();
 }),
 online_reps (*this),
-stats (config.stat_config)
+stats (config.stat_config),
+ipc_server (*this)
 {
 	wallets.observer = [this](bool active) {
 		observers.wallet.notify (active);
@@ -1687,6 +1688,7 @@ void rai::node::stop ()
 	{
 		block_processor_thread.join ();
 	}
+	ipc_server.stop ();
 	active.stop ();
 	network.stop ();
 	bootstrap_initiator.stop ();

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -2,6 +2,7 @@
 
 #include <rai/lib/work.hpp>
 #include <rai/node/bootstrap.hpp>
+#include <rai/node/ipc.hpp>
 #include <rai/node/logging.hpp>
 #include <rai/node/nodeconfig.hpp>
 #include <rai/node/peers.hpp>
@@ -471,6 +472,7 @@ public:
 	rai::block_arrival block_arrival;
 	rai::online_reps online_reps;
 	rai::stat stats;
+	nano::ipc::ipc_server ipc_server;
 	rai::keypair node_id;
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;

--- a/rai/node/nodeconfig.cpp
+++ b/rai/node/nodeconfig.cpp
@@ -292,6 +292,11 @@ bool rai::node_config::deserialize_json (bool & upgraded_a, boost::property_tree
 		{
 			result |= stat_config.deserialize_json (stat_config_l.get ());
 		}
+		auto ipc_config_l (tree_a.get_child_optional ("ipc"));
+		if (ipc_config_l)
+		{
+			result |= ipc_config.deserialize_json (ipc_config_l.get ());
+		}
 		auto online_weight_minimum_l (tree_a.get<std::string> ("online_weight_minimum"));
 		auto online_weight_quorum_l (tree_a.get<std::string> ("online_weight_quorum"));
 		auto password_fanout_l (tree_a.get<std::string> ("password_fanout"));

--- a/rai/node/nodeconfig.hpp
+++ b/rai/node/nodeconfig.hpp
@@ -3,6 +3,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <chrono>
 #include <rai/lib/numbers.hpp>
+#include <rai/node/ipc.hpp>
 #include <rai/node/logging.hpp>
 #include <rai/node/stats.hpp>
 #include <vector>
@@ -42,6 +43,7 @@ public:
 	std::string callback_target;
 	int lmdb_max_dbs;
 	rai::stat_config stat_config;
+	nano::ipc::ipc_config ipc_config;
 	rai::uint256_union epoch_block_link;
 	rai::account epoch_block_signer;
 	std::chrono::milliseconds block_processor_batch_max_time;

--- a/rai/node/stats.cpp
+++ b/rai/node/stats.cpp
@@ -348,6 +348,9 @@ std::string rai::stat::type_to_string (uint32_t key)
 		case rai::stat::type::message:
 			res = "message";
 			break;
+		case rai::stat::type::api:
+			res = "api";
+			break;
 	}
 	return res;
 }
@@ -396,6 +399,9 @@ std::string rai::stat::detail_to_string (uint32_t key)
 			break;
 		case rai::stat::detail::initiate:
 			res = "initiate";
+			break;
+		case rai::stat::detail::invocations:
+			res = "invocations";
 			break;
 		case rai::stat::detail::insufficient_work:
 			res = "insufficient_work";

--- a/rai/node/stats.hpp
+++ b/rai/node/stats.hpp
@@ -184,6 +184,7 @@ public:
 		bootstrap,
 		vote,
 		http_callback,
+		api,
 		peering,
 		udp
 	};
@@ -244,6 +245,9 @@ public:
 
 		// peering
 		handshake,
+
+		// api
+		invocations,
 	};
 
 	/** Direction of the stat. If the direction is irrelevant, use in */

--- a/rai/slow_test/CMakeLists.txt
+++ b/rai/slow_test/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable (slow_test
 	node.cpp)
 
-target_link_libraries (slow_test node secure gtest_main gtest libminiupnpc-static Boost::boost)
+target_link_libraries (slow_test node secure gtest_main gtest libminiupnpc-static Boost::boost ${PROTOBUF_LIBRARY})


### PR DESCRIPTION
I've started documenting this over at https://nanoapi.github.io/. There's a chapter regarding the node implementation which should be useful when reviewing this.

The PR is mostly about the IPC/API *framework* - only a handful of actual APIs are added, just to get started. Going forward, people can submit PR's to extend the API, hopefully generating good discussions on how to best create focused and composable messages.

There are currently clients for C, C++, Go and Python, as well as a REST server. Rust, Node and JVM support are in the pipeline:
https://github.com/nanoapi/

If this PR is accepted, I can hand over the nanoapi org to core, or the repositories can be moved into the official repo (though a separate repo may make it easier to have contributors for client API stuff?)

Another git submodule is added for protobuf, as this seems to be the only robust way to integrate it with CMake on all OS's, so be sure to run `git submodule update --init --recursive` before building.
