### PR TITLE
Speed up travis builds: enable ccache, cache cargo and reduce test timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,23 @@ matrix:
 compiler:
   - clang
 
+cache:
+  - ccache: true
+
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo mkdir -p /etc/docker && echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json && sudo service docker restart; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew install qt5 && brew cask install xquartz && brew upgrade boost && brew install rust; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo mkdir -p /etc/docker && echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json && sudo service docker restart; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ci/build-docker-image.sh docker/ci/Dockerfile nanocurrency/nano-ci; fi
+
+install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ccache; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
 
 script:
   - if [ -n "$ONE_TIME_TESTS" ]; then ci/check-commit-format.sh; fi
   - if [ -n "$ONE_TIME_TESTS" ]; then doxygen doxygen.config; fi # TODO also deploy the built HTML
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ci/build-travis.sh "/usr/local/opt/qt5/lib/cmake/Qt5"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then docker run -v $TRAVIS_BUILD_DIR:/workspace nanocurrency/nano-ci /bin/bash -c "cd /workspace && ASAN=${ASAN} TSAN=${TSAN} ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then docker run -v $TRAVIS_BUILD_DIR:/workspace -v $HOME/.ccache:/ccache nanocurrency/nano-ci /bin/bash -c "apt install ccache; cd /workspace && ASAN=${ASAN} TSAN=${TSAN} CCACHE_DIR=/ccache ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"; fi
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ compiler:
 
 cache:
   - ccache: true
+  - directories:
+      - $HOME/Library/Caches/Homebrew
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew install qt5 && brew cask install xquartz && brew upgrade boost && brew install rust; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
   - directories:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.cargo
+      - $TRAVIS_BUILD_DIR/load-tester/target
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew install qt5 && brew cask install xquartz && brew upgrade boost && brew install rust; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
   - ccache: true
   - directories:
       - $HOME/Library/Caches/Homebrew
+      - $HOME/.cargo
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew install qt5 && brew cask install xquartz && brew upgrade boost && brew install rust; fi
@@ -35,7 +36,7 @@ script:
   - if [ -n "$ONE_TIME_TESTS" ]; then ci/check-commit-format.sh; fi
   - if [ -n "$ONE_TIME_TESTS" ]; then doxygen doxygen.config; fi # TODO also deploy the built HTML
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ci/build-travis.sh "/usr/local/opt/qt5/lib/cmake/Qt5"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then docker run -v $TRAVIS_BUILD_DIR:/workspace -v $HOME/.ccache:/ccache nanocurrency/nano-ci /bin/bash -c "apt install ccache; cd /workspace && ASAN=${ASAN} TSAN=${TSAN} CCACHE_DIR=/ccache ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then docker run -v $TRAVIS_BUILD_DIR:/workspace -v $HOME/.ccache:/ccache -v $HOME/.cargo:/cargo nanocurrency/nano-ci /bin/bash -c "apt install ccache; cd /workspace && ASAN=${ASAN} TSAN=${TSAN} CCACHE_DIR=/ccache CARGO_HOME=/cargo ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"; fi
 
 deploy:
   provider: script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.4)
 project (rai)
 
 set (CPACK_PACKAGE_VERSION_MAJOR "15")

--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -30,6 +30,7 @@ cmake \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
     -DBOOST_ROOT=/usr/local \
     -DQt5_DIR=${qt_dir} \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     ${SANITIZERS} \
     ..
 

--- a/ci/deploy-docker.sh
+++ b/ci/deploy-docker.sh
@@ -3,7 +3,7 @@ set -e
 
 scripts="$(dirname "$0")"
 
-docker login -u nanocurrency -p "$DOCKER_PASSWORD"
+echo "$DOCKER_PASSWORD" | docker login -u nanocurrency --password-stdin
 
 # We push this just so it can be a cache next time
 if [ "$TRAVIS_BRANCH" = "master" ]; then

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 build_dir=${1-${PWD}}
+TIMEOUT_DEFAULT=120
 
 BUSYBOX_BASH=${BUSYBOX_BASH-0}
 
@@ -25,7 +26,7 @@ xvfb_run_() {
     Xvfb :2 -screen 0 1024x768x24 &
     xvfb_pid=$!
     sleep ${INIT_DELAY_SEC}
-    DISPLAY=:2 ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_SEC-420} $@
+    DISPLAY=:2 ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_SEC-${TIMEOUT_DEFAULT}} $@
     res=${?}
     kill ${xvfb_pid}
 
@@ -41,13 +42,13 @@ run_tests() {
         TIMEOUT_TIME_ARG=""
     fi
 
-    ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_SEC-420} ./core_test
+    ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_SEC-${TIMEOUT_DEFAULT}} ./core_test
     core_test_res=${?}
 
     xvfb_run_ ./qt_test
     qt_test_res=${?}
 
-    ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_SEC-420} ./load_test ./rai_node -s 150
+    ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_SEC-${TIMEOUT_DEFAULT}} ./load_test ./rai_node -s 150
     load_test_res=${?}
 
     echo "Core Test return code: ${core_test_res}"


### PR DESCRIPTION
These changes make the compilation on travis faster, with ~36 minutes as reference, it takes about ~20 minutes with cold caches and ~10 minutes with warm caches.

Summary of changes:
 * Enable build caches: ccache and cargo, this requires two slightly different approaches because the linux build runs inside a docker container. The solution on osx is just enabling the caches as explained in the travis documentation, the solution for linux maps a few folders from the docker container to the host to be able to store the cache. ccache is enabled through a cmake 3.4 feature, thus the change in the required version.
 * Enable homebrew cache: it does not avoid the compilation but speeds up the download.
 * Reduce tests timeout from 420 to 120. One of the tests hangs and was slowing down the build process.
 * A minor improvement to avoid docker waiting for password if the travis project is not configured with the docker password.

This is my first contribution so please don't hesitate to comment if I need to do something differently. I am planning to contribute a general improvement on the cmake code but it is taking longer than expected, soon...