### PR TITLE
Empty response message when there's no error code

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -207,7 +207,7 @@ void rai::rpc_handler::response_errors ()
 	if (ec || response_l.empty ())
 	{
 		boost::property_tree::ptree response_error;
-		response_error.put ("error", ec.message ());
+		response_error.put ("error", ec ? ec.message () : "Empty response");
 		response (response_error);
 	}
 	else


### PR DESCRIPTION
Otherwise the error message is undefined.