### PR TITLE
Fix the work value of the beta network genesis block

### DIFF
--- a/rai/common.cpp
+++ b/rai/common.cpp
@@ -32,7 +32,7 @@ char const * beta_genesis_data = R"%%%({
         "source": "A59A47CC4F593E75AE9AD653FDA9358E2F7898D9ACC8C60E80D0495CE20FBA9F",
         "representative": "xrb_3betaz86ypbygpqbookmzpnmd5jhh4efmd8arr9a3n4bdmj1zgnzad7xpmfp",
         "account": "xrb_3betaz86ypbygpqbookmzpnmd5jhh4efmd8arr9a3n4bdmj1zgnzad7xpmfp",
-        "work": "dc4914cce98187b5",
+        "work": "000000000f0aaeeb",
         "signature": "A726490E3325E4FA59C1C900D5B6EEBB15FE13D99F49D475B93F0AACC5635929A0614CF3892764A04D1C6732A0D716FFEB254D4154C6F544D11E6630F201450B"
 })%%%";
 


### PR DESCRIPTION
The previous value does not exceed the threshold of 0xffffffc000000000 and is therefore invalid.