### PR TITLE
Change default desktop config.json

### DIFF
--- a/rai/rai_wallet/entry.cpp
+++ b/rai/rai_wallet/entry.cpp
@@ -123,6 +123,8 @@ public:
 		tree_a.put ("wallet", wallet_string);
 		tree_a.put ("account", account.to_account ());
 		boost::property_tree::ptree node_l;
+		node.enable_voting = false;
+		node.bootstrap_connections_max = 4;
 		node.serialize_json (node_l);
 		tree_a.add_child ("node", node_l);
 		boost::property_tree::ptree rpc_l;


### PR DESCRIPTION
set "enable_voting": "false", "bootstrap_connections_max": "4"
to reduce load on slow PCs