### PR TITLE
Reduce announcement_minimum 

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3637,7 +3637,7 @@ void rai::active_transactions::announce_votes ()
 				unconfirmed_announcements += i->announcements;
 			}
 			election_l->broadcast_winner (transaction);
-			if (i->announcements % announcement_min == 2)
+			if (i->announcements % 4 == 1)
 			{
 				auto reps (std::make_shared<std::vector<rai::peer_information>> (node.peers.representatives (std::numeric_limits<size_t>::max ())));
 

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -115,7 +115,7 @@ public:
 	// Maximum number of conflicts to vote on per interval, lowest root hash first
 	static unsigned constexpr announcements_per_interval = 32;
 	// Minimum number of block announcements
-	static unsigned constexpr announcement_min = 4;
+	static unsigned constexpr announcement_min = 2;
 	// Threshold to start logging blocks haven't yet been confirmed
 	static unsigned constexpr announcement_long = 20;
 	static unsigned constexpr announce_interval_ms = (rai::rai_network == rai::rai_networks::rai_test_network) ? 10 : 16000;


### PR DESCRIPTION
as quorum must be met for block confirmation now and announcements will continue until minimum quorum is met fixes #992

