### PR TITLE
Minimum bootstrap node version

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2123,7 +2123,7 @@ rai::endpoint rai::peer_container::bootstrap_peer ()
 	;
 	for (auto i (peers.get<4> ().begin ()), n (peers.get<4> ().end ()); i != n;)
 	{
-		if (i->network_version >= 0x5)
+		if (i->network_version >= protocol_version_bootstrap_min)
 		{
 			result = i->endpoint;
 			peers.get<4> ().modify (i, [](rai::peer_information & peer_a) {

--- a/rai/secure/common.hpp
+++ b/rai/secure/common.hpp
@@ -29,6 +29,9 @@ const uint8_t protocol_version = 0x0f;
 const uint8_t protocol_version_min = 0x07;
 const uint8_t node_id_version = 0x0c;
 
+/** Do not bootstrap from nodes older than this version */
+const uint8_t protocol_version_bootstrap_min = 0x0d;
+
 /**
  * A key pair. The private key is generated from the random pool, or passed in
  * as a hex string. The public key is derived using ed25519.


### PR DESCRIPTION
About 18% of the bootstrap targets are nodes that can never be in sync - this sets the minimum version to ensure the node groks VBH (please verify version). An alternative is to depeer them outright, or we can use this as a first step.