### PR TITLE
Explicitly set message type values

### DIFF
--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -124,19 +124,23 @@ struct hash<rai::endpoint>
 
 namespace rai
 {
+/**
+ * Message types are serialized to the network and existing values must thus never change as
+ * types are added, removed and reordered in the enum.
+ */
 enum class message_type : uint8_t
 {
-	invalid,
-	not_a_type,
-	keepalive,
-	publish,
-	confirm_req,
-	confirm_ack,
-	bulk_pull,
-	bulk_push,
-	frontier_req,
-	bulk_pull_blocks,
-	node_id_handshake
+	invalid = 0x0,
+	not_a_type = 0x1,
+	keepalive = 0x2,
+	publish = 0x3,
+	confirm_req = 0x4,
+	confirm_ack = 0x5,
+	bulk_pull = 0x6,
+	bulk_push = 0x7,
+	frontier_req = 0x8,
+	bulk_pull_blocks = 0x9,
+	node_id_handshake = 0x0a
 };
 enum class bulk_pull_blocks_mode : uint8_t
 {


### PR DESCRIPTION
Allows message types to be safely removed in the future, and I think it's good documentation since it's part of the protocol.