### PR TITLE
Make build from build folder instead of root source folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,9 @@ CTestTestfile.cmake
 install_manifest.txt
 Makefile
 Testing
+/build
+
+# Build generated files
+bootstrap_weights.cpp
+counters.stat
+samples.stat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ endif ()
 set (CPACK_PACKAGE_VENDOR "Nano Currency")
 
 set(CMAKE_INSTALL_RPATH "@executable_path/../Frameworks")
+
 # Create all libraries and executables in the root binary dir
+set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/build/bin")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 set (RAIBLOCKS_GUI OFF CACHE BOOL "")


### PR DESCRIPTION
Build from `build` folder to not pollute root source folder with CMake generated files, and easy cleaning up by just `rm -rf build`.

Configure the project build with the following command to create the `build` directory with the configuration.

```shell
mkdir build
cd build               # Create a build directory
cmake ..              # Configure the project
cmake --build .  # Build all default targets
```

To build `rai_node`: `cmake --build .  --target rai_node`
To build `wallet`: `cmake --build .  --target nano_wallet`

Target built files are in `<source>/build/bin`