### PR TITLE
Better error messages

### DIFF
--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -87,9 +87,9 @@ void rai::message_header::ipv4_only_set (bool value_a)
 // MTU - IP header - UDP header
 const size_t rai::message_parser::max_safe_udp_message_size = 508;
 
-const char * rai::message_parser::parse_status_to_string (const rai::message_parser::parse_status & id)
+std::string rai::message_parser::status_string ()
 {
-	switch (id)
+	switch (status)
 	{
 		case rai::message_parser::parse_status::success:
 		{

--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -87,6 +87,57 @@ void rai::message_header::ipv4_only_set (bool value_a)
 // MTU - IP header - UDP header
 const size_t rai::message_parser::max_safe_udp_message_size = 508;
 
+const char * operator~ (const rai::message_parser::parse_status & id)
+{
+	switch (id)
+	{
+		case rai::message_parser::parse_status::success:
+		{
+			return "success";
+		}
+		case rai::message_parser::parse_status::insufficient_work:
+		{
+			return "insufficient_work";
+		}
+		case rai::message_parser::parse_status::invalid_header:
+		{
+			return "invalid_header";
+		}
+		case rai::message_parser::parse_status::invalid_message_type:
+		{
+			return "invalid_message_type";
+		}
+		case rai::message_parser::parse_status::invalid_keepalive_message:
+		{
+			return "invalid_keepalive_message";
+		}
+		case rai::message_parser::parse_status::invalid_publish_message:
+		{
+			return "invalid_publish_message";
+		}
+		case rai::message_parser::parse_status::invalid_confirm_req_message:
+		{
+			return "invalid_confirm_req_message";
+		}
+		case rai::message_parser::parse_status::invalid_confirm_ack_message:
+		{
+			return "invalid_confirm_ack_message";
+		}
+		case rai::message_parser::parse_status::invalid_node_id_handshake_message:
+		{
+			return "invalid_node_id_handshake_message";
+		}
+		case rai::message_parser::parse_status::outdated_version:
+		{
+			return "outdated_version";
+		}
+	}
+
+	assert (false);
+
+	return "[unknown parse_status]";
+}
+
 rai::message_parser::message_parser (rai::message_visitor & visitor_a, rai::work_pool & pool_a) :
 visitor (visitor_a),
 pool (pool_a),

--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -131,6 +131,14 @@ const char * operator~ (const rai::message_parser::parse_status & id)
 		{
 			return "outdated_version";
 		}
+		case rai::message_parser::parse_status::invalid_magic:
+		{
+			return "invalid_magic";
+		}
+		case rai::message_parser::parse_status::invalid_network:
+		{
+			return "invalid_network";
+		}
 	}
 
 	assert (false);

--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -87,7 +87,7 @@ void rai::message_header::ipv4_only_set (bool value_a)
 // MTU - IP header - UDP header
 const size_t rai::message_parser::max_safe_udp_message_size = 508;
 
-const char * operator~ (const rai::message_parser::parse_status & id)
+const char * rai::message_parser::parse_status_to_string (const rai::message_parser::parse_status & id)
 {
 	switch (id)
 	{

--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -367,3 +367,9 @@ inline uint64_t seconds_since_epoch ()
 	return std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now ().time_since_epoch ()).count ();
 }
 }
+
+/*
+ * Allow "parse_status" enum class to be explicitly converted to a
+ * string describing that item.
+ */
+const char * operator~ (const rai::message_parser::parse_status &);

--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -214,6 +214,11 @@ public:
 		invalid_magic,
 		invalid_network
 	};
+	/*
+	 * Allow "parse_status" enum class to be explicitly converted to a
+	 * string describing that item.
+	 */
+	static const char * parse_status_to_string (const rai::message_parser::parse_status &);
 	message_parser (rai::message_visitor &, rai::work_pool &);
 	void deserialize_buffer (uint8_t const *, size_t);
 	void deserialize_keepalive (rai::stream &, rai::message_header const &);
@@ -367,9 +372,3 @@ inline uint64_t seconds_since_epoch ()
 	return std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now ().time_since_epoch ()).count ();
 }
 }
-
-/*
- * Allow "parse_status" enum class to be explicitly converted to a
- * string describing that item.
- */
-const char * operator~ (const rai::message_parser::parse_status &);

--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -214,11 +214,6 @@ public:
 		invalid_magic,
 		invalid_network
 	};
-	/*
-	 * Allow "parse_status" enum class to be explicitly converted to a
-	 * string describing that item.
-	 */
-	static const char * parse_status_to_string (const rai::message_parser::parse_status &);
 	message_parser (rai::message_visitor &, rai::work_pool &);
 	void deserialize_buffer (uint8_t const *, size_t);
 	void deserialize_keepalive (rai::stream &, rai::message_header const &);
@@ -230,6 +225,7 @@ public:
 	rai::message_visitor & visitor;
 	rai::work_pool & pool;
 	parse_status status;
+	std::string status_string ();
 	static const size_t max_safe_udp_message_size;
 };
 class keepalive : public message

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -619,14 +619,28 @@ void rai::network::receive_action (rai::udp_data * data_a)
 					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_network);
 					break;
 				case rai::message_parser::parse_status::invalid_header:
+					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_header);
+					break;
 				case rai::message_parser::parse_status::invalid_message_type:
+					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_message_type);
+					break;
 				case rai::message_parser::parse_status::invalid_keepalive_message:
+					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_keepalive_message);
+					break;
 				case rai::message_parser::parse_status::invalid_publish_message:
+					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_publish_message);
+					break;
 				case rai::message_parser::parse_status::invalid_confirm_req_message:
+					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_confirm_req_message);
+					break;
 				case rai::message_parser::parse_status::invalid_confirm_ack_message:
+					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_confirm_ack_message);
+					break;
 				case rai::message_parser::parse_status::invalid_node_id_handshake_message:
+					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_node_id_handshake_message);
+					break;
 				case rai::message_parser::parse_status::outdated_version:
-					/* XXX:TODO */
+					node.stats.inc (rai::stat::type::udp, rai::stat::detail::outdated_version);
 					break;
 				case rai::message_parser::parse_status::success:
 					/* Already checked, unreachable */

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -635,7 +635,7 @@ void rai::network::receive_action (rai::udp_data * data_a)
 
 			if (node.config.logging.network_logging ())
 			{
-				BOOST_LOG (node.log) << "Could not parse message.  Error: " << ~parser.status;
+				BOOST_LOG (node.log) << "Could not parse message.  Error: " << rai::message_parser::parse_status_to_string (parser.status);
 			}
 		}
 		else

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1952,7 +1952,7 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 						{
 							if (!node_l->bootstrap_initiator.in_progress ())
 							{
-								BOOST_LOG (node_l->log) << boost::str (boost::format ("Missing confirmed block %1%") % hash.to_string ());
+								BOOST_LOG (node_l->log) << boost::str (boost::format ("Missing block %1% which has enough votes to warrant bootstrapping it") % hash.to_string ());
 							}
 							node_l->bootstrap_initiator.bootstrap ();
 						}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -649,7 +649,7 @@ void rai::network::receive_action (rai::udp_data * data_a)
 
 			if (node.config.logging.network_logging ())
 			{
-				BOOST_LOG (node.log) << "Could not parse message.  Error: " << rai::message_parser::parse_status_to_string (parser.status);
+				BOOST_LOG (node.log) << "Could not parse message.  Error: " << parser.status_string ();
 			}
 		}
 		else

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -684,7 +684,7 @@ void rai::network::receive_action (rai::udp_data * data_a)
 			}
 			else
 			{
-				BOOST_LOG (node.log) << "Could not deserialize buffer";
+				BOOST_LOG (node.log) << "Could not deserialize buffer (error = " << ~parser.status << ")";
 			}
 		}
 		else

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -607,7 +607,8 @@ void rai::network::receive_action (rai::udp_data * data_a)
 		{
 			node.stats.inc (rai::stat::type::error);
 
-			switch (parser.status) {
+			switch (parser.status)
+			{
 				case rai::message_parser::parse_status::insufficient_work:
 					// We've already increment error count, update detail only
 					node.stats.inc_detail_only (rai::stat::type::error, rai::stat::detail::insufficient_work);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -618,6 +618,16 @@ void rai::network::receive_action (rai::udp_data * data_a)
 				case rai::message_parser::parse_status::invalid_network:
 					node.stats.inc (rai::stat::type::udp, rai::stat::detail::invalid_network);
 					break;
+				case rai::message_parser::parse_status::invalid_header:
+				case rai::message_parser::parse_status::invalid_message_type:
+				case rai::message_parser::parse_status::invalid_keepalive_message:
+				case rai::message_parser::parse_status::invalid_publish_message:
+				case rai::message_parser::parse_status::invalid_confirm_req_message:
+				case rai::message_parser::parse_status::invalid_confirm_ack_message:
+				case rai::message_parser::parse_status::invalid_node_id_handshake_message:
+				case rai::message_parser::parse_status::outdated_version:
+					/* XXX:TODO */
+					break;
 				case rai::message_parser::parse_status::success:
 					/* Already checked, unreachable */
 					break;

--- a/rai/node/stats.cpp
+++ b/rai/node/stats.cpp
@@ -445,6 +445,30 @@ std::string rai::stat::detail_to_string (uint32_t key)
 		case rai::stat::detail::invalid_network:
 			res = "invalid_network";
 			break;
+		case rai::stat::detail::invalid_header:
+			res = "invalid_header";
+			break;
+		case rai::stat::detail::invalid_message_type:
+			res = "invalid_message_type";
+			break;
+		case rai::stat::detail::invalid_keepalive_message:
+			res = "invalid_keepalive_message";
+			break;
+		case rai::stat::detail::invalid_publish_message:
+			res = "invalid_publish_message";
+			break;
+		case rai::stat::detail::invalid_confirm_req_message:
+			res = "invalid_confirm_req_message";
+			break;
+		case rai::stat::detail::invalid_confirm_ack_message:
+			res = "invalid_confirm_ack_message";
+			break;
+		case rai::stat::detail::invalid_node_id_handshake_message:
+			res = "invalid_node_id_handshake_message";
+			break;
+		case rai::stat::detail::outdated_version:
+			res = "outdated_version";
+			break;
 	}
 	return res;
 }

--- a/rai/node/stats.hpp
+++ b/rai/node/stats.hpp
@@ -233,6 +233,14 @@ public:
 		overflow,
 		invalid_magic,
 		invalid_network,
+		invalid_header,
+		invalid_message_type,
+		invalid_keepalive_message,
+		invalid_publish_message,
+		invalid_confirm_req_message,
+		invalid_confirm_ack_message,
+		invalid_node_id_handshake_message,
+		outdated_version,
 
 		// peering
 		handshake,


### PR DESCRIPTION
Better error messages for gap_cache::vote (Fixes #1208)

Better error messages when deserializing buffers (Fixes #1207)