### PR TITLE
Check genesis on startup

### DIFF
--- a/rai/lib/utility.cpp
+++ b/rai/lib/utility.cpp
@@ -9,5 +9,5 @@ void release_assert_internal (bool check, const char * check_expr, const char * 
 	}
 
 	std::cerr << "Assertion (" << check_expr << ") failed " << file << ":" << line << std::endl;
-	abort();
+	abort ();
 }

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1855,13 +1855,19 @@ stats (config.stat_config)
 		{
 			BOOST_LOG (log) << "Constructing node";
 		}
+		rai::genesis genesis;
 		rai::transaction transaction (store.environment, true);
 		if (store.latest_begin (transaction) == store.latest_end ())
 		{
 			// Store was empty meaning we just created it, add the genesis block
-			rai::genesis genesis;
 			store.initialize (transaction, genesis);
 		}
+		if (!store.block_exists (transaction, genesis.hash ()))
+		{
+			BOOST_LOG (log) << "Genesis block not found. Make sure the node network ID is correct.";
+			std::exit (1);
+		}
+
 		node_id = rai::keypair (store.get_node_id (transaction));
 		BOOST_LOG (log) << "Node ID: " << node_id.pub.to_account ();
 	}


### PR DESCRIPTION
There seems to be nodes on betanet running with livenet databases (blocks are from livenet). Since it's easy to mix up databases when using `--data_path`, this PR proposes to check that the db contains the correct genesis block ~~write the network id into the `meta` db and abort the process if it doesn't match the process' network id on startup.~~