### PR TITLE
Allow the "bulk_pull" bootstrapping message to accept a block hash as…

### DIFF
--- a/rai/core_test/network.cpp
+++ b/rai/core_test/network.cpp
@@ -497,6 +497,21 @@ TEST (bulk_pull, get_next_on_open)
 	ASSERT_EQ (request->current, request->request->end);
 }
 
+TEST (bulk_pull, by_block)
+{
+	rai::system system (24000, 1);
+	auto connection (std::make_shared<rai::bootstrap_server> (nullptr, system.nodes[0]));
+	rai::genesis genesis;
+	std::unique_ptr<rai::bulk_pull> req (new rai::bulk_pull{});
+	req->start = genesis.hash ();
+	req->end.clear ();
+	connection->requests.push (std::unique_ptr<rai::message>{});
+	auto request (std::make_shared<rai::bulk_pull_server> (connection, std::move (req)));
+	auto block (request->get_next ());
+	ASSERT_NE (nullptr, block);
+	ASSERT_EQ (block->hash (), genesis.hash ());
+}
+
 TEST (bootstrap_processor, DISABLED_process_none)
 {
 	rai::system system (24000, 1);

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1575,21 +1575,14 @@ void rai::bulk_pull_server::set_current_end ()
 		}
 		else
 		{
+			current = info.head;
 			if (!request->end.is_zero ())
 			{
 				auto account (connection->node->ledger.account (transaction, request->end));
-				if (account == request->start)
-				{
-					current = info.head;
-				}
-				else
+				if (account != request->start)
 				{
 					current = request->end;
 				}
-			}
-			else
-			{
-				current = info.head;
 			}
 		}
 	}

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1581,6 +1581,10 @@ void rai::bulk_pull_server::set_current_end ()
 				auto account (connection->node->ledger.account (transaction, request->end));
 				if (account != request->start)
 				{
+					if (connection->node->config.logging.bulk_pull_logging ())
+					{
+						BOOST_LOG (connection->node->log) << boost::str (boost::format ("Request for block that is not on account chain: %1% not on %2%") % request->end.to_string () % request->start.to_account ());
+					}
 					current = request->end;
 				}
 			}

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1533,7 +1533,11 @@ void rai::bootstrap_server::run_next ()
 /**
  * Handle a request for the pull of all blocks associated with an account
  * The account is supplied as the "start" member, and the final block to
- * send is the "end" member
+ * send is the "end" member.  The "start" member may also be a block
+ * hash, in which case the that hash is used as the start of a chain
+ * to send.  To determine if "start" is interpretted as an account or
+ * hash, the ledger is checked to see if the block specified exists,
+ * if not then it is interpretted as an account.
  */
 void rai::bulk_pull_server::set_current_end ()
 {
@@ -1547,33 +1551,43 @@ void rai::bulk_pull_server::set_current_end ()
 		}
 		request->end.clear ();
 	}
-	rai::account_info info;
-	auto no_address (connection->node->store.account_get (transaction, request->start, info));
-	if (no_address)
-	{
+
+	if (connection->node->store.block_exists (transaction, request->start)) {
 		if (connection->node->config.logging.bulk_pull_logging ())
 		{
-			BOOST_LOG (connection->node->log) << boost::str (boost::format ("Request for unknown account: %1%") % request->start.to_account ());
+			BOOST_LOG (connection->node->log) << boost::str (boost::format ("Bulk pull request for block hash: %1%") % request->start.to_string ());
 		}
-		current = request->end;
-	}
-	else
-	{
-		if (!request->end.is_zero ())
+
+		current = request->start;
+	} else {
+		rai::account_info info;
+		auto no_address (connection->node->store.account_get (transaction, request->start, info));
+		if (no_address)
 		{
-			auto account (connection->node->ledger.account (transaction, request->end));
-			if (account == request->start)
+			if (connection->node->config.logging.bulk_pull_logging ())
 			{
-				current = info.head;
+				BOOST_LOG (connection->node->log) << boost::str (boost::format ("Request for unknown account: %1%") % request->start.to_account ());
 			}
-			else
-			{
-				current = request->end;
-			}
+			current = request->end;
 		}
 		else
 		{
-			current = info.head;
+			if (!request->end.is_zero ())
+			{
+				auto account (connection->node->ledger.account (transaction, request->end));
+				if (account == request->start)
+				{
+					current = info.head;
+				}
+				else
+				{
+					current = request->end;
+				}
+			}
+			else
+			{
+				current = info.head;
+			}
 		}
 	}
 }

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1552,14 +1552,17 @@ void rai::bulk_pull_server::set_current_end ()
 		request->end.clear ();
 	}
 
-	if (connection->node->store.block_exists (transaction, request->start)) {
+	if (connection->node->store.block_exists (transaction, request->start))
+	{
 		if (connection->node->config.logging.bulk_pull_logging ())
 		{
 			BOOST_LOG (connection->node->log) << boost::str (boost::format ("Bulk pull request for block hash: %1%") % request->start.to_string ());
 		}
 
 		current = request->start;
-	} else {
+	}
+	else
+	{
 		rai::account_info info;
 		auto no_address (connection->node->store.account_get (transaction, request->start, info));
 		if (no_address)


### PR DESCRIPTION
… its first argument in replace of an account hash;

This is useful to enable bootstrapping to follow chains it finds as references in a link in a receiving block and wants to follow that chain downward as well.