### PR TITLE
Require 2 conditions to confirm election

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3600,14 +3600,14 @@ void rai::election::confirm_if_quorum (rai::transaction const & transaction_a)
 	{
 		sum += i.first;
 	}
-	if (sum >= node.config.online_weight_minimum.number () && !(*block_l == *status.winner))
+	if (sum >= node.config.online_weight_minimum.number () && have_quorum (tally_l))
 	{
-		auto node_l (node.shared ());
-		node_l->block_processor.force (block_l);
-		status.winner = block_l;
-	}
-	if (have_quorum (tally_l))
-	{
+		if (block_l->hash () != status.winner->hash ())
+		{
+			auto node_l (node.shared ());
+			node_l->block_processor.force (block_l);
+			status.winner = block_l;
+		}
 		if (node.config.logging.vote_logging () || blocks.size () > 1)
 		{
 			log_votes (tally_l);


### PR DESCRIPTION
Both sum >= node.config.online_weight_minimum & have_quorum () required
To prevent possible situations with confirmed election without calling block_processor.force or block_processor.force without confirmed election