### PR TITLE
Resize stack to 8MB to match Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif ()
 if (APPLE)
 	set (PLATFORM_LINK_FLAGS "-framework Foundation -framework OpenCL")
 elseif (WIN32)
-	set (PLATFORM_LINK_FLAGS "")
+	set (PLATFORM_LINK_FLAGS "/STACK:8000000") #provides 8MB default stack size for linux on windows
 else ()
 	set (PLATFORM_LINK_FLAGS "-static-libgcc -static-libstdc++")
 	if (RAIBLOCKS_ASAN)


### PR DESCRIPTION
Fixes #1212 by setting stack size to 8MB to match linux