### PR TITLE
Fix vote DB deserialization

### DIFF
--- a/rai/core_test/block_store.cpp
+++ b/rai/core_test/block_store.cpp
@@ -863,6 +863,26 @@ TEST (block_store, sequence_flush)
 	ASSERT_EQ (*seq3, *vote1);
 }
 
+TEST (block_store, sequence_flush_by_hash)
+{
+	auto path (rai::unique_path ());
+	bool init (false);
+	rai::block_store store (init, path);
+	ASSERT_FALSE (init);
+	rai::transaction transaction (store.environment, true);
+	rai::keypair key1;
+	std::vector<rai::block_hash> blocks1;
+	blocks1.push_back (rai::genesis ().hash ());
+	blocks1.push_back (1234);
+	blocks1.push_back (5678);
+	auto vote1 (store.vote_generate (transaction, key1.pub, key1.prv, blocks1));
+	auto seq2 (store.vote_get (transaction, vote1->account));
+	ASSERT_EQ (nullptr, seq2);
+	store.flush (transaction);
+	auto seq3 (store.vote_get (transaction, vote1->account));
+	ASSERT_EQ (*seq3, *vote1);
+}
+
 // Upgrading tracking block sequence numbers to whole vote.
 TEST (block_store, upgrade_v8_v9)
 {

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -231,16 +231,10 @@ rai::mdb_val::operator std::shared_ptr<rai::state_block> () const
 
 rai::mdb_val::operator std::shared_ptr<rai::vote> () const
 {
-	auto result (std::make_shared<rai::vote> ());
 	rai::bufferstream stream (reinterpret_cast<uint8_t const *> (value.mv_data), value.mv_size);
-	auto error (rai::read (stream, result->account.bytes));
+	auto error (false);
+	std::shared_ptr<rai::vote> result (std::make_shared<rai::vote> (error, stream));
 	assert (!error);
-	error = rai::read (stream, result->signature.bytes);
-	assert (!error);
-	error = rai::read (stream, result->sequence);
-	assert (!error);
-	result->blocks.push_back (rai::deserialize_block (stream));
-	assert (boost::get<std::shared_ptr<rai::block>> (result->blocks[0]) != nullptr);
 	return result;
 }
 


### PR DESCRIPTION
28945d6 copied the vote constructor, but was rebased on top of vote by hash where that changed. This also adds a test for the behavior.