### PR TITLE
Add "latest-rc" tag for Docker

### DIFF
--- a/ci/deploy-docker.sh
+++ b/ci/deploy-docker.sh
@@ -12,7 +12,7 @@ fi
 
 tags=()
 if [[ "${TRAVIS_TAG}" =~ 'RC' ]]; then
-    tags+=("$TRAVIS_TAG")
+    tags+=("$TRAVIS_TAG" latest-rc)
 elif [ -n "$TRAVIS_TAG" ]; then
     tags+=("$TRAVIS_TAG" latest)
 elif [ -n "$TRAVIS_BRANCH" ]; then

--- a/ci/deploy-docker.sh
+++ b/ci/deploy-docker.sh
@@ -12,9 +12,9 @@ fi
 
 tags=()
 if [[ "${TRAVIS_TAG}" =~ 'RC' ]]; then
-    tags+=("$TRAVIS_TAG" latest-rc)
+    tags+=("$TRAVIS_TAG" latest-including-rc)
 elif [ -n "$TRAVIS_TAG" ]; then
-    tags+=("$TRAVIS_TAG" latest)
+    tags+=("$TRAVIS_TAG" latest latest-including-rc)
 elif [ -n "$TRAVIS_BRANCH" ]; then
     tags+=("$TRAVIS_BRANCH")
 fi


### PR DESCRIPTION
So we can pull the "latest-rc" tag that points to the latest release candidate.