### PR TITLE
Swallow exceptions regarding changing filesystem permissions

### DIFF
--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -10,12 +10,12 @@
 
 rai::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, int max_dbs)
 {
-	boost::system::error_code error;
+	boost::system::error_code error_mkdir, error_chmod;
 	if (path_a.has_parent_path ())
 	{
-		boost::filesystem::create_directories (path_a.parent_path (), error);
-		boost::filesystem::permissions (path_a.parent_path (), boost::filesystem::owner_all);
-		if (!error)
+		boost::filesystem::create_directories (path_a.parent_path (), error_mkdir);
+		boost::filesystem::permissions (path_a.parent_path (), boost::filesystem::owner_all, error_chmod);
+		if (!error_mkdir)
 		{
 			auto status1 (mdb_env_create (&environment));
 			assert (status1 == 0);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2441,9 +2441,11 @@ void rai::node::backup_wallet ()
 	auto transaction (store.tx_begin_read ());
 	for (auto i (wallets.items.begin ()), n (wallets.items.end ()); i != n; ++i)
 	{
+		boost::system::error_code error_chmod;
 		auto backup_path (application_path / "backup");
+
 		boost::filesystem::create_directories (backup_path);
-		boost::filesystem::permissions (backup_path, boost::filesystem::owner_all);
+		boost::filesystem::permissions (backup_path, boost::filesystem::owner_all, error_chmod);
 		i->second->store.write_backup (transaction, backup_path / (i->first.to_string () + ".json"));
 	}
 	auto this_l (shared ());
@@ -4116,8 +4118,13 @@ service (boost::make_shared<boost::asio::io_service> ()),
 alarm (*service),
 work (1, nullptr)
 {
+	boost::system::error_code error_chmod;
+
+	/*
+	 * @warning May throw a filesystem exception
+	 */
 	boost::filesystem::create_directories (path);
-	boost::filesystem::permissions (path, boost::filesystem::owner_all);
+	boost::filesystem::permissions (path, boost::filesystem::owner_all, error_chmod);
 	logging.max_size = std::numeric_limits<std::uintmax_t>::max ();
 	logging.init (path);
 	node = std::make_shared<rai::node> (init, *service, 24000, path, alarm, logging, work);

--- a/rai/rai_node/daemon.cpp
+++ b/rai/rai_node/daemon.cpp
@@ -95,14 +95,15 @@ bool rai_daemon::daemon_config::upgrade_json (unsigned version_a, boost::propert
 
 void rai_daemon::daemon::run (boost::filesystem::path const & data_path)
 {
+	boost::system::error_code error_chmod;
 	boost::filesystem::create_directories (data_path);
-	boost::filesystem::permissions (data_path, boost::filesystem::owner_all);
+	boost::filesystem::permissions (data_path, boost::filesystem::owner_all, error_chmod);
 	rai_daemon::daemon_config config (data_path);
 	auto config_path ((data_path / "config.json"));
 	std::fstream config_file;
 	std::unique_ptr<rai::thread_runner> runner;
 	auto error (rai::fetch_object (config, config_path, config_file));
-	boost::filesystem::permissions (config_path, boost::filesystem::owner_read | boost::filesystem::owner_write);
+	boost::filesystem::permissions (config_path, boost::filesystem::owner_read | boost::filesystem::owner_write, error_chmod);
 	if (!error)
 	{
 		config.node.logging.init (data_path);

--- a/rai/rai_wallet/entry.cpp
+++ b/rai/rai_wallet/entry.cpp
@@ -190,8 +190,9 @@ bool update_config (qt_wallet_config & config_a, boost::filesystem::path const &
 int run_wallet (QApplication & application, int argc, char * const * argv, boost::filesystem::path const & data_path)
 {
 	rai_qt::eventloop_processor processor;
+	boost::system::error_code error_chmod;
 	boost::filesystem::create_directories (data_path);
-	boost::filesystem::permissions (data_path, boost::filesystem::owner_all);
+	boost::filesystem::permissions (data_path, boost::filesystem::owner_all, error_chmod);
 	QPixmap pixmap (":/logo.png");
 	QSplashScreen * splash = new QSplashScreen (pixmap);
 	splash->show ();
@@ -204,7 +205,7 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 	std::fstream config_file;
 	auto error (rai::fetch_object (config, config_path, config_file));
 	config_file.close ();
-	boost::filesystem::permissions (config_path, boost::filesystem::owner_read | boost::filesystem::owner_write);
+	boost::filesystem::permissions (config_path, boost::filesystem::owner_read | boost::filesystem::owner_write, error_chmod);
 	if (!error)
 	{
 		boost::asio::io_service service;


### PR DESCRIPTION
If the user has not granted access to change permissions, don't abort when trying to change permissions