### PR TITLE
 Store block_info for each 4 legacy blocks

### DIFF
--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -1046,7 +1046,7 @@ void rai::mdb_store::upgrade_v10_to_v11 (rai::transaction const & transaction_a)
 
 void rai::mdb_store::upgrade_v11_to_v12 (rai::transaction const & transaction_a)
 {
-	std::cout << boost::str (boost::format ("Performing database upgrade to version 12 ...\n"));
+	//std::cout << boost::str (boost::format ("Performing database upgrade to version 12 ...\n"));
 	version_put (transaction_a, 12);
 	for (auto i (latest_v0_begin (transaction_a)), n (latest_v0_end ()); i != n; ++i)
 	{

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -1032,6 +1032,7 @@ void rai::mdb_store::upgrade_v8_to_v9 (rai::transaction const & transaction_a)
 
 void rai::mdb_store::upgrade_v9_to_v10 (rai::transaction const & transaction_a)
 {
+	version_put (transaction_a, 10);
 	// Replaced with upgrade_v11_to_v12
 }
 
@@ -1045,7 +1046,7 @@ void rai::mdb_store::upgrade_v10_to_v11 (rai::transaction const & transaction_a)
 
 void rai::mdb_store::upgrade_v11_to_v12 (rai::transaction const & transaction_a)
 {
-	std::cout << boost::str (boost::format ("Performing database upgrade to version 12...\n"));
+	std::cout << boost::str (boost::format ("Performing database upgrade to version 12 ...\n"));
 	version_put (transaction_a, 12);
 	for (auto i (latest_v0_begin (transaction_a)), n (latest_v0_end ()); i != n; ++i)
 	{
@@ -1053,7 +1054,7 @@ void rai::mdb_store::upgrade_v11_to_v12 (rai::transaction const & transaction_a)
 		if (info.block_count >= block_info_max)
 		{
 			rai::account account (i->first);
-			std::cout << boost::str (boost::format ("Upgrading account %1%...\n") % account.to_account ());
+			std::cout << boost::str (boost::format ("Upgrading account %1% ...\n") % account.to_account ());
 			size_t block_count (1);
 			auto hash (info.open_block);
 			auto block (block_get (transaction_a, hash));

--- a/rai/secure/blockstore.hpp
+++ b/rai/secure/blockstore.hpp
@@ -151,7 +151,7 @@ public:
 	virtual rai::store_iterator<rai::block_hash, rai::block_info> block_info_end () = 0;
 	virtual rai::uint128_t block_balance (rai::transaction const &, rai::block_hash const &) = 0;
 	virtual rai::epoch block_version (rai::transaction const &, rai::block_hash const &) = 0;
-	static size_t const block_info_max = 32;
+	static size_t const block_info_max = 4;
 
 	virtual rai::uint128_t representation_get (rai::transaction const &, rai::account const &) = 0;
 	virtual void representation_put (rai::transaction const &, rai::account const &, rai::uint128_t const &) = 0;


### PR DESCRIPTION
To reduce interations for calculation of block amount