### PR TITLE
Basic confirm_req improvements

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -339,20 +339,13 @@ void rai::network::broadcast_confirm_req (std::shared_ptr<rai::block> block_a)
 	broadcast_confirm_req_base (block_a, list, 0);
 }
 
-void rai::network::broadcast_confirm_req_base (std::shared_ptr<rai::block> block_a, std::shared_ptr<std::vector<rai::peer_information>> endpoints_a, unsigned delay_a)
+void rai::network::broadcast_confirm_req_base (std::shared_ptr<rai::block> block_a, std::shared_ptr<std::vector<rai::peer_information>> endpoints_a, unsigned delay_a, bool resumption)
 {
 	const size_t max_reps = 10;
-	if (node.config.logging.network_logging ())
+	if (!resumption && node.config.logging.network_logging ())
 	{
-		auto endpoint_count (endpoints_a->size ());
-		if (endpoint_count > max_reps)
-		{
-			endpoint_count = max_reps;
-		}
-
-		BOOST_LOG (node.log) << boost::str (boost::format ("Broadcasting confirm req for block %1% to %2% representatives") % block_a->hash ().to_string () % endpoint_count);
+		BOOST_LOG (node.log) << boost::str (boost::format ("Broadcasting confirm req for block %1% to %2% representatives") % block_a->hash ().to_string () % endpoints_a->size ());
 	}
-
 	auto count (0);
 	while (!endpoints_a->empty () && count < max_reps)
 	{
@@ -360,22 +353,16 @@ void rai::network::broadcast_confirm_req_base (std::shared_ptr<rai::block> block
 		endpoints_a->pop_back ();
 		count++;
 	}
-
 	if (!endpoints_a->empty ())
 	{
 		delay_a += 50;
 		delay_a += std::rand() % 50;
 
-		if (node.config.logging.network_logging ())
-		{
-			BOOST_LOG (node.log) << boost::str (boost::format ("Scheduling more confirm req for block %1% to %2% more representatives in %3% ms") % block_a->hash ().to_string () % endpoints_a->size () % delay_a);
-		}
-
 		std::weak_ptr<rai::node> node_w (node.shared ());
 		node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (delay_a), [node_w, block_a, endpoints_a, delay_a]() {
 			if (auto node_l = node_w.lock ())
 			{
-				node_l->network.broadcast_confirm_req_base (block_a, endpoints_a, delay_a);
+				node_l->network.broadcast_confirm_req_base (block_a, endpoints_a, delay_a, true);
 			}
 		});
 	}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -5,6 +5,7 @@
 #include <rai/node/common.hpp>
 #include <rai/node/rpc.hpp>
 
+#include <cstdlib>
 #include <algorithm>
 #include <future>
 #include <sstream>
@@ -363,6 +364,7 @@ void rai::network::broadcast_confirm_req_base (std::shared_ptr<rai::block> block
 	if (!endpoints_a->empty ())
 	{
 		delay_a += 50;
+		delay_a += std::rand() % 30;
 
 		if (node.config.logging.network_logging ())
 		{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -5,8 +5,8 @@
 #include <rai/node/common.hpp>
 #include <rai/node/rpc.hpp>
 
-#include <cstdlib>
 #include <algorithm>
+#include <cstdlib>
 #include <future>
 #include <sstream>
 
@@ -356,7 +356,7 @@ void rai::network::broadcast_confirm_req_base (std::shared_ptr<rai::block> block
 	if (!endpoints_a->empty ())
 	{
 		delay_a += 50;
-		delay_a += std::rand() % 50;
+		delay_a += std::rand () % 50;
 
 		std::weak_ptr<rai::node> node_w (node.shared ());
 		node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (delay_a), [node_w, block_a, endpoints_a, delay_a]() {

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -364,7 +364,7 @@ void rai::network::broadcast_confirm_req_base (std::shared_ptr<rai::block> block
 	if (!endpoints_a->empty ())
 	{
 		delay_a += 50;
-		delay_a += std::rand() % 30;
+		delay_a += std::rand() % 50;
 
 		if (node.config.logging.network_logging ())
 		{

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -455,7 +455,7 @@ public:
 	void send_keepalive (rai::endpoint const &);
 	void send_node_id_handshake (rai::endpoint const &, boost::optional<rai::uint256_union> const & query, boost::optional<rai::uint256_union> const & respond_to);
 	void broadcast_confirm_req (std::shared_ptr<rai::block>);
-	void broadcast_confirm_req_base (std::shared_ptr<rai::block>, std::shared_ptr<std::vector<rai::peer_information>>, unsigned, bool = false);
+	void broadcast_confirm_req_base (std::shared_ptr<rai::block>, std::shared_ptr<std::vector<rai::peer_information>>, unsigned);
 	void send_confirm_req (rai::endpoint const &, std::shared_ptr<rai::block>);
 	void send_buffer (uint8_t const *, size_t, rai::endpoint const &, std::function<void(boost::system::error_code const &, size_t)>);
 	rai::endpoint endpoint ();

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -455,7 +455,7 @@ public:
 	void send_keepalive (rai::endpoint const &);
 	void send_node_id_handshake (rai::endpoint const &, boost::optional<rai::uint256_union> const & query, boost::optional<rai::uint256_union> const & respond_to);
 	void broadcast_confirm_req (std::shared_ptr<rai::block>);
-	void broadcast_confirm_req_base (std::shared_ptr<rai::block>, std::shared_ptr<std::vector<rai::peer_information>>, unsigned);
+	void broadcast_confirm_req_base (std::shared_ptr<rai::block>, std::shared_ptr<std::vector<rai::peer_information>>, unsigned, bool = false);
 	void send_confirm_req (rai::endpoint const &, std::shared_ptr<rai::block>);
 	void send_buffer (uint8_t const *, size_t, rai::endpoint const &, std::function<void(boost::system::error_code const &, size_t)>);
 	rai::endpoint endpoint ();


### PR DESCRIPTION
Improves logging to indicate how many representatives it is broadcasting to in each batch, and delays the second group by 50ms from the first group (instead of 0ms).