### PR TITLE
Copy processed_active before dequeuing it

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1599,10 +1599,8 @@ void rai::block_processor::process_receive_many (std::unique_lock<std::mutex> & 
 	lock_a.unlock ();
 
 	// Start elections for recent blocks
-	while (!processed_active_copy.empty ())
+	for (const auto & block : processed_active_copy)
 	{
-		auto block (processed_active_copy.front ());
-		processed_active_copy.pop_front ();
 		node.active.start (block);
 	}
 }

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1588,14 +1588,24 @@ void rai::block_processor::process_receive_many (std::unique_lock<std::mutex> & 
 			++count;
 		}
 	}
+
+	/*
+	 * Copy "processed_active" to a local variable so that we
+	 * may operate on it without holding the mutex.
+	 */
+	decltype(processed_active) processed_active_copy;
+	processed_active_copy.swap (processed_active);
+
+	lock_a.unlock ();
+
 	// Start elections for recent blocks
-	while (!processed_active.empty ())
+	while (!processed_active_copy.empty ())
 	{
-		auto block (processed_active.front ());
-		processed_active.pop_front ();
+		auto block (processed_active_copy.front ());
+		processed_active_copy.pop_front ();
 		node.active.start (block);
 	}
-	lock_a.unlock ();
+
 }
 
 rai::process_return rai::block_processor::process_receive_one (rai::transaction const & transaction_a, std::shared_ptr<rai::block> block_a, std::chrono::steady_clock::time_point origination)
@@ -1615,6 +1625,13 @@ rai::process_return rai::block_processor::process_receive_one (rai::transaction 
 			}
 			if (node.block_arrival.recent (hash))
 			{
+				/*
+				 * The dequeuing of this buffer uses the mutex
+				 * named "mutex", so we must use it when we
+				 * enqueue it.
+				 */
+				std::unique_lock<std::mutex> lock (mutex);
+
 				processed_active.push_back (block_a);
 			}
 			queue_unchecked (transaction_a, hash);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1593,7 +1593,7 @@ void rai::block_processor::process_receive_many (std::unique_lock<std::mutex> & 
 	 * Copy "processed_active" to a local variable so that we
 	 * may operate on it without holding the mutex.
 	 */
-	decltype(processed_active) processed_active_copy;
+	decltype (processed_active) processed_active_copy;
 	processed_active_copy.swap (processed_active);
 
 	lock_a.unlock ();
@@ -1605,7 +1605,6 @@ void rai::block_processor::process_receive_many (std::unique_lock<std::mutex> & 
 		processed_active_copy.pop_front ();
 		node.active.start (block);
 	}
-
 }
 
 rai::process_return rai::block_processor::process_receive_one (rai::transaction const & transaction_a, std::shared_ptr<rai::block> block_a, std::chrono::steady_clock::time_point origination)


### PR DESCRIPTION
Copy processed_active before dequeuing it so that we may call node.active.start without a lock held

Option 2 for issue #1235 