### PR TITLE
Deadlines in tests

### DIFF
--- a/rai/core_test/CMakeLists.txt
+++ b/rai/core_test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable (core_test
+	testutil.hpp
 	block.cpp
 	block_store.cpp
 	interface.cpp

--- a/rai/core_test/gap_cache.cpp
+++ b/rai/core_test/gap_cache.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
+#include <rai/core_test/testutil.hpp>
 #include <rai/node/testing.hpp>
+
+using namespace std::chrono_literals;
 
 TEST (gap_cache, add_new)
 {
@@ -67,12 +70,10 @@ TEST (gap_cache, gap_bootstrap)
 	system.wallet (0)->send_action (rai::test_genesis_key.pub, key.pub, 100);
 	ASSERT_EQ (rai::genesis_amount - 200, system.nodes[0]->balance (rai::genesis_account));
 	ASSERT_EQ (rai::genesis_amount, system.nodes[1]->balance (rai::genesis_account));
-	auto iterations2 (0);
+	system.deadline_set (10s);
 	while (system.nodes[1]->balance (rai::genesis_account) != rai::genesis_amount - 200)
 	{
-		system.poll ();
-		++iterations2;
-		ASSERT_LT (iterations2, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 }
 

--- a/rai/core_test/network.cpp
+++ b/rai/core_test/network.cpp
@@ -819,7 +819,7 @@ TEST (bulk, offline_send)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (rai::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_NE (std::numeric_limits<rai::uint256_t>::max (), system.nodes[0]->balance (rai::test_genesis_key.pub));
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	system.deadline_set (10s);
+	system.deadline_set (20s);
 	while (node1->balance (key2.pub) != system.nodes[0]->config.receive_minimum.number ())
 	{
 		ASSERT_NO_ERROR (system.poll ());

--- a/rai/core_test/network.cpp
+++ b/rai/core_test/network.cpp
@@ -1,6 +1,9 @@
 #include <boost/thread.hpp>
 #include <gtest/gtest.h>
+#include <rai/core_test/testutil.hpp>
 #include <rai/node/testing.hpp>
+
+using namespace std::chrono_literals;
 
 TEST (network, tcp_connection)
 {
@@ -71,21 +74,17 @@ TEST (network, send_node_id_handshake)
 	system.nodes[0]->network.send_keepalive (node1->network.endpoint ());
 	ASSERT_EQ (0, system.nodes[0]->peers.list ().size ());
 	ASSERT_EQ (0, node1->peers.list ().size ());
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (node1->stats.count (rai::stat::type::message, rai::stat::detail::node_id_handshake, rai::stat::dir::in) == initial_node1)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (0, system.nodes[0]->peers.list ().size ());
 	ASSERT_EQ (1, node1->peers.list ().size ());
-	iterations = 0;
+	system.deadline_set (10s);
 	while (system.nodes[0]->stats.count (rai::stat::type::message, rai::stat::detail::node_id_handshake, rai::stat::dir::in) < initial + 2)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	auto peers1 (system.nodes[0]->peers.list ());
 	auto peers2 (node1->peers.list ());
@@ -106,12 +105,10 @@ TEST (network, keepalive_ipv4)
 	node1->start ();
 	node1->send_keepalive (rai::endpoint (boost::asio::ip::address_v4::loopback (), 24000));
 	auto initial (system.nodes[0]->stats.count (rai::stat::type::message, rai::stat::detail::keepalive, rai::stat::dir::in));
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->stats.count (rai::stat::type::message, rai::stat::detail::keepalive, rai::stat::dir::in) == initial)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	node1->stop ();
 }
@@ -129,24 +126,20 @@ TEST (network, multi_keepalive)
 	node1->network.send_keepalive (system.nodes[0]->network.endpoint ());
 	ASSERT_EQ (0, node1->peers.size ());
 	ASSERT_EQ (0, system.nodes[0]->peers.size ());
-	auto iterations1 (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->peers.size () != 1)
 	{
-		system.poll ();
-		++iterations1;
-		ASSERT_LT (iterations1, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	rai::node_init init2;
 	auto node2 (std::make_shared<rai::node> (init2, system.service, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init2.error ());
 	node2->start ();
 	node2->network.send_keepalive (system.nodes[0]->network.endpoint ());
-	auto iterations2 (0);
+	system.deadline_set (10s);
 	while (node1->peers.size () != 2 || system.nodes[0]->peers.size () != 2 || node2->peers.size () != 2)
 	{
-		system.poll ();
-		++iterations2;
-		ASSERT_LT (iterations2, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	node1->stop ();
 	node2->stop ();
@@ -163,12 +156,10 @@ TEST (network, send_discarded_publish)
 		ASSERT_EQ (genesis.hash (), system.nodes[0]->ledger.latest (transaction, rai::test_genesis_key.pub));
 		ASSERT_EQ (genesis.hash (), system.nodes[1]->latest (rai::test_genesis_key.pub));
 	}
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[1]->stats.count (rai::stat::type::message, rai::stat::detail::publish, rai::stat::dir::in) == 0)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	rai::transaction transaction (system.nodes[0]->store.environment, nullptr, false);
 	ASSERT_EQ (genesis.hash (), system.nodes[0]->ledger.latest (transaction, rai::test_genesis_key.pub));
@@ -186,12 +177,10 @@ TEST (network, send_invalid_publish)
 		ASSERT_EQ (genesis.hash (), system.nodes[0]->ledger.latest (transaction, rai::test_genesis_key.pub));
 		ASSERT_EQ (genesis.hash (), system.nodes[1]->latest (rai::test_genesis_key.pub));
 	}
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[1]->stats.count (rai::stat::type::message, rai::stat::detail::publish, rai::stat::dir::in) == 0)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	rai::transaction transaction (system.nodes[0]->store.environment, nullptr, false);
 	ASSERT_EQ (genesis.hash (), system.nodes[0]->ledger.latest (transaction, rai::test_genesis_key.pub));
@@ -208,13 +197,11 @@ TEST (network, send_valid_confirm_ack)
 	rai::send_block block2 (latest1, key2.pub, 50, rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.work.generate (latest1));
 	rai::block_hash latest2 (system.nodes[1]->latest (rai::test_genesis_key.pub));
 	system.nodes[0]->process_active (std::unique_ptr<rai::block> (new rai::send_block (block2)));
-	auto iterations (0);
+	system.deadline_set (10s);
 	// Keep polling until latest block changes
 	while (system.nodes[1]->latest (rai::test_genesis_key.pub) == latest2)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	// Make sure the balance has decreased after processing the block.
 	ASSERT_EQ (50, system.nodes[1]->balance (rai::test_genesis_key.pub));
@@ -233,20 +220,16 @@ TEST (network, send_valid_publish)
 	auto hash2 (block2.hash ());
 	rai::block_hash latest2 (system.nodes[1]->latest (rai::test_genesis_key.pub));
 	system.nodes[1]->process_active (std::unique_ptr<rai::block> (new rai::send_block (block2)));
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->stats.count (rai::stat::type::message, rai::stat::detail::publish, rai::stat::dir::in) == 0)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_NE (hash2, latest2);
-	auto iterations2 (0);
+	system.deadline_set (10s);
 	while (system.nodes[1]->latest (rai::test_genesis_key.pub) == latest2)
 	{
-		system.poll ();
-		++iterations2;
-		ASSERT_LT (iterations2, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (50, system.nodes[1]->balance (rai::test_genesis_key.pub));
 }
@@ -264,12 +247,10 @@ TEST (network, send_insufficient_work)
 	auto node1 (system.nodes[1]->shared ());
 	system.nodes[0]->network.send_buffer (bytes->data (), bytes->size (), system.nodes[1]->network.endpoint (), [bytes, node1](boost::system::error_code const & ec, size_t size) {});
 	ASSERT_EQ (0, system.nodes[0]->stats.count (rai::stat::type::error, rai::stat::detail::insufficient_work));
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[1]->stats.count (rai::stat::type::error, rai::stat::detail::insufficient_work) == 0)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (1, system.nodes[1]->stats.count (rai::stat::type::error, rai::stat::detail::insufficient_work));
 }
@@ -326,12 +307,10 @@ TEST (receivable_processor, send_with_receive)
 	ASSERT_EQ (0, system.nodes[0]->balance (key2.pub));
 	ASSERT_EQ (amount - system.nodes[0]->config.receive_minimum.number (), system.nodes[1]->balance (rai::test_genesis_key.pub));
 	ASSERT_EQ (0, system.nodes[1]->balance (key2.pub));
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->balance (key2.pub) != system.nodes[0]->config.receive_minimum.number ())
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (amount - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (rai::test_genesis_key.pub));
 	ASSERT_EQ (system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (key2.pub));
@@ -350,12 +329,10 @@ TEST (network, receive_weight_change)
 		system.wallet (1)->store.representative_set (transaction, key2.pub);
 	}
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (rai::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (std::any_of (system.nodes.begin (), system.nodes.end (), [&](std::shared_ptr<rai::node> const & node_a) { return node_a->weight (key2.pub) != system.nodes[0]->config.receive_minimum.number (); }))
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 }
 
@@ -560,13 +537,11 @@ TEST (bootstrap_processor, process_one)
 	rai::block_hash hash2 (node1->latest (rai::test_genesis_key.pub));
 	ASSERT_NE (hash1, hash2);
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	auto iterations (0);
 	ASSERT_NE (node1->latest (rai::test_genesis_key.pub), system.nodes[0]->latest (rai::test_genesis_key.pub));
+	system.deadline_set (10s);
 	while (node1->latest (rai::test_genesis_key.pub) != system.nodes[0]->latest (rai::test_genesis_key.pub))
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (0, node1->active.roots.size ());
 	node1->stop ();
@@ -588,13 +563,11 @@ TEST (bootstrap_processor, process_two)
 	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	auto iterations (0);
 	ASSERT_NE (node1->latest (rai::test_genesis_key.pub), system.nodes[0]->latest (rai::test_genesis_key.pub));
+	system.deadline_set (10s);
 	while (node1->latest (rai::test_genesis_key.pub) != system.nodes[0]->latest (rai::test_genesis_key.pub))
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	node1->stop ();
 }
@@ -617,13 +590,11 @@ TEST (bootstrap_processor, process_state)
 	ASSERT_EQ (node0->latest (rai::test_genesis_key.pub), block2->hash ());
 	ASSERT_NE (node1->latest (rai::test_genesis_key.pub), block2->hash ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
-	auto iterations (0);
 	ASSERT_NE (node1->latest (rai::test_genesis_key.pub), node0->latest (rai::test_genesis_key.pub));
+	system.deadline_set (10s);
 	while (node1->latest (rai::test_genesis_key.pub) != node0->latest (rai::test_genesis_key.pub))
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (0, node1->active.roots.size ());
 	node1->stop ();
@@ -636,12 +607,10 @@ TEST (bootstrap_processor, process_new)
 	rai::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (rai::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
-	auto iterations1 (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->balance (key2.pub).is_zero ())
 	{
-		system.poll ();
-		++iterations1;
-		ASSERT_LT (iterations1, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	rai::uint128_t balance1 (system.nodes[0]->balance (rai::test_genesis_key.pub));
 	rai::uint128_t balance2 (system.nodes[0]->balance (key2.pub));
@@ -649,12 +618,10 @@ TEST (bootstrap_processor, process_new)
 	auto node1 (std::make_shared<rai::node> (init1, system.service, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	auto iterations2 (0);
+	system.deadline_set (10s);
 	while (node1->balance (key2.pub) != balance2)
 	{
-		system.poll ();
-		++iterations2;
-		ASSERT_LT (iterations2, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (balance1, node1->balance (rai::test_genesis_key.pub));
 	node1->stop ();
@@ -676,12 +643,10 @@ TEST (bootstrap_processor, pull_diamond)
 	auto node1 (std::make_shared<rai::node> (init1, system.service, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (node1->balance (rai::test_genesis_key.pub) != 100)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (100, node1->balance (rai::test_genesis_key.pub));
 	node1->stop ();
@@ -706,12 +671,10 @@ TEST (bootstrap_processor, push_diamond)
 	std::unique_ptr<rai::receive_block> receive (new rai::receive_block (send1->hash (), send2->hash (), rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.work.generate (send1->hash ())));
 	ASSERT_EQ (rai::process_result::progress, node1->process (*receive).code);
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->balance (rai::test_genesis_key.pub) != 100)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (100, system.nodes[0]->balance (rai::test_genesis_key.pub));
 	node1->stop ();
@@ -730,12 +693,10 @@ TEST (bootstrap_processor, push_one)
 	ASSERT_NE (nullptr, wallet->send_action (rai::test_genesis_key.pub, key1.pub, 100));
 	ASSERT_NE (balance1, node1->balance (rai::test_genesis_key.pub));
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->balance (rai::test_genesis_key.pub) == balance1)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	node1->stop ();
 }
@@ -829,12 +790,10 @@ TEST (bulk, genesis)
 	rai::block_hash latest3 (system.nodes[0]->latest (rai::test_genesis_key.pub));
 	ASSERT_NE (latest1, latest3);
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (node1->latest (rai::test_genesis_key.pub) != system.nodes[0]->latest (rai::test_genesis_key.pub))
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (node1->latest (rai::test_genesis_key.pub), system.nodes[0]->latest (rai::test_genesis_key.pub));
 	node1->stop ();
@@ -849,12 +808,10 @@ TEST (bulk, offline_send)
 	ASSERT_FALSE (init1.error ());
 	node1->network.send_keepalive (system.nodes[0]->network.endpoint ());
 	node1->start ();
-	auto iterations (0);
+	system.deadline_set (10s);
 	do
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	} while (system.nodes[0]->peers.empty () || node1->peers.empty ());
 	rai::keypair key2;
 	auto wallet (node1->wallets.create (rai::uint256_union ()));
@@ -862,12 +819,10 @@ TEST (bulk, offline_send)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (rai::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_NE (std::numeric_limits<rai::uint256_t>::max (), system.nodes[0]->balance (rai::test_genesis_key.pub));
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	auto iterations2 (0);
+	system.deadline_set (10s);
 	while (node1->balance (key2.pub) != system.nodes[0]->config.receive_minimum.number ())
 	{
-		system.poll ();
-		++iterations2;
-		ASSERT_LT (iterations2, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	node1->stop ();
 }

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -1,14 +1,16 @@
 #include <gtest/gtest.h>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/beast.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/thread.hpp>
+#include <rai/core_test/testutil.hpp>
 #include <rai/node/common.hpp>
 #include <rai/node/rpc.hpp>
 #include <rai/node/testing.hpp>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/thread.hpp>
+using namespace std::chrono_literals;
 
 class test_response
 {
@@ -252,12 +254,10 @@ TEST (rpc, send)
 	request.put ("destination", rai::test_genesis_key.pub.to_account ());
 	request.put ("amount", "100");
 	std::thread thread2 ([&system]() {
-		auto iterations (0);
+		system.deadline_set (10s);
 		while (system.nodes[0]->balance (rai::test_genesis_key.pub) == rai::genesis_amount)
 		{
-			system.poll ();
-			++iterations;
-			ASSERT_LT (iterations, 200);
+			ASSERT_NO_ERROR (system.poll ());
 		}
 	});
 	test_response response (request, rpc, system.service);
@@ -289,12 +289,10 @@ TEST (rpc, send_fail)
 	request.put ("amount", "100");
 	std::atomic<bool> done (false);
 	std::thread thread2 ([&system, &done]() {
-		auto iterations (0);
+		system.deadline_set (10s);
 		while (!done)
 		{
-			system.poll ();
-			++iterations;
-			ASSERT_LT (iterations, 200);
+			ASSERT_NO_ERROR (system.poll ());
 		}
 	});
 	test_response response (request, rpc, system.service);
@@ -323,21 +321,19 @@ TEST (rpc, send_work)
 	request.put ("amount", "100");
 	request.put ("work", "1");
 	test_response response (request, rpc, system.service);
-	auto iterations1 (0);
+	system.deadline_set (10s);
 	while (response.status == 0)
 	{
-		system.poll ();
-		ASSERT_LT (++iterations1, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (response.json.get<std::string> ("error"), "Invalid work");
 	request.erase ("work");
 	request.put ("work", rai::to_string_hex (system.nodes[0]->work_generate_blocking (system.nodes[0]->latest (rai::test_genesis_key.pub))));
 	test_response response2 (request, rpc, system.service);
-	auto iterations2 (0);
+	system.deadline_set (10s);
 	while (response2.status == 0)
 	{
-		system.poll ();
-		ASSERT_LT (++iterations2, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (200, response2.status);
 	std::string block_text (response2.json.get<std::string> ("block"));
@@ -486,14 +482,12 @@ TEST (rpc, wallet_password_change)
 TEST (rpc, wallet_password_enter)
 {
 	rai::system system (24000, 1);
-	auto iterations (0);
 	rai::raw_key password_l;
 	password_l.data.clear ();
+	system.deadline_set (10s);
 	while (password_l.data == 0)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 		system.wallet (0)->store.password.value (password_l);
 	}
 	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
@@ -1019,12 +1013,10 @@ TEST (rpc, process_block)
 		system.poll ();
 	}
 	ASSERT_EQ (200, response.status);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->latest (rai::test_genesis_key.pub) != send.hash ())
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	std::string send_hash (response.json.get<std::string> ("hash"));
 	ASSERT_EQ (send.hash ().to_string (), send_hash);
@@ -1074,12 +1066,10 @@ TEST (rpc, process_republish)
 		system.poll ();
 	}
 	ASSERT_EQ (200, response.status);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[1]->latest (rai::test_genesis_key.pub) != send.hash ())
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 }
 
@@ -1105,13 +1095,11 @@ TEST (rpc, keepalive)
 		system.poll ();
 	}
 	ASSERT_EQ (200, response.status);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (!system.nodes[0]->peers.known_peer (node1->network.endpoint ()))
 	{
 		ASSERT_EQ (0, system.nodes[0]->peers.size ());
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	node1->stop ();
 }
@@ -1163,18 +1151,17 @@ TEST (rpc, payment_begin_end)
 	ASSERT_TRUE (wallet->exists (account));
 	auto root1 (system.nodes[0]->ledger.latest_root (rai::transaction (wallet->store.environment, nullptr, false), account));
 	uint64_t work (0);
-	auto iteration (0);
 	while (!rai::work_validate (root1, work))
 	{
 		++work;
 		ASSERT_LT (work, 50);
 	}
+	system.deadline_set (10s);
 	while (rai::work_validate (root1, work))
 	{
-		system.poll ();
+		auto ec = system.poll ();
 		ASSERT_FALSE (wallet->store.work_get (rai::transaction (wallet->store.environment, nullptr, false), account, work));
-		++iteration;
-		ASSERT_LT (iteration, 200);
+		ASSERT_NO_ERROR (ec);
 	}
 	ASSERT_EQ (wallet->free_accounts.end (), wallet->free_accounts.find (account));
 	boost::property_tree::ptree request2;
@@ -1499,12 +1486,10 @@ TEST (rpc, search_pending)
 		system.poll ();
 	}
 	ASSERT_EQ (200, response.status);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->balance (rai::test_genesis_key.pub) != rai::genesis_amount)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 }
 
@@ -1581,20 +1566,20 @@ TEST (rpc, work_cancel)
 	request1.put ("action", "work_cancel");
 	request1.put ("hash", hash1.to_string ());
 	auto done (false);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (!done)
 	{
 		system.work.generate (hash1, [&done](boost::optional<uint64_t> work_a) {
 			done = !work_a;
 		});
 		test_response response1 (request1, rpc, system.service);
+		std::error_code ec;
 		while (response1.status == 0)
 		{
-			system.poll ();
+			ec = system.poll ();
 		}
 		ASSERT_EQ (200, response1.status);
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (ec);
 	}
 }
 
@@ -1960,13 +1945,11 @@ TEST (rpc, bootstrap)
 	{
 		system0.poll ();
 	}
-	auto iterations (0);
+	system1.deadline_set (10s);
 	while (system0.nodes[0]->latest (rai::genesis_account) != system1.nodes[0]->latest (rai::genesis_account))
 	{
-		system0.poll ();
-		system1.poll ();
-		++iterations;
-		ASSERT_GT (200, iterations);
+		ASSERT_NO_ERROR (system0.poll ());
+		ASSERT_NO_ERROR (system1.poll ());
 	}
 }
 
@@ -2182,12 +2165,10 @@ TEST (rpc, republish)
 		system.poll ();
 	}
 	ASSERT_EQ (200, response.status);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[1]->balance (rai::test_genesis_key.pub) == rai::genesis_amount)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_GT (200, iterations);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	auto & blocks_node (response.json.get_child ("blocks"));
 	std::vector<rai::block_hash> blocks;
@@ -2754,12 +2735,10 @@ TEST (rpc, search_pending_all)
 		system.poll ();
 	}
 	ASSERT_EQ (200, response.status);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->balance (rai::test_genesis_key.pub) != rai::genesis_amount)
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 }
 
@@ -3589,12 +3568,10 @@ TEST (rpc, online_reps)
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	ASSERT_TRUE (system.nodes[1]->online_reps.online_stake () == system.nodes[1]->config.online_weight_minimum.number ());
 	system.wallet (0)->send_action (rai::test_genesis_key.pub, rai::test_genesis_key.pub, rai::Gxrb_ratio);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (system.nodes[1]->online_reps.online_stake () == system.nodes[1]->config.online_weight_minimum.number ())
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	rai::rpc rpc (system.service, *system.nodes[1], rai::rpc_config (true));
 	rpc.start ();
@@ -3618,13 +3595,11 @@ TEST (rpc, confirmation_history)
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	auto block (system.wallet (0)->send_action (rai::test_genesis_key.pub, rai::test_genesis_key.pub, rai::Gxrb_ratio));
-	auto iterations (0);
 	ASSERT_TRUE (system.nodes[0]->active.confirmed.empty ());
+	system.deadline_set (10s);
 	while (system.nodes[0]->active.confirmed.empty ())
 	{
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();

--- a/rai/core_test/testutil.hpp
+++ b/rai/core_test/testutil.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#define GTEST_TEST_ERROR_CODE(expression, text, actual, expected, fail)                       \
+	GTEST_AMBIGUOUS_ELSE_BLOCKER_                                                             \
+	if (const ::testing::AssertionResult gtest_ar_ = ::testing::AssertionResult (expression)) \
+		;                                                                                     \
+	else                                                                                      \
+		fail (::testing::internal::GetBoolAssertionFailureMessage (                           \
+		gtest_ar_, text, actual, expected)                                                    \
+		      .c_str ())
+
+/** Extends gtest with a std::error_code assert that prints the error code message when non-zero */
+#define ASSERT_NO_ERROR(condition)                                                      \
+	GTEST_TEST_ERROR_CODE (!(condition), #condition, condition.message ().c_str (), "", \
+	GTEST_FATAL_FAILURE_)

--- a/rai/core_test/wallet.cpp
+++ b/rai/core_test/wallet.cpp
@@ -1,7 +1,10 @@
 #include <gtest/gtest.h>
 
 #include <fstream>
+#include <rai/core_test/testutil.hpp>
 #include <rai/node/testing.hpp>
+
+using namespace std::chrono_literals;
 
 TEST (wallet, no_key)
 {
@@ -169,12 +172,10 @@ TEST (wallet, send_async)
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	rai::keypair key2;
 	std::thread thread ([&system]() {
-		auto iterations (0);
+		system.deadline_set (10s);
 		while (!system.nodes[0]->balance (rai::test_genesis_key.pub).is_zero ())
 		{
-			system.poll ();
-			++iterations;
-			ASSERT_LT (iterations, 200);
+			ASSERT_NO_ERROR (system.poll ());
 		}
 	});
 	bool success (false);
@@ -604,7 +605,7 @@ TEST (wallet, work)
 	wallet->insert_adhoc (rai::test_genesis_key.prv);
 	rai::genesis genesis;
 	auto done (false);
-	auto iterations (0);
+	system.deadline_set (10s);
 	while (!done)
 	{
 		rai::transaction transaction (system.nodes[0]->store.environment, nullptr, false);
@@ -613,9 +614,7 @@ TEST (wallet, work)
 		{
 			done = !rai::work_validate (genesis.hash (), work);
 		}
-		system.poll ();
-		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
 }
 
@@ -633,20 +632,16 @@ TEST (wallet, work_generate)
 	}
 	rai::keypair key;
 	wallet->send_action (rai::test_genesis_key.pub, key.pub, 100);
-	auto iterations1 (0);
+	system.deadline_set (10s);
 	while (system.nodes[0]->ledger.account_balance (rai::transaction (system.nodes[0]->store.environment, nullptr, false), rai::test_genesis_key.pub) == amount1)
 	{
-		system.poll ();
-		++iterations1;
-		ASSERT_LT (iterations1, 200);
+		ASSERT_NO_ERROR (system.poll ());
 	}
-	auto iterations2 (0);
+	system.deadline_set (10s);
 	auto again (true);
 	while (again)
 	{
-		system.poll ();
-		++iterations2;
-		ASSERT_LT (iterations2, 200);
+		ASSERT_NO_ERROR (system.poll ());
 		rai::transaction transaction (system.nodes[0]->store.environment, nullptr, false);
 		again = wallet->store.work_get (transaction, account1, work1) || rai::work_validate (system.nodes[0]->ledger.latest_root (transaction, account1), work1);
 	}

--- a/rai/core_test/wallets.cpp
+++ b/rai/core_test/wallets.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 
+#include <rai/core_test/testutil.hpp>
 #include <rai/node/testing.hpp>
+
+using namespace std::chrono_literals;
 
 TEST (wallets, open_create)
 {
@@ -28,14 +31,12 @@ TEST (wallets, open_existing)
 		auto wallet (wallets.create (id));
 		ASSERT_NE (nullptr, wallet);
 		ASSERT_EQ (wallet, wallets.open (id));
-		auto iterations (0);
 		rai::raw_key password;
 		password.data.clear ();
+		system.deadline_set (10s);
 		while (password.data == 0)
 		{
-			system.poll ();
-			++iterations;
-			ASSERT_LT (iterations, 200);
+			ASSERT_NO_ERROR (system.poll ());
 			wallet->store.password.value (password);
 		}
 	}

--- a/rai/node/testing.cpp
+++ b/rai/node/testing.cpp
@@ -4,10 +4,26 @@
 #include <rai/node/common.hpp>
 #include <rai/node/testing.hpp>
 
+std::string rai::error_system_messages::message (int ev) const
+{
+	switch (static_cast<rai::error_system> (ev))
+	{
+		case rai::error_system::generic:
+			return "Unknown error";
+		case rai::error_system::deadline_expired:
+			return "Deadline expired";
+	}
+}
+
 rai::system::system (uint16_t port_a, size_t count_a) :
 alarm (service),
 work (1, nullptr)
 {
+	auto scale_str = std::getenv ("DEADLINE_SCALE_FACTOR");
+	if (scale_str)
+	{
+		deadline_scaling_factor = std::stod (scale_str);
+	}
 	logging.init (rai::unique_path ());
 	nodes.reserve (count_a);
 	for (size_t i (0); i < count_a; ++i)
@@ -79,13 +95,24 @@ rai::account rai::system::account (MDB_txn * transaction_a, size_t index_a)
 	return result.uint256 ();
 }
 
-void rai::system::poll ()
+void rai::system::deadline_set (const std::chrono::duration<double, std::nano> & delta_a)
 {
-	auto polled1 (service.poll_one ());
-	if (polled1 == 0)
+	deadline = std::chrono::steady_clock::now () + delta_a * deadline_scaling_factor;
+}
+
+std::error_code rai::system::poll (const std::chrono::nanoseconds & sleep_time)
+{
+	std::error_code ec;
+	if (service.poll_one () == 0)
 	{
-		std::this_thread::sleep_for (std::chrono::milliseconds (50));
+		std::this_thread::sleep_for (sleep_time);
 	}
+
+	if (std::chrono::steady_clock::now () > deadline)
+	{
+		ec = rai::error_system::deadline_expired;
+	}
+	return ec;
 }
 
 namespace

--- a/rai/node/testing.hpp
+++ b/rai/node/testing.hpp
@@ -1,9 +1,17 @@
 #pragma once
 
+#include <chrono>
+#include <rai/lib/errors.hpp>
 #include <rai/node/node.hpp>
 
 namespace rai
 {
+/** Test-system related error codes */
+enum error_system
+{
+	generic = 1,
+	deadline_expired
+};
 class system
 {
 public:
@@ -23,13 +31,20 @@ public:
 	void generate_send_existing (rai::node &, std::vector<rai::account> &);
 	std::shared_ptr<rai::wallet> wallet (size_t);
 	rai::account account (MDB_txn *, size_t);
-	void poll ();
+	/**
+	 * Polls, sleep if there's no work to be done (default 50ms), then check the deadline
+	 * @returns 0 or rai::deadline_expired
+	 */
+	std::error_code poll (const std::chrono::nanoseconds & sleep_time = std::chrono::milliseconds (50));
 	void stop ();
+	void deadline_set (const std::chrono::duration<double, std::nano> & delta);
 	boost::asio::io_service service;
 	rai::alarm alarm;
 	std::vector<std::shared_ptr<rai::node>> nodes;
 	rai::logging logging;
 	rai::work_pool work;
+	std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double>> deadline{ std::chrono::steady_clock::time_point::max () };
+	double deadline_scaling_factor{ 1.0 };
 };
 class landing_store
 {
@@ -62,3 +77,4 @@ public:
 	static std::chrono::seconds constexpr sleep_seconds = std::chrono::seconds (7);
 };
 }
+REGISTER_ERROR_CODES (rai, error_system);


### PR DESCRIPTION


Summary:

* Uses deadlines (durations in any time unit) instead of iterations
* gtest extended with ASSERT_NO_ERROR which prints std::error_code messages on error. 
* system::poll returns std::error_code. ASSERT_NO_ERROR will have more uses in the future as more code migrates to error_code.
* Deadline scale factor support

The scale factor is an environment variable which makes it easier to experiment with deadlines (instead of recompiling).

It can also be set when running tests on slow machines.

For instance, to see if 10% of the deadline (1 second in this case) is enough to pass the `node_receive_quorum` test:

`DEADLINE_SCALE_FACTOR=0.1 GTEST_FILTER=node.node_receive_quorum Debug/core_test`

To allow 20% more time on all tests on a slow machine, a Travis config or whatever can export:

`DEADLINE_SCALE_FACTOR=1.2`

Sample error when using ASSERT_NO_ERROR:

```
node.cpp:230: Failure
Value of: system.poll ()
  Actual: Deadline expired
Expected:
```