### PR TITLE
Add callback stats

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1755,6 +1755,7 @@ stats (config.stat_config)
 													{
 														if (resp->result () == boost::beast::http::status::ok)
 														{
+															node_l->stats.inc (rai::stat::type::http_callback, rai::stat::detail::initiate, rai::stat::dir::out);
 														}
 														else
 														{
@@ -1762,6 +1763,7 @@ stats (config.stat_config)
 															{
 																BOOST_LOG (node_l->log) << boost::str (boost::format ("Callback to %1%:%2% failed with status: %3%") % address % port % resp->result ());
 															}
+															node_l->stats.inc (rai::stat::type::error, rai::stat::detail::http_callback, rai::stat::dir::out);
 														}
 													}
 													else
@@ -1770,6 +1772,7 @@ stats (config.stat_config)
 														{
 															BOOST_LOG (node_l->log) << boost::str (boost::format ("Unable complete callback: %1%:%2%: %3%") % address % port % ec.message ());
 														}
+														node_l->stats.inc (rai::stat::type::error, rai::stat::detail::http_callback, rai::stat::dir::out);
 													};
 												});
 											}
@@ -1779,6 +1782,7 @@ stats (config.stat_config)
 												{
 													BOOST_LOG (node_l->log) << boost::str (boost::format ("Unable to send callback: %1%:%2%: %3%") % address % port % ec.message ());
 												}
+												node_l->stats.inc (rai::stat::type::error, rai::stat::detail::http_callback, rai::stat::dir::out);
 											}
 										});
 									}
@@ -1788,6 +1792,7 @@ stats (config.stat_config)
 										{
 											BOOST_LOG (node_l->log) << boost::str (boost::format ("Unable to connect to callback address: %1%:%2%: %3%") % address % port % ec.message ());
 										}
+										node_l->stats.inc (rai::stat::type::error, rai::stat::detail::http_callback, rai::stat::dir::out);
 									}
 								});
 							}
@@ -1798,6 +1803,7 @@ stats (config.stat_config)
 							{
 								BOOST_LOG (node_l->log) << boost::str (boost::format ("Error resolving callback: %1%:%2%: %3%") % address % port % ec.message ());
 							}
+							node_l->stats.inc (rai::stat::type::error, rai::stat::detail::http_callback, rai::stat::dir::out);
 						}
 					});
 				}

--- a/rai/node/stats.cpp
+++ b/rai/node/stats.cpp
@@ -325,6 +325,9 @@ std::string rai::stat::type_to_string (uint32_t key)
 		case rai::stat::type::error:
 			res = "error";
 			break;
+		case rai::stat::type::http_callback:
+			res = "http_callback";
+			break;
 		case rai::stat::type::ledger:
 			res = "ledger";
 			break;
@@ -388,6 +391,9 @@ std::string rai::stat::detail_to_string (uint32_t key)
 			break;
 		case rai::stat::detail::handshake:
 			res = "handshake";
+			break;
+		case rai::stat::detail::http_callback:
+			res = "http_callback";
 			break;
 		case rai::stat::detail::initiate:
 			res = "initiate";

--- a/rai/node/stats.hpp
+++ b/rai/node/stats.hpp
@@ -184,7 +184,8 @@ public:
 		rollback,
 		bootstrap,
 		vote,
-		peering
+		http_callback,
+		peering,
 	};
 
 	/** Optional detail type */
@@ -195,6 +196,7 @@ public:
 		// error specific
 		bad_sender,
 		insufficient_work,
+		http_callback,
 
 		// ledger, block, bootstrap
 		send,
@@ -212,8 +214,10 @@ public:
 		confirm_ack,
 		node_id_handshake,
 
-		// bootstrap specific
+		// bootstrap, callback
 		initiate,
+
+		// bootstrap specific
 		bulk_pull,
 		bulk_push,
 		bulk_pull_account,


### PR DESCRIPTION
Several reports of missed callback. This PR adds `http_callback.initiate` and `error.http_callback`. If the initiation count > what the recipient observes, maybe there's a problem at the other end.