### PR TITLE
Remove unused param from daemon_config ctor

### DIFF
--- a/rai/rai_node/daemon.cpp
+++ b/rai/rai_node/daemon.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <rai/node/working.hpp>
 
-rai_daemon::daemon_config::daemon_config (boost::filesystem::path const & application_path_a) :
+rai_daemon::daemon_config::daemon_config () :
 rpc_enable (false),
 opencl_enable (false)
 {
@@ -96,7 +96,7 @@ bool rai_daemon::daemon_config::upgrade_json (unsigned version_a, boost::propert
 void rai_daemon::daemon::run (boost::filesystem::path const & data_path)
 {
 	boost::filesystem::create_directories (data_path);
-	rai_daemon::daemon_config config (data_path);
+	rai_daemon::daemon_config config;
 	auto config_path ((data_path / "config.json"));
 	std::fstream config_file;
 	std::unique_ptr<rai::thread_runner> runner;

--- a/rai/rai_node/daemon.hpp
+++ b/rai/rai_node/daemon.hpp
@@ -11,7 +11,7 @@ public:
 class daemon_config
 {
 public:
-	daemon_config (boost::filesystem::path const &);
+	daemon_config ();
 	bool deserialize_json (bool &, boost::property_tree::ptree &);
 	void serialize_json (boost::property_tree::ptree &);
 	bool upgrade_json (unsigned, boost::property_tree::ptree &);


### PR DESCRIPTION
Removed unused parameter `application_path_a` from `daemon_config` constructor.