### PR TITLE
frontier_req_server accounts deque

### DIFF
--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -2370,7 +2370,7 @@ void rai::frontier_req_server::next ()
 	// Filling accounts deque to prevent often read transactions
 	if (accounts.empty ())
 	{
-		size_t max_size = 128;
+		size_t max_size (128);
 		auto transaction (connection->node->store.tx_begin_read ());
 		for (auto i (connection->node->store.latest_begin (transaction, current.number () + 1)), n (connection->node->store.latest_end ()); i != n && accounts.size () != max_size; ++i)
 		{

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -311,5 +311,6 @@ public:
 	std::unique_ptr<rai::frontier_req> request;
 	std::shared_ptr<std::vector<uint8_t>> send_buffer;
 	size_t count;
+	std::deque<std::pair<rai::account, rai::account_info>> accounts;
 };
 }


### PR DESCRIPTION
to prevent often read transactions