### PR TITLE
 Remove processing blocks from confirm_req

### DIFF
--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -266,7 +266,7 @@ TEST (node, receive_gap)
 	ASSERT_EQ (0, node1.gap_cache.blocks.size ());
 	auto block (std::make_shared<rai::send_block> (5, 1, 2, rai::keypair ().prv, 4, 0));
 	node1.work_generate_blocking (*block);
-	rai::confirm_req message (block);
+	rai::publish message (block);
 	node1.process_message (message, node1.network.endpoint ());
 	node1.block_processor.flush ();
 	ASSERT_EQ (1, node1.gap_cache.blocks.size ());

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -515,8 +515,6 @@ public:
 		}
 		node.stats.inc (rai::stat::type::message, rai::stat::detail::confirm_req, rai::stat::dir::in);
 		node.peers.contacted (sender, message_a.header.version_using);
-		node.process_active (message_a.block);
-		node.active.publish (message_a.block);
 		auto transaction_a (node.store.tx_begin_read ());
 		auto successor (node.ledger.successor (transaction_a, message_a.block->root ()));
 		if (successor != nullptr)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -515,6 +515,7 @@ public:
 		}
 		node.stats.inc (rai::stat::type::message, rai::stat::detail::confirm_req, rai::stat::dir::in);
 		node.peers.contacted (sender, message_a.header.version_using);
+		node.process_active (message_a.block);
 		// Don't load nodes with disabled voting
 		if (node.config.enable_voting)
 		{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -515,11 +515,15 @@ public:
 		}
 		node.stats.inc (rai::stat::type::message, rai::stat::detail::confirm_req, rai::stat::dir::in);
 		node.peers.contacted (sender, message_a.header.version_using);
-		auto transaction_a (node.store.tx_begin_read ());
-		auto successor (node.ledger.successor (transaction_a, message_a.block->root ()));
-		if (successor != nullptr)
+		// Don't load nodes with disabled voting
+		if (node.config.enable_voting)
 		{
-			confirm_block (transaction_a, node, sender, std::move (successor));
+			auto transaction (node.store.tx_begin_read ());
+			auto successor (node.ledger.successor (transaction, message_a.block->root ()));
+			if (successor != nullptr)
+			{
+				confirm_block (transaction, node, sender, std::move (successor));
+			}
 		}
 	}
 	void confirm_ack (rai::confirm_ack const & message_a) override


### PR DESCRIPTION
To reduce unnecessary average nodes load.

- addditional disable successor confirmation for nodes with disabled voting in config