### PR TITLE
 Escalation for long unconfirmed elections

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3888,7 +3888,7 @@ void rai::active_transactions::announce_votes ()
 							auto previous (node.store.block_get (transaction, previous_hash));
 							if (previous != nullptr)
 							{
-								start (previous);
+								start (std::move (previous));
 							}
 						}
 						auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
@@ -3897,7 +3897,7 @@ void rai::active_transactions::announce_votes ()
 							auto source (node.store.block_get (transaction, source_hash));
 							if (source != nullptr)
 							{
-								start (source);
+								start (std::move (source));
 							}
 						}
 					}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3877,6 +3877,30 @@ void rai::active_transactions::announce_votes ()
 				{
 					auto tally_l (election_l->tally (transaction));
 					election_l->log_votes (tally_l);
+					/* Escalation for very long unconfirmed elections
+					Start new elections for previous block & source
+					if there are less than 100 active elections */
+					if (roots.size () < 100)
+					{
+						auto previous_hash (election_l->status.winner->previous ());
+						if (!previous_hash.is_zero ())
+						{
+							auto previous (node.store.block_get (transaction, previous_hash));
+							if (previous != nullptr)
+							{
+								start (previous);
+							}
+						}
+						auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
+						if (!source_hash.is_zero ())
+						{
+							auto source (node.store.block_get (transaction, source_hash));
+							if (source != nullptr)
+							{
+								start (source);
+							}
+						}
+					}
 				}
 			}
 			if (i->announcements < announcement_long || i->announcements % announcement_long == 1)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3877,28 +3877,28 @@ void rai::active_transactions::announce_votes ()
 				{
 					auto tally_l (election_l->tally (transaction));
 					election_l->log_votes (tally_l);
-					/* Escalation for very long unconfirmed elections
-					Start new elections for previous block & source
-					if there are less than 100 active elections */
-					if (roots.size () < 100)
+				}
+				/* Escalation for long unconfirmed elections
+				Start new elections for previous block & source
+				if there are less than 100 active elections */
+				if (i->announcements % announcement_long == 1 && roots.size () < 100)
+				{
+					auto previous_hash (election_l->status.winner->previous ());
+					if (!previous_hash.is_zero ())
 					{
-						auto previous_hash (election_l->status.winner->previous ());
-						if (!previous_hash.is_zero ())
+						auto previous (node.store.block_get (transaction, previous_hash));
+						if (previous != nullptr)
 						{
-							auto previous (node.store.block_get (transaction, previous_hash));
-							if (previous != nullptr)
-							{
-								start (std::move (previous));
-							}
+							start (std::move (previous));
 						}
-						auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
-						if (!source_hash.is_zero ())
+					}
+					auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
+					if (!source_hash.is_zero ())
+					{
+						auto source (node.store.block_get (transaction, source_hash));
+						if (source != nullptr)
 						{
-							auto source (node.store.block_get (transaction, source_hash));
-							if (source != nullptr)
-							{
-								start (std::move (source));
-							}
+							start (std::move (source));
 						}
 					}
 				}


### PR DESCRIPTION
Start new elections for previous block & source if there are less than 100 active elections