### PR TITLE
Abort if decoding hex numbers fails

### DIFF
--- a/rai/lib/numbers.cpp
+++ b/rai/lib/numbers.cpp
@@ -185,7 +185,9 @@ rai::uint256_union rai::uint256_union::operator^ (rai::uint256_union const & oth
 
 rai::uint256_union::uint256_union (std::string const & hex_a)
 {
-	decode_hex (hex_a);
+	auto error (decode_hex (hex_a));
+
+	assert (!error);
 }
 
 void rai::uint256_union::clear ()
@@ -429,7 +431,9 @@ bool rai::validate_message (rai::public_key const & public_key, rai::uint256_uni
 
 rai::uint128_union::uint128_union (std::string const & string_a)
 {
-	decode_hex (string_a);
+	auto error (decode_hex (string_a));
+
+	assert (!error);
 }
 
 rai::uint128_union::uint128_union (uint64_t value_a)

--- a/rai/lib/numbers.cpp
+++ b/rai/lib/numbers.cpp
@@ -187,7 +187,7 @@ rai::uint256_union::uint256_union (std::string const & hex_a)
 {
 	auto error (decode_hex (hex_a));
 
-	assert (!error);
+	release_assert (!error);
 }
 
 void rai::uint256_union::clear ()
@@ -433,7 +433,7 @@ rai::uint128_union::uint128_union (std::string const & string_a)
 {
 	auto error (decode_hex (string_a));
 
-	assert (!error);
+	release_assert (!error);
 }
 
 rai::uint128_union::uint128_union (uint64_t value_a)


### PR DESCRIPTION
Abort if decoding hex numbers fail in a constructor.

We may want to not merge this PR and instead get rid of this constructor as discussed in #888 but this is a start

Closes #888 