### PR TITLE
Add epoch blocks to disable old type blocks

### DIFF
--- a/rai/blockstore.cpp
+++ b/rai/blockstore.cpp
@@ -562,7 +562,6 @@ void rai::block_store::upgrade_v10_to_v11 (MDB_txn * transaction_a)
 	mdb_drop (transaction_a, unsynced, 1);
 }
 
-
 void rai::block_store::upgrade_v11_to_v12 (MDB_txn * transaction_a)
 {
 	version_put (transaction_a, 12);

--- a/rai/blockstore.cpp
+++ b/rai/blockstore.cpp
@@ -608,7 +608,7 @@ uint8_t rai::block_store::block_version (MDB_txn * transaction_a, rai::block_has
 	rai::block_type type;
 	rai::mdb_val value;
 	auto status (mdb_get (transaction_a, state_blocks, rai::mdb_val (hash_a), value));
-	assert (status == 0 || (status == MDB_NOTFOUND && block_exists (transaction_a, hash_a)));
+	assert (status == 0 || status == MDB_NOTFOUND);
 	uint8_t result (0);
 	if (status == 0)
 	{
@@ -1027,6 +1027,8 @@ bool rai::block_store::pending_get (MDB_txn * transaction_a, rai::pending_key co
 		assert (!error1);
 		auto error2 (rai::read (stream, pending_a.amount));
 		assert (!error2);
+		auto error3 (rai::read (stream, pending_a.min_version));
+		assert (!error3);
 	}
 	return result;
 }

--- a/rai/blockstore.cpp
+++ b/rai/blockstore.cpp
@@ -1021,7 +1021,7 @@ bool rai::block_store::pending_get (MDB_txn * transaction_a, rai::pending_key co
 	else
 	{
 		result = false;
-		assert (value.size () == sizeof (pending_a.source.bytes) + sizeof (pending_a.amount.bytes));
+		assert (value.size () == sizeof (pending_a.source.bytes) + sizeof (pending_a.amount.bytes) + sizeof (pending_a.min_version));
 		rai::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
 		auto error1 (rai::read (stream, pending_a.source));
 		assert (!error1);

--- a/rai/blockstore.hpp
+++ b/rai/blockstore.hpp
@@ -50,7 +50,7 @@ public:
 
 	MDB_dbi block_database (rai::block_type);
 	void block_put_raw (MDB_txn *, MDB_dbi, rai::block_hash const &, MDB_val);
-	void block_put (MDB_txn *, rai::block_hash const &, rai::block const &, rai::block_hash const & = rai::block_hash (0));
+	void block_put (MDB_txn *, rai::block_hash const &, rai::block const &, rai::block_hash const & = rai::block_hash (0), uint8_t version = 0);
 	MDB_val block_get_raw (MDB_txn *, rai::block_hash const &, rai::block_type &);
 	rai::block_hash block_successor (MDB_txn *, rai::block_hash const &);
 	void block_successor_clear (MDB_txn *, rai::block_hash const &);
@@ -91,6 +91,7 @@ public:
 	rai::store_iterator block_info_begin (MDB_txn *);
 	rai::store_iterator block_info_end ();
 	rai::uint128_t block_balance (MDB_txn *, rai::block_hash const &);
+	uint8_t block_version (MDB_txn *, rai::block_hash const &);
 	static size_t const block_info_max = 32;
 
 	rai::uint128_t representation_get (MDB_txn *, rai::account const &);

--- a/rai/blockstore.hpp
+++ b/rai/blockstore.hpp
@@ -140,6 +140,7 @@ public:
 	void upgrade_v8_to_v9 (MDB_txn *);
 	void upgrade_v9_to_v10 (MDB_txn *);
 	void upgrade_v10_to_v11 (MDB_txn *);
+	void upgrade_v11_to_v12 (MDB_txn *);
 
 	// Requires a write transaction
 	rai::raw_key get_node_id (MDB_txn *);

--- a/rai/common.cpp
+++ b/rai/common.cpp
@@ -290,7 +290,8 @@ size_t rai::block_counts::sum ()
 
 rai::pending_info::pending_info () :
 source (0),
-amount (0)
+amount (0),
+min_version (0)
 {
 }
 

--- a/rai/common.hpp
+++ b/rai/common.hpp
@@ -110,13 +110,14 @@ std::unique_ptr<rai::block> deserialize_block (MDB_val const &);
 /**
  * Latest information about an account
  */
+#pragma pack(push, 1)
 class account_info
 {
 public:
 	account_info ();
 	account_info (MDB_val const &);
 	account_info (rai::account_info const &) = default;
-	account_info (rai::block_hash const &, rai::block_hash const &, rai::block_hash const &, rai::amount const &, uint64_t, uint64_t);
+	account_info (rai::block_hash const &, rai::block_hash const &, rai::block_hash const &, rai::amount const &, uint64_t, uint64_t, uint8_t);
 	void serialize (rai::stream &) const;
 	bool deserialize (rai::stream &);
 	bool operator== (rai::account_info const &) const;
@@ -129,24 +130,29 @@ public:
 	/** Seconds since posix epoch */
 	uint64_t modified;
 	uint64_t block_count;
+	uint8_t version;
 };
+#pragma pack(pop)
 
 /**
  * Information on an uncollected send
  */
+#pragma pack(push, 1)
 class pending_info
 {
 public:
 	pending_info ();
 	pending_info (MDB_val const &);
-	pending_info (rai::account const &, rai::amount const &);
+	pending_info (rai::account const &, rai::amount const &, uint8_t);
 	void serialize (rai::stream &) const;
 	bool deserialize (rai::stream &);
 	bool operator== (rai::pending_info const &) const;
 	rai::mdb_val val () const;
 	rai::account source;
 	rai::amount amount;
+	uint8_t min_version;
 };
+#pragma pack(pop)
 class pending_key
 {
 public:

--- a/rai/common.hpp
+++ b/rai/common.hpp
@@ -228,7 +228,7 @@ enum class process_result
 	old, // Already seen and was valid
 	negative_spend, // Malicious attempt to spend a negative amount
 	fork, // Malicious fork based on previous
-	unreceivable, // Source block doesn't exist or has already been received
+	unreceivable, // Source block doesn't exist, has already been received, or requires an account upgrade (epoch blocks)
 	gap_previous, // Block marked as previous is unknown
 	gap_source, // Block marked as source is unknown
 	opened_burn_account, // The impossible happened, someone found the private key associated with the public key '0'.

--- a/rai/common.hpp
+++ b/rai/common.hpp
@@ -233,6 +233,7 @@ enum class process_result
 	gap_source, // Block marked as source is unknown
 	opened_burn_account, // The impossible happened, someone found the private key associated with the public key '0'.
 	balance_mismatch, // Balance and amount delta don't match
+	representative_mismatch, // Representative is changed when it is not allowed
 	block_position // This block cannot follow the previous block
 };
 class process_return

--- a/rai/core_test/block_store.cpp
+++ b/rai/core_test/block_store.cpp
@@ -128,7 +128,7 @@ TEST (block_store, pending_iterator)
 	ASSERT_TRUE (!init);
 	rai::transaction transaction (store.environment, nullptr, true);
 	ASSERT_EQ (store.pending_end (), store.pending_begin (transaction));
-	store.pending_put (transaction, rai::pending_key (1, 2), { 2, 3 });
+	store.pending_put (transaction, rai::pending_key (1, 2), { 2, 3, 4 });
 	auto current (store.pending_begin (transaction));
 	ASSERT_NE (store.pending_end (), current);
 	rai::pending_key key1 (current->first);
@@ -137,6 +137,7 @@ TEST (block_store, pending_iterator)
 	rai::pending_info pending (current->second);
 	ASSERT_EQ (rai::account (2), pending.source);
 	ASSERT_EQ (rai::amount (3), pending.amount);
+	ASSERT_EQ (4, pending.min_version);
 }
 
 TEST (block_store, genesis)
@@ -313,7 +314,7 @@ TEST (block_store, frontier_retrieval)
 	rai::block_store store (init, rai::unique_path ());
 	ASSERT_TRUE (!init);
 	rai::account account1 (0);
-	rai::account_info info1 (0, 0, 0, 0, 0, 0);
+	rai::account_info info1 (0, 0, 0, 0, 0, 0, 0);
 	rai::transaction transaction (store.environment, nullptr, true);
 	store.account_put (transaction, account1, info1);
 	rai::account_info info2;
@@ -329,7 +330,7 @@ TEST (block_store, one_account)
 	rai::account account (0);
 	rai::block_hash hash (0);
 	rai::transaction transaction (store.environment, nullptr, true);
-	store.account_put (transaction, account, { hash, account, hash, 42, 100, 200 });
+	store.account_put (transaction, account, { hash, account, hash, 42, 100, 200, 0 });
 	auto begin (store.latest_begin (transaction));
 	auto end (store.latest_end ());
 	ASSERT_NE (end, begin);
@@ -374,8 +375,8 @@ TEST (block_store, two_account)
 	rai::account account2 (3);
 	rai::block_hash hash2 (4);
 	rai::transaction transaction (store.environment, nullptr, true);
-	store.account_put (transaction, account1, { hash1, account1, hash1, 42, 100, 300 });
-	store.account_put (transaction, account2, { hash2, account2, hash2, 84, 200, 400 });
+	store.account_put (transaction, account1, { hash1, account1, hash1, 42, 100, 300, 0 });
+	store.account_put (transaction, account2, { hash2, account2, hash2, 84, 200, 400, 0 });
 	auto begin (store.latest_begin (transaction));
 	auto end (store.latest_end ());
 	ASSERT_NE (end, begin);
@@ -407,8 +408,8 @@ TEST (block_store, latest_find)
 	rai::account account2 (3);
 	rai::block_hash hash2 (4);
 	rai::transaction transaction (store.environment, nullptr, true);
-	store.account_put (transaction, account1, { hash1, account1, hash1, 100, 0, 300 });
-	store.account_put (transaction, account2, { hash2, account2, hash2, 200, 0, 400 });
+	store.account_put (transaction, account1, { hash1, account1, hash1, 100, 0, 300, 0 });
+	store.account_put (transaction, account2, { hash2, account2, hash2, 200, 0, 400, 0 });
 	auto first (store.latest_begin (transaction));
 	auto second (store.latest_begin (transaction));
 	++second;

--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -513,14 +513,12 @@ TEST (node_config, serialization)
 	config1.receive_minimum = 10;
 	config1.online_weight_minimum = 10;
 	config1.online_weight_quorum = 10;
-	config1.password_fanout = 10;
+	config1.password_fanout = 20;
 	config1.enable_voting = false;
 	config1.callback_address = "test";
 	config1.callback_port = 10;
 	config1.callback_target = "test";
 	config1.lmdb_max_dbs = 256;
-	config1.epoch_block_link = 10;
-	config1.epoch_block_signer = 12;
 	boost::property_tree::ptree tree;
 	config1.serialize_json (tree);
 	rai::logging logging2;
@@ -538,11 +536,12 @@ TEST (node_config, serialization)
 	ASSERT_NE (config2.callback_port, config1.callback_port);
 	ASSERT_NE (config2.callback_target, config1.callback_target);
 	ASSERT_NE (config2.lmdb_max_dbs, config1.lmdb_max_dbs);
-	ASSERT_NE (config2.epoch_block_link, config1.epoch_block_link);
-	ASSERT_NE (config2.epoch_block_signer, config1.epoch_block_signer);
+
+	ASSERT_FALSE (tree.get_optional<std::string> ("epoch_block_link"));
+	ASSERT_FALSE (tree.get_optional<std::string> ("epoch_block_signer"));
 
 	bool upgraded (false);
-	config2.deserialize_json (upgraded, tree);
+	ASSERT_FALSE (config2.deserialize_json (upgraded, tree));
 	ASSERT_FALSE (upgraded);
 	ASSERT_EQ (config2.bootstrap_fraction_numerator, config1.bootstrap_fraction_numerator);
 	ASSERT_EQ (config2.peering_port, config1.peering_port);
@@ -555,8 +554,6 @@ TEST (node_config, serialization)
 	ASSERT_EQ (config2.callback_port, config1.callback_port);
 	ASSERT_EQ (config2.callback_target, config1.callback_target);
 	ASSERT_EQ (config2.lmdb_max_dbs, config1.lmdb_max_dbs);
-	ASSERT_EQ (config2.epoch_block_link, config1.epoch_block_link);
-	ASSERT_EQ (config2.epoch_block_signer, config1.epoch_block_signer);
 }
 
 TEST (node_config, v1_v2_upgrade)

--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -519,8 +519,8 @@ TEST (node_config, serialization)
 	config1.callback_port = 10;
 	config1.callback_target = "test";
 	config1.lmdb_max_dbs = 256;
-	config1.state_block_parse_canary = 10;
-	config1.state_block_generate_canary = 10;
+	config1.epoch_block_link = 10;
+	config1.epoch_block_signer = 12;
 	boost::property_tree::ptree tree;
 	config1.serialize_json (tree);
 	rai::logging logging2;
@@ -538,8 +538,8 @@ TEST (node_config, serialization)
 	ASSERT_NE (config2.callback_port, config1.callback_port);
 	ASSERT_NE (config2.callback_target, config1.callback_target);
 	ASSERT_NE (config2.lmdb_max_dbs, config1.lmdb_max_dbs);
-	ASSERT_NE (config2.state_block_parse_canary, config1.state_block_parse_canary);
-	ASSERT_NE (config2.state_block_generate_canary, config1.state_block_generate_canary);
+	ASSERT_NE (config2.epoch_block_link, config1.epoch_block_link);
+	ASSERT_NE (config2.epoch_block_signer, config1.epoch_block_signer);
 
 	bool upgraded (false);
 	config2.deserialize_json (upgraded, tree);
@@ -555,8 +555,8 @@ TEST (node_config, serialization)
 	ASSERT_EQ (config2.callback_port, config1.callback_port);
 	ASSERT_EQ (config2.callback_target, config1.callback_target);
 	ASSERT_EQ (config2.lmdb_max_dbs, config1.lmdb_max_dbs);
-	ASSERT_EQ (config2.state_block_parse_canary, config1.state_block_parse_canary);
-	ASSERT_EQ (config2.state_block_generate_canary, config1.state_block_generate_canary);
+	ASSERT_EQ (config2.epoch_block_link, config1.epoch_block_link);
+	ASSERT_EQ (config2.epoch_block_signer, config1.epoch_block_signer);
 }
 
 TEST (node_config, v1_v2_upgrade)

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -819,7 +819,7 @@ TEST (rpc, frontier)
 		{
 			rai::keypair key;
 			source[key.pub] = key.prv.data;
-			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0));
+			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, 0));
 		}
 	}
 	rai::keypair key;
@@ -859,7 +859,7 @@ TEST (rpc, frontier_limited)
 		{
 			rai::keypair key;
 			source[key.pub] = key.prv.data;
-			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0));
+			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, 0));
 		}
 	}
 	rai::keypair key;
@@ -889,7 +889,7 @@ TEST (rpc, frontier_startpoint)
 		{
 			rai::keypair key;
 			source[key.pub] = key.prv.data;
-			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0));
+			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, 0));
 		}
 	}
 	rai::keypair key;

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -1415,6 +1415,8 @@ TEST (rpc, pending)
 		blocks[hash] = amount;
 		boost::optional<std::string> source (i->second.get_optional<std::string> ("source"));
 		ASSERT_FALSE (source.is_initialized ());
+		boost::optional<uint8_t> min_version (i->second.get_optional<uint8_t> ("min_version"));
+		ASSERT_FALSE (min_version.is_initialized ());
 	}
 	ASSERT_EQ (blocks[block1->hash ()], 100);
 	request.put ("threshold", "101");
@@ -1428,6 +1430,7 @@ TEST (rpc, pending)
 	ASSERT_EQ (0, blocks_node.size ());
 	request.put ("threshold", "0");
 	request.put ("source", "true");
+	request.put ("min_version", "true");
 	test_response response2 (request, rpc, system.service);
 	while (response2.status == 0)
 	{
@@ -1444,6 +1447,7 @@ TEST (rpc, pending)
 		hash.decode_hex (i->first);
 		amounts[hash].decode_dec (i->second.get<std::string> ("amount"));
 		sources[hash].decode_account (i->second.get<std::string> ("source"));
+		ASSERT_EQ (i->second.get<uint8_t> ("min_version"), 0);
 	}
 	ASSERT_EQ (amounts[block1->hash ()], 100);
 	ASSERT_EQ (sources[block1->hash ()], rai::test_genesis_key.pub);
@@ -2570,6 +2574,8 @@ TEST (rpc, wallet_pending)
 			blocks[hash] = amount;
 			boost::optional<std::string> source (i->second.get_optional<std::string> ("source"));
 			ASSERT_FALSE (source.is_initialized ());
+			boost::optional<uint8_t> min_version (i->second.get_optional<uint8_t> ("min_version"));
+			ASSERT_FALSE (min_version.is_initialized ());
 		}
 	}
 	ASSERT_EQ (blocks[block1->hash ()], 100);
@@ -2584,6 +2590,7 @@ TEST (rpc, wallet_pending)
 	ASSERT_EQ (0, pending1.size ());
 	request.put ("threshold", "0");
 	request.put ("source", "true");
+	request.put ("min_version", "true");
 	test_response response2 (request, rpc, system0.service);
 	while (response2.status == 0)
 	{
@@ -2602,6 +2609,7 @@ TEST (rpc, wallet_pending)
 			hash.decode_hex (i->first);
 			amounts[hash].decode_dec (i->second.get<std::string> ("amount"));
 			sources[hash].decode_account (i->second.get<std::string> ("source"));
+			ASSERT_EQ (i->second.get<uint8_t> ("min_version"), 0);
 		}
 	}
 	ASSERT_EQ (amounts[block1->hash ()], 100);

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -2893,6 +2893,7 @@ TEST (rpc, account_info)
 	ASSERT_TRUE (time - stol (modified_timestamp) < 5);
 	std::string block_count (response.json.get<std::string> ("block_count"));
 	ASSERT_EQ ("2", block_count);
+	ASSERT_EQ (0, response.json.get<uint8_t> ("account_version"));
 	boost::optional<std::string> weight (response.json.get_optional<std::string> ("weight"));
 	ASSERT_FALSE (weight.is_initialized ());
 	boost::optional<std::string> pending (response.json.get_optional<std::string> ("pending"));

--- a/rai/ledger.cpp
+++ b/rai/ledger.cpp
@@ -131,15 +131,17 @@ public:
 			ledger.store.pending_del (transaction, key);
 			ledger.stats.inc (rai::stat::type::rollback, rai::stat::detail::send);
 		}
-		else if (!block_a.hashables.link.is_zero ())
+		else if (!block_a.hashables.link.is_zero () && block_a.hashables.link != ledger.epoch_link)
 		{
-			rai::pending_info pending_info (ledger.account (transaction, block_a.hashables.link), block_a.hashables.balance.number () - balance, info.version);
+			auto source_version (ledger.store.block_version (transaction, block_a.hashables.link));
+			rai::pending_info pending_info (ledger.account (transaction, block_a.hashables.link), block_a.hashables.balance.number () - balance, source_version);
 			ledger.store.pending_put (transaction, rai::pending_key (block_a.hashables.account, block_a.hashables.link), pending_info);
 			ledger.stats.inc (rai::stat::type::rollback, rai::stat::detail::receive);
 		}
 
 		assert (!error);
-		ledger.change_latest (transaction, block_a.hashables.account, block_a.hashables.previous, representative, balance, info.block_count - 1, info.version);
+		auto previous_version (ledger.store.block_version (transaction, block_a.hashables.previous));
+		ledger.change_latest (transaction, block_a.hashables.account, block_a.hashables.previous, representative, balance, info.block_count - 1, false, previous_version);
 
 		auto previous (ledger.store.block_get (transaction, block_a.hashables.previous));
 		if (previous != nullptr)
@@ -171,6 +173,7 @@ public:
 	void change_block (rai::change_block const &) override;
 	void state_block (rai::state_block const &) override;
 	void state_block_impl (rai::state_block const &);
+	void epoch_block_impl (rai::state_block const &);
 	rai::ledger & ledger;
 	MDB_txn * transaction;
 	rai::process_return result;
@@ -178,7 +181,17 @@ public:
 
 void ledger_processor::state_block (rai::state_block const & block_a)
 {
-	state_block_impl (block_a);
+	// Check if this is an epoch block
+	rai::account_info info;
+	ledger.store.account_get (transaction, block_a.hashables.account, info);
+	if (block_a.hashables.balance == info.balance && !ledger.epoch_link.is_zero () && block_a.hashables.link == ledger.epoch_link)
+	{
+		epoch_block_impl (block_a);
+	}
+	else
+	{
+		state_block_impl (block_a);
+	}
 }
 
 void ledger_processor::state_block_impl (rai::state_block const & block_a)
@@ -239,6 +252,7 @@ void ledger_processor::state_block_impl (rai::state_block const & block_a)
 								if (result.code == rai::process_result::progress)
 								{
 									result.code = result.amount == pending.amount ? rai::process_result::progress : rai::process_result::balance_mismatch;
+									account_version = std::max (account_version, pending.min_version);
 								}
 							}
 						}
@@ -253,7 +267,7 @@ void ledger_processor::state_block_impl (rai::state_block const & block_a)
 				{
 					ledger.stats.inc (rai::stat::type::ledger, rai::stat::detail::state_block);
 					result.state_is_send = is_send;
-					ledger.store.block_put (transaction, hash, block_a);
+					ledger.store.block_put (transaction, hash, block_a, account_version);
 
 					if (!info.rep_block.is_zero ())
 					{
@@ -281,6 +295,69 @@ void ledger_processor::state_block_impl (rai::state_block const & block_a)
 					}
 					// Frontier table is unnecessary for state blocks and this also prevents old blocks from being inserted on top of state blocks
 					result.account = block_a.hashables.account;
+				}
+			}
+		}
+	}
+}
+
+void ledger_processor::epoch_block_impl (rai::state_block const & block_a)
+{
+	auto hash (block_a.hash ());
+	auto existing (ledger.store.block_exists (transaction, hash));
+	result.code = existing ? rai::process_result::old : rai::process_result::progress; // Have we seen this block before? (Unambiguous)
+	if (result.code == rai::process_result::progress)
+	{
+		result.code = validate_message (ledger.epoch_signer, hash, block_a.signature) ? rai::process_result::bad_signature : rai::process_result::progress; // Is this block signed correctly (Unambiguous)
+		if (result.code == rai::process_result::progress)
+		{
+			result.code = block_a.hashables.account.is_zero () ? rai::process_result::opened_burn_account : rai::process_result::progress; // Is this for the burn account? (Unambiguous)
+			if (result.code == rai::process_result::progress)
+			{
+				rai::account_info info;
+				auto account_error (ledger.store.account_get (transaction, block_a.hashables.account, info));
+				if (!account_error)
+				{
+					// Account already exists
+					result.code = block_a.hashables.previous.is_zero () ? rai::process_result::fork : rai::process_result::progress; // Has this account already been opened? (Ambigious)
+					if (result.code == rai::process_result::progress)
+					{
+						result.code = ledger.store.block_exists (transaction, block_a.hashables.previous) ? rai::process_result::progress : rai::process_result::gap_previous; // Does the previous block exist in the ledger? (Unambigious)
+						if (result.code == rai::process_result::progress)
+						{
+							result.code = block_a.hashables.previous == info.head ? rai::process_result::progress : rai::process_result::fork; // Is the previous block the account's head block? (Ambigious)
+							if (result.code == rai::process_result::progress)
+							{
+								auto last_rep_block (ledger.store.block_get (transaction, info.rep_block));
+								assert (last_rep_block != nullptr);
+								result.code = block_a.hashables.representative == last_rep_block->representative () ? rai::process_result::progress : rai::process_result::representative_mismatch;
+							}
+						}
+					}
+				}
+				else
+				{
+					result.code = block_a.hashables.representative.is_zero () ? rai::process_result::progress : rai::process_result::representative_mismatch;
+				}
+				if (result.code == rai::process_result::progress)
+				{
+					result.code = info.version == 0 ? rai::process_result::progress : rai::process_result::block_position;
+					if (result.code == rai::process_result::progress)
+					{
+						result.code = block_a.hashables.balance == info.balance ? rai::process_result::progress : rai::process_result::balance_mismatch;
+						if (result.code == rai::process_result::progress)
+						{
+							ledger.stats.inc (rai::stat::type::ledger, rai::stat::detail::epoch_block);
+							result.account = block_a.hashables.account;
+							result.amount = 0;
+							ledger.store.block_put (transaction, hash, block_a, 1);
+							ledger.change_latest (transaction, block_a.hashables.account, hash, hash, info.balance, info.block_count + 1, true, 1);
+							if (!ledger.store.frontier_get (transaction, info.head).is_zero ())
+							{
+								ledger.store.frontier_del (transaction, info.head);
+							}
+						}
+					}
 				}
 			}
 		}
@@ -410,19 +487,23 @@ void ledger_processor::receive_block (rai::receive_block const & block_a)
 								result.code = ledger.store.pending_get (transaction, key, pending) ? rai::process_result::unreceivable : rai::process_result::progress; // Has this source already been received (Malformed)
 								if (result.code == rai::process_result::progress)
 								{
-									auto new_balance (info.balance.number () + pending.amount.number ());
-									rai::account_info source_info;
-									auto error (ledger.store.account_get (transaction, pending.source, source_info));
-									assert (!error);
-									ledger.store.pending_del (transaction, key);
-									ledger.store.block_put (transaction, hash, block_a);
-									ledger.change_latest (transaction, account, hash, info.rep_block, new_balance, info.block_count + 1);
-									ledger.store.representation_add (transaction, info.rep_block, pending.amount.number ());
-									ledger.store.frontier_del (transaction, block_a.hashables.previous);
-									ledger.store.frontier_put (transaction, hash, account);
-									result.account = account;
-									result.amount = pending.amount;
-									ledger.stats.inc (rai::stat::type::ledger, rai::stat::detail::receive);
+									result.code = pending.min_version == 0 ? rai::process_result::progress : rai::process_result::unreceivable; // Are we receiving a state-only send? (Malformed)
+									if (result.code == rai::process_result::progress)
+									{
+										auto new_balance (info.balance.number () + pending.amount.number ());
+										rai::account_info source_info;
+										auto error (ledger.store.account_get (transaction, pending.source, source_info));
+										assert (!error);
+										ledger.store.pending_del (transaction, key);
+										ledger.store.block_put (transaction, hash, block_a);
+										ledger.change_latest (transaction, account, hash, info.rep_block, new_balance, info.block_count + 1);
+										ledger.store.representation_add (transaction, info.rep_block, pending.amount.number ());
+										ledger.store.frontier_del (transaction, block_a.hashables.previous);
+										ledger.store.frontier_put (transaction, hash, account);
+										result.account = account;
+										result.amount = pending.amount;
+										ledger.stats.inc (rai::stat::type::ledger, rai::stat::detail::receive);
+									}
 								}
 							}
 						}
@@ -463,17 +544,21 @@ void ledger_processor::open_block (rai::open_block const & block_a)
 						result.code = block_a.hashables.account == rai::burn_account ? rai::process_result::opened_burn_account : rai::process_result::progress; // Is it burning 0 account? (Malicious)
 						if (result.code == rai::process_result::progress)
 						{
-							rai::account_info source_info;
-							auto error (ledger.store.account_get (transaction, pending.source, source_info));
-							assert (!error);
-							ledger.store.pending_del (transaction, key);
-							ledger.store.block_put (transaction, hash, block_a);
-							ledger.change_latest (transaction, block_a.hashables.account, hash, hash, pending.amount.number (), info.block_count + 1);
-							ledger.store.representation_add (transaction, hash, pending.amount.number ());
-							ledger.store.frontier_put (transaction, hash, block_a.hashables.account);
-							result.account = block_a.hashables.account;
-							result.amount = pending.amount;
-							ledger.stats.inc (rai::stat::type::ledger, rai::stat::detail::open);
+							result.code = pending.min_version == 0 ? rai::process_result::progress : rai::process_result::unreceivable; // Are we receiving a state-only send? (Malformed)
+							if (result.code == rai::process_result::progress)
+							{
+								rai::account_info source_info;
+								auto error (ledger.store.account_get (transaction, pending.source, source_info));
+								assert (!error);
+								ledger.store.pending_del (transaction, key);
+								ledger.store.block_put (transaction, hash, block_a);
+								ledger.change_latest (transaction, block_a.hashables.account, hash, hash, pending.amount.number (), info.block_count + 1);
+								ledger.store.representation_add (transaction, hash, pending.amount.number ());
+								ledger.store.frontier_put (transaction, hash, block_a.hashables.account);
+								result.account = block_a.hashables.account;
+								result.amount = pending.amount;
+								ledger.stats.inc (rai::stat::type::ledger, rai::stat::detail::open);
+							}
 						}
 					}
 				}
@@ -501,10 +586,12 @@ bool rai::shared_ptr_block_hash::operator() (std::shared_ptr<rai::block> const &
 	return lhs->hash () == rhs->hash ();
 }
 
-rai::ledger::ledger (rai::block_store & store_a, rai::stat & stat_a) :
+rai::ledger::ledger (rai::block_store & store_a, rai::stat & stat_a, rai::uint256_union const & epoch_link_a, rai::account const & epoch_signer_a) :
 store (store_a),
 stats (stat_a),
-check_bootstrap_weights (true)
+check_bootstrap_weights (true),
+epoch_link (epoch_link_a),
+epoch_signer (epoch_signer_a)
 {
 }
 

--- a/rai/ledger.cpp
+++ b/rai/ledger.cpp
@@ -267,7 +267,7 @@ void ledger_processor::state_block_impl (rai::state_block const & block_a)
 				{
 					ledger.stats.inc (rai::stat::type::ledger, rai::stat::detail::state_block);
 					result.state_is_send = is_send;
-					ledger.store.block_put (transaction, hash, block_a, account_version);
+					ledger.store.block_put (transaction, hash, block_a, 0, account_version);
 
 					if (!info.rep_block.is_zero ())
 					{
@@ -350,7 +350,7 @@ void ledger_processor::epoch_block_impl (rai::state_block const & block_a)
 							ledger.stats.inc (rai::stat::type::ledger, rai::stat::detail::epoch_block);
 							result.account = block_a.hashables.account;
 							result.amount = 0;
-							ledger.store.block_put (transaction, hash, block_a, 1);
+							ledger.store.block_put (transaction, hash, block_a, 0, 1);
 							ledger.change_latest (transaction, block_a.hashables.account, hash, hash, info.balance, info.block_count + 1, true, 1);
 							if (!ledger.store.frontier_get (transaction, info.head).is_zero ())
 							{

--- a/rai/ledger.cpp
+++ b/rai/ledger.cpp
@@ -205,16 +205,16 @@ void ledger_processor::state_block_impl (rai::state_block const & block_a)
 		if (result.code == rai::process_result::progress)
 		{
 			result.code = block_a.hashables.account.is_zero () ? rai::process_result::opened_burn_account : rai::process_result::progress; // Is this for the burn account? (Unambiguous)
-			uint8_t account_version (0);
 			if (result.code == rai::process_result::progress)
 			{
+				uint8_t account_version (0);
 				rai::account_info info;
-				account_version = info.version;
 				result.amount = block_a.hashables.balance;
 				auto is_send (false);
 				auto account_error (ledger.store.account_get (transaction, block_a.hashables.account, info));
 				if (!account_error)
 				{
+					account_version = info.version;
 					// Account already exists
 					result.code = block_a.hashables.previous.is_zero () ? rai::process_result::fork : rai::process_result::progress; // Has this account already been opened? (Ambigious)
 					if (result.code == rai::process_result::progress)

--- a/rai/ledger.hpp
+++ b/rai/ledger.hpp
@@ -17,7 +17,7 @@ using tally_t = std::map<rai::uint128_t, std::shared_ptr<rai::block>, std::great
 class ledger
 {
 public:
-	ledger (rai::block_store &, rai::stat &);
+	ledger (rai::block_store &, rai::stat &, rai::uint256_union const & = 1, rai::account const & = 0);
 	std::pair<rai::uint128_t, std::shared_ptr<rai::block>> winner (MDB_txn *, rai::votes const & votes_a);
 	// Map of weight -> associated block, ordered greatest to least
 	rai::tally_t tally (MDB_txn *, rai::votes const &);
@@ -51,5 +51,7 @@ public:
 	std::unordered_map<rai::account, rai::uint128_t> bootstrap_weights;
 	uint64_t bootstrap_weight_max_blocks;
 	std::atomic<bool> check_bootstrap_weights;
+	rai::uint256_union epoch_link;
+	rai::account epoch_signer;
 };
 };

--- a/rai/ledger.hpp
+++ b/rai/ledger.hpp
@@ -41,7 +41,7 @@ public:
 	rai::block_hash block_source (MDB_txn *, rai::block const &);
 	rai::process_return process (MDB_txn *, rai::block const &);
 	void rollback (MDB_txn *, rai::block_hash const &);
-	void change_latest (MDB_txn *, rai::account const &, rai::block_hash const &, rai::account const &, rai::uint128_union const &, uint64_t, bool = false);
+	void change_latest (MDB_txn *, rai::account const &, rai::block_hash const &, rai::account const &, rai::uint128_union const &, uint64_t, bool = false, uint8_t = 0);
 	void checksum_update (MDB_txn *, rai::block_hash const &);
 	rai::checksum checksum (MDB_txn *, rai::account const &, rai::account const &);
 	void dump_account_chain (rai::account const &);

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1985,7 +1985,7 @@ void rai::bulk_push_server::received_block (boost::system::error_code const & ec
 rai::frontier_req_server::frontier_req_server (std::shared_ptr<rai::bootstrap_server> const & connection_a, std::unique_ptr<rai::frontier_req> request_a) :
 connection (connection_a),
 current (request_a->start.number () - 1),
-info (0, 0, 0, 0, 0, 0),
+info (0, 0, 0, 0, 0, 0, 0),
 request (std::move (request_a)),
 send_buffer (std::make_shared<std::vector<uint8_t>> ())
 {

--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -99,37 +99,44 @@ void rai::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t s
 	rai::message_header header (error, stream);
 	if (!error)
 	{
-		switch (header.type)
+		if (rai::rai_network == rai::rai_networks::rai_beta_network && header.version_using < rai::protocol_version)
 		{
-			case rai::message_type::keepalive:
+			status = parse_status::outdated_version;
+		}
+		else
+		{
+			switch (header.type)
 			{
-				deserialize_keepalive (stream, header);
-				break;
-			}
-			case rai::message_type::publish:
-			{
-				deserialize_publish (stream, header);
-				break;
-			}
-			case rai::message_type::confirm_req:
-			{
-				deserialize_confirm_req (stream, header);
-				break;
-			}
-			case rai::message_type::confirm_ack:
-			{
-				deserialize_confirm_ack (stream, header);
-				break;
-			}
-			case rai::message_type::node_id_handshake:
-			{
-				deserialize_node_id_handshake (stream, header);
-				break;
-			}
-			default:
-			{
-				status = parse_status::invalid_message_type;
-				break;
+				case rai::message_type::keepalive:
+				{
+					deserialize_keepalive (stream, header);
+					break;
+				}
+				case rai::message_type::publish:
+				{
+					deserialize_publish (stream, header);
+					break;
+				}
+				case rai::message_type::confirm_req:
+				{
+					deserialize_confirm_req (stream, header);
+					break;
+				}
+				case rai::message_type::confirm_ack:
+				{
+					deserialize_confirm_ack (stream, header);
+					break;
+				}
+				case rai::message_type::node_id_handshake:
+				{
+					deserialize_node_id_handshake (stream, header);
+					break;
+				}
+				default:
+				{
+					status = parse_status::invalid_message_type;
+					break;
+				}
 			}
 		}
 	}

--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -190,7 +190,8 @@ public:
 		invalid_publish_message,
 		invalid_confirm_req_message,
 		invalid_confirm_ack_message,
-		invalid_node_id_handshake_message
+		invalid_node_id_handshake_message,
+		outdated_version
 	};
 	message_parser (rai::message_visitor &, rai::work_pool &);
 	void deserialize_buffer (uint8_t const *, size_t);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1532,6 +1532,14 @@ rai::process_return rai::block_processor::process_receive_one (MDB_txn * transac
 			}
 			break;
 		}
+		case rai::process_result::representative_mismatch:
+		{
+			if (node.config.logging.ledger_logging ())
+			{
+				BOOST_LOG (node.log) << boost::str (boost::format ("Representative mismatch for: %1%") % hash.to_string ());
+			}
+			break;
+		}
 		case rai::process_result::block_position:
 		{
 			if (node.config.logging.ledger_logging ())

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -899,11 +899,8 @@ bootstrap_connections_max (64),
 callback_port (0),
 lmdb_max_dbs (128)
 {
-	std::string epoch_str ("epoch v1 block");
-	blake2b_state hash;
-	blake2b_init (&hash, sizeof (epoch_block_link.bytes));
-	blake2b_update (&hash, epoch_str.data (), epoch_str.size ());
-	blake2b_final (&hash, epoch_block_link.bytes.data (), sizeof (epoch_block_link.bytes));
+	const char * epoch_message ("epoch v1 block");
+	strncpy ((char *)epoch_block_link.bytes.data (), epoch_message, epoch_block_link.bytes.size ());
 	epoch_block_signer = rai::genesis_account;
 	switch (rai::rai_network)
 	{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -977,8 +977,6 @@ void rai::node_config::serialize_json (boost::property_tree::ptree & tree_a) con
 	tree_a.put ("callback_port", std::to_string (callback_port));
 	tree_a.put ("callback_target", callback_target);
 	tree_a.put ("lmdb_max_dbs", lmdb_max_dbs);
-	tree_a.put ("epoch_block_link", epoch_block_link.to_string ());
-	tree_a.put ("epoch_block_signer", epoch_block_signer.to_account ());
 }
 
 bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptree & tree_a)
@@ -1077,8 +1075,6 @@ bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptr
 		case 12:
 			tree_a.erase ("state_block_parse_canary");
 			tree_a.erase ("state_block_generate_canary");
-			tree_a.put ("epoch_block_link", epoch_block_link.to_string ());
-			tree_a.put ("epoch_block_signer", epoch_block_link.to_account ());
 			tree_a.erase ("version");
 			tree_a.put ("version", "13");
 			result = true;
@@ -1168,8 +1164,6 @@ bool rai::node_config::deserialize_json (bool & upgraded_a, boost::property_tree
 		callback_target = tree_a.get<std::string> ("callback_target");
 		auto lmdb_max_dbs_l = tree_a.get<std::string> ("lmdb_max_dbs");
 		result |= parse_port (callback_port_l, callback_port);
-		auto epoch_block_link_l = tree_a.get<std::string> ("epoch_block_link");
-		auto epoch_block_signer_l = tree_a.get<std::string> ("epoch_block_signer");
 		try
 		{
 			peering_port = std::stoul (peering_port_l);
@@ -1189,8 +1183,6 @@ bool rai::node_config::deserialize_json (bool & upgraded_a, boost::property_tree
 			result |= password_fanout < 16;
 			result |= password_fanout > 1024 * 1024;
 			result |= io_threads == 0;
-			result |= epoch_block_link.decode_hex (epoch_block_link_l);
-			result |= epoch_block_signer.decode_hex (epoch_block_signer_l);
 		}
 		catch (std::logic_error const &)
 		{

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -483,8 +483,8 @@ public:
 	std::string callback_target;
 	int lmdb_max_dbs;
 	rai::stat_config stat_config;
-	rai::block_hash state_block_parse_canary;
-	rai::block_hash state_block_generate_canary;
+	rai::uint256_union epoch_block_link;
+	rai::account epoch_block_signer;
 	static std::chrono::seconds constexpr keepalive_period = std::chrono::seconds (60);
 	static std::chrono::seconds constexpr keepalive_cutoff = keepalive_period * 5;
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1790,6 +1790,14 @@ public:
 					tree.put ("subtype", "change");
 				}
 			}
+			else if (balance == previous_balance && !handler.node.ledger.epoch_link.is_zero () && block_a.hashables.link == handler.node.ledger.epoch_link)
+			{
+				if (raw)
+				{
+					tree.put ("subtype", "epoch");
+					tree.put ("account", handler.node.ledger.epoch_signer.to_account ());
+				}
+			}
 			else
 			{
 				if (raw)

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -2317,6 +2317,7 @@ void rai::rpc_handler::pending ()
 			}
 		}
 		const bool source = request.get<bool> ("source", false);
+		const bool min_version = request.get<bool> ("min_version", false);
 		boost::property_tree::ptree response_l;
 		boost::property_tree::ptree peers_l;
 		{
@@ -2325,7 +2326,7 @@ void rai::rpc_handler::pending ()
 			for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))), n (node.store.pending_begin (transaction, rai::pending_key (end, 0))); i != n && peers_l.size () < count; ++i)
 			{
 				rai::pending_key key (i->first);
-				if (threshold.is_zero () && !source)
+				if (threshold.is_zero () && !source && !min_version)
 				{
 					boost::property_tree::ptree entry;
 					entry.put ("", key.hash.to_string ());
@@ -2336,11 +2337,18 @@ void rai::rpc_handler::pending ()
 					rai::pending_info info (i->second);
 					if (info.amount.number () >= threshold.number ())
 					{
-						if (source)
+						if (source || min_version)
 						{
 							boost::property_tree::ptree pending_tree;
 							pending_tree.put ("amount", info.amount.number ().convert_to<std::string> ());
-							pending_tree.put ("source", info.source.to_account ());
+							if (source)
+							{
+								pending_tree.put ("source", info.source.to_account ());
+							}
+							if (min_version)
+							{
+								pending_tree.put ("min_version", std::to_string (info.min_version));
+							}
 							peers_l.add_child (key.hash.to_string (), pending_tree);
 						}
 						else
@@ -3986,6 +3994,7 @@ void rai::rpc_handler::wallet_pending ()
 				}
 			}
 			const bool source = request.get<bool> ("source", false);
+			const bool min_version = request.get<bool> ("min_version", false);
 			boost::property_tree::ptree response_l;
 			boost::property_tree::ptree pending;
 			rai::transaction transaction (node.store.environment, nullptr, false);
@@ -4008,11 +4017,18 @@ void rai::rpc_handler::wallet_pending ()
 						rai::pending_info info (ii->second);
 						if (info.amount.number () >= threshold.number ())
 						{
-							if (source)
+							if (source || min_version)
 							{
 								boost::property_tree::ptree pending_tree;
 								pending_tree.put ("amount", info.amount.number ().convert_to<std::string> ());
-								pending_tree.put ("source", info.source.to_account ());
+								if (source)
+								{
+									pending_tree.put ("source", info.source.to_account ());
+								}
+								if (min_version)
+								{
+									pending_tree.put ("min_version", std::to_string (info.min_version));
+								}
 								peers_l.add_child (key.hash.to_string (), pending_tree);
 							}
 							else

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -351,6 +351,7 @@ void rai::rpc_handler::account_info ()
 			response_l.put ("balance", balance);
 			response_l.put ("modified_timestamp", std::to_string (info.modified));
 			response_l.put ("block_count", std::to_string (info.block_count));
+			response_l.put ("account_version", std::to_string (info.version));
 			if (representative)
 			{
 				auto block (node.store.block_get (transaction, info.rep_block));

--- a/rai/node/stats.cpp
+++ b/rai/node/stats.cpp
@@ -411,6 +411,9 @@ std::string rai::stat::detail_to_string (uint32_t key)
 		case rai::stat::detail::state_block:
 			res = "state_block";
 			break;
+		case rai::stat::detail::epoch_block:
+			res = "epoch_block";
+			break;
 		case rai::stat::detail::vote_valid:
 			res = "vote_valid";
 			break;

--- a/rai/node/stats.hpp
+++ b/rai/node/stats.hpp
@@ -202,6 +202,7 @@ public:
 		open,
 		change,
 		state_block,
+		epoch_block,
 
 		// message specific
 		keepalive,

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -547,6 +547,11 @@ public:
 				type = "Change";
 				account = block_a.hashables.representative;
 			}
+			else if (balance == previous_balance && !ledger.epoch_link.is_zero () && block_a.hashables.link == ledger.epoch_link)
+			{
+				type = "Epoch";
+				account = ledger.epoch_signer;
+			}
 			else
 			{
 				type = "Receive";


### PR DESCRIPTION
This PR adds epoch blocks, which are a variant of state blocks. They will be used to prevent future old type (non-state) blocks. This code may also be used for future upgrades.

How to detect if a state block is a epoch block:
- Its link field is epoch_link (currently `"epoch v1 block"` then a bunch of null bytes)
- Its balance is the same as the previous block for the account (or 0 if previous is 0)

Additional requirements of an epoch block (for more details see `rai::ledger_processor::epoch_block_impl`):
- Its account must not be the burn account
- It is signed by epoch_signer (currently the genesis account) instead of its account
- Its representative is the same as the previous block for the account (or the burn account if previous is 0)
- Its account's version must be 0

An epoch block will change the account version from 0 to 1, which means:
- It cannot be followed by old type blocks (like how state blocks already work)
- Any future sends will have a min_version of 1
  - These cannot be received by old type blocks
  - When received by a state block, this automatically upgrades the account to version 1

We'll make a script to generate epoch blocks for any currently open accounts and any unopened account with pending sends (except the burn account).