### PR TITLE
Remove redundant config_file parameter of fetch_object

### DIFF
--- a/nano/core_test/uint256_union.cpp
+++ b/nano/core_test/uint256_union.cpp
@@ -468,7 +468,7 @@ TEST (json, fetch_object)
 	stream1.close ();
 	nano::open_or_create (stream1, path1.string ());
 	json_upgrade_test object1;
-	auto error1 (nano::fetch_object (object1, path1, stream1));
+	auto error1 (nano::fetch_object (object1, path1));
 	ASSERT_FALSE (error1);
 	ASSERT_EQ ("changed", object1.text);
 	boost::property_tree::ptree tree1;
@@ -492,7 +492,7 @@ TEST (json, fetch_object)
 	std::fstream stream4;
 	nano::open_or_create (stream4, path2.string ());
 	json_upgrade_test object4;
-	auto error4 (nano::fetch_object (object4, path2, stream4));
+	auto error4 (nano::fetch_object (object4, path2));
 	ASSERT_FALSE (error4);
 	ASSERT_EQ ("created", object4.text);
 	boost::property_tree::ptree tree2;

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -101,9 +101,8 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 	nano_daemon::daemon_config config;
 	nano::set_secure_perm_directory (data_path, error_chmod);
 	auto config_path ((data_path / "config.json"));
-	std::fstream config_file;
 	std::unique_ptr<nano::thread_runner> runner;
-	auto error (nano::fetch_object (config, config_path, config_file));
+	auto error (nano::fetch_object (config, config_path));
 	nano::set_secure_perm_file (config_path, error_chmod);
 	if (!error)
 	{

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -107,7 +107,6 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 	if (!error)
 	{
 		config.node.logging.init (data_path);
-		config_file.close ();
 		boost::asio::io_context io_ctx;
 		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, config.node.logging));
 		nano::work_pool opencl_work (config.node.work_threads, opencl ? [&opencl](nano::uint256_union const & root_a) {

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -174,13 +174,12 @@ bool update_config (qt_wallet_config & config_a, boost::filesystem::path const &
 	auto account (config_a.account);
 	auto wallet (config_a.wallet);
 	auto error (false);
-	if (!nano::fetch_object (config_a, config_path_a, config_file_a))
+	if (!nano::fetch_object (config_a, config_path_a))
 	{
 		if (account != config_a.account || wallet != config_a.wallet)
 		{
 			config_a.account = account;
 			config_a.wallet = wallet;
-			config_file_a.close ();
 			config_file_a.open (config_path_a.string (), std::ios_base::out | std::ios_base::trunc);
 			error = config_a.serialize_json_stream (config_file_a);
 		}
@@ -205,7 +204,7 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 	auto config_path ((data_path / "config.json"));
 	int result (0);
 	std::fstream config_file;
-	auto error (nano::fetch_object (config, config_path, config_file));
+	auto error (nano::fetch_object (config, config_path));
 	config_file.close ();
 	nano::set_secure_perm_file (config_path, error_chmod);
 	if (!error)


### PR DESCRIPTION
`rai::fetch_object` doesn't need `config_file` parameter, `config_file` is only used inside this function, carries no input/output.

Close #1143