### PR TITLE
Move enter_initial_password out of node.background

### DIFF
--- a/rai/node/cli.cpp
+++ b/rai/node/cli.cpp
@@ -404,7 +404,6 @@ std::error_code rai::handle_node_options (boost::program_options::variables_map 
 		rai::keypair key;
 		std::cout << key.pub.to_string () << std::endl;
 		auto wallet (node.node->wallets.create (key.pub));
-		wallet->enter_initial_password ();
 	}
 	else if (vm.count ("wallet_decrypt_unsafe"))
 	{

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1282,9 +1282,6 @@ thread ([this]() { do_wallet_actions (); })
 			auto wallet (std::make_shared<rai::wallet> (error, transaction, node_a, text));
 			if (!error)
 			{
-				node_a.background ([wallet]() {
-					wallet->enter_initial_password ();
-				});
 				items[id] = wallet;
 			}
 			else
@@ -1292,6 +1289,10 @@ thread ([this]() { do_wallet_actions (); })
 				// Couldn't open wallet
 			}
 		}
+	}
+	for (auto i (items.begin ()), n (items.end ()); i != n; ++i)
+	{
+		i->second->enter_initial_password ();
 	}
 }
 
@@ -1323,9 +1324,7 @@ std::shared_ptr<rai::wallet> rai::wallets::create (rai::uint256_union const & id
 	if (!error)
 	{
 		items[id_a] = result;
-		node.background ([result]() {
-			result->enter_initial_password ();
-		});
+		result->enter_initial_password ();
 	}
 	return result;
 }


### PR DESCRIPTION
& remove unnessesary enter_initial_password after wallets.create in cli.cpp