### PR TITLE
Script to make source tarball to replace Github's broken one

### DIFF
--- a/util/makesrc
+++ b/util/makesrc
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+#    makesrc <tag>
+#    requires ruby gem github_changelog_generator
+#    API_KEY generated here https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token
+
+if [ -e $1 ]; then
+	echo "makesrc <tag> - valid <tag> for nanocurrency/raiblocks"
+	exit 1
+fi
+TAG="$1"
+VERSION=`echo $TAG | sed 's/V//'`
+TAG_DATE=""
+VERSION_MAJOR=`echo $VERSION |cut -d "." -f 1`
+function make_source () {
+	git clone --recursive --single-branch --branch releases/v${VERSION_MAJOR} https://github.com/nanocurrency/raiblocks nano-$VERSION
+	cd nano-$VERSION
+	COUNT=`git tag -l "${TAG}" | wc -l`
+	if [ "$COUNT" -eq 0 ]; then
+		echo "tag $TAG not found"
+		exit 1
+	else
+		git checkout "${TAG}"
+	fi
+	source_information
+	rm -fr */.git .git* .clang-format .travis.yml appveyor.yml asan_blacklist ci docker
+	find . -type f ! -print 2>/dev/null | egrep -v '^\./(MD5SUMS|SHA256SUMS)$' | sort -u | sed s/'^\.\/'/''/ | sed 's/ /\\ /g' | xargs openssl md5 | sed 's@MD5(\(.*\))= \([0-9a-f]*\)@\2  \1@' > MD5SUMS 2>/dev/null
+	find . -type f ! -print 2>/dev/null | egrep -v '^\./(SHA256SUMS)$' | sort -u | sed s/'^\.\/'/''/ | sed 's/ /\\ /g' | xargs openssl sha1 -sha256 | sed 's@SHA256(\(.*\))= \([0-9a-f]*\)@\2  \1@' > SHA256SUMS 2>/dev/null
+	tarball_creation
+}
+function source_information () {
+	DATE=`git log --tags --simplify-by-decoration --pretty="format:%ai %d" | head -1 |cut -d " " -f1-3`
+	COMMIT=`git log | head -1 | cut -d " " -f 2`
+	TAG_DATE=`TZ=UTC date -d"$DATE" +%s`
+	github_changelog_generator -t "${API_KEY}" -u nanocurrency -p raiblocks --release_branch releases/v${VERSION_MAJOR} --no-issues --simple-list true
+	if [ ! -f CHANGELOG.md ]; then
+		echo "CHANGELOG not generated is github_changelog_generator gem installed"
+		exit 1
+	fi
+	export TAG_DATE
+}
+function cleanup_source () {
+	mv nano-$VERSION.tar.gz ~/.
+	echo "ARCHIVE MOVDED TO HOME..."
+	rm -fr nano-$TAG/
+
+}
+function tarball_creation() {
+	cd ..
+	ARCHIVE_FILE_NAME="nano-${VERSION}.tar.gz"
+	echo "CREATING ${ARCHIVE_FILE_NAME}..."
+	# Determine if we can create a stable archive
+	tarArgs=()
+	if tar -Pcf - /dev/null | tar --sort=name -Ptvf - >/dev/null 2>/dev/null; then
+	tarArgs=("${tarArgs[@]}" --sort=name)
+	fi
+	if tar -Pcf - /dev/null | tar --owner=root:0 --group=root:0 -Ptvf - >/dev/null 2>/dev/null; then
+		tarArgs=("${tarArgs[@]}" --owner=root:0 --group=root:0)
+	fi
+	if [ -n "${TAG_DATE}" ]; then
+		if tar -Pcf - /dev/null | TZ=UTC tar --mtime="${TAG_DATE}" -Ptvf - >/dev/null 2>/dev/null; then
+			tarArgs=("${tarArgs[@]}" --mtime="@${TAG_DATE}")
+		fi
+	fi
+	TZ=UTC LANG=C LC_ALL=C tar "${tarArgs[@]}" -cvf - nano-${VERSION} | TZ=UTC gzip --no-name -9c > "${ARCHIVE_FILE_NAME}" || exit 1
+}
+make_source
+cleanup_source
+


### PR DESCRIPTION
Script will create source tarball to replace github releases broken automatically created ones fixed #1109 
Next issue will be to automate this script as an artifact in one of the CI/CD tools.

makesrc <tag>
requires ruby gem github_changelog_generator
API_KEY generated here https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token

