### PR TITLE
Compare value in merge itr only when key is equal

### DIFF
--- a/rai/core_test/block_store.cpp
+++ b/rai/core_test/block_store.cpp
@@ -140,6 +140,55 @@ TEST (block_store, pending_iterator)
 	ASSERT_EQ (rai::epoch::epoch_1, pending.epoch);
 }
 
+/**
+ * Regression test for Issue 1164
+ * This reconstructs the situation where a key is larger in pending than the account being iterated in pending_v1, leaving
+ * iteration order up to the value, causing undefined behavior.
+ * After the bugfix, the value is compared only if the keys are equal.
+ */
+TEST (block_store, pending_iterator_comparison)
+{
+	bool init (false);
+	rai::mdb_store store (init, rai::unique_path ());
+	ASSERT_TRUE (!init);
+	rai::stat stats;
+	auto transaction (store.tx_begin (true));
+	// Populate pending
+	store.pending_put (transaction, rai::pending_key (rai::account (3), rai::block_hash (1)), rai::pending_info (rai::account (10), rai::amount (1), rai::epoch::epoch_0));
+	store.pending_put (transaction, rai::pending_key (rai::account (3), rai::block_hash (4)), rai::pending_info (rai::account (10), rai::amount (0), rai::epoch::epoch_0));
+	// Populate pending_v1
+	store.pending_put (transaction, rai::pending_key (rai::account (2), rai::block_hash (2)), rai::pending_info (rai::account (10), rai::amount (2), rai::epoch::epoch_1));
+	store.pending_put (transaction, rai::pending_key (rai::account (2), rai::block_hash (3)), rai::pending_info (rai::account (10), rai::amount (3), rai::epoch::epoch_1));
+
+	// Iterate account 3 (pending)
+	{
+		size_t count = 0;
+		rai::account begin (3);
+		rai::account end (begin.number () + 1);
+		for (auto i (store.pending_begin (transaction, rai::pending_key (begin, 0))), n (store.pending_begin (transaction, rai::pending_key (end, 0))); i != n; ++i, ++count)
+		{
+			rai::pending_key key (i->first);
+			ASSERT_EQ (key.account, begin);
+			ASSERT_LT (count, 3);
+		}
+		ASSERT_EQ (count, 2);
+	}
+
+	// Iterate account 2 (pending_v1)
+	{
+		size_t count = 0;
+		rai::account begin (2);
+		rai::account end (begin.number () + 1);
+		for (auto i (store.pending_begin (transaction, rai::pending_key (begin, 0))), n (store.pending_begin (transaction, rai::pending_key (end, 0))); i != n; ++i, ++count)
+		{
+			rai::pending_key key (i->first);
+			ASSERT_EQ (key.account, begin);
+			ASSERT_LT (count, 3);
+		}
+		ASSERT_EQ (count, 2);
+	}
+}
+
 TEST (block_store, genesis)
 {
 	bool init (false);

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -626,8 +626,20 @@ rai::mdb_iterator<T, U> & rai::mdb_merge_iterator<T, U>::least_iterator () const
 	else
 	{
 		auto key_cmp (mdb_cmp (mdb_cursor_txn (impl1->cursor), mdb_cursor_dbi (impl1->cursor), impl1->current.first, impl2->current.first));
-		auto val_cmp (mdb_cmp (mdb_cursor_txn (impl1->cursor), mdb_cursor_dbi (impl1->cursor), impl1->current.second, impl2->current.second));
-		result = key_cmp < 0 ? impl1.get () : val_cmp < 0 ? impl1.get () : impl2.get ();
+
+		if (key_cmp < 0)
+		{
+			result = impl1.get ();
+		}
+		else if (key_cmp > 0)
+		{
+			result = impl2.get ();
+		}
+		else
+		{
+			auto val_cmp (mdb_cmp (mdb_cursor_txn (impl1->cursor), mdb_cursor_dbi (impl1->cursor), impl1->current.second, impl2->current.second));
+			result = val_cmp < 0 ? impl1.get () : impl2.get ();
+		}
 	}
 	return *result;
 }


### PR DESCRIPTION
Fixes https://github.com/nanocurrency/raiblocks/issues/1164