### PR TITLE
Fix deadlock for elections escalation

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3889,7 +3889,7 @@ void rai::active_transactions::announce_votes ()
 						auto previous (node.store.block_get (transaction, previous_hash));
 						if (previous != nullptr)
 						{
-							start (std::move (previous));
+							add (std::make_pair (std::move (previous), nullptr));
 						}
 					}
 					auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
@@ -3898,7 +3898,7 @@ void rai::active_transactions::announce_votes ()
 						auto source (node.store.block_get (transaction, source_hash));
 						if (source != nullptr)
 						{
-							start (std::move (source));
+							add (std::make_pair (std::move (source), nullptr));
 						}
 					}
 				}
@@ -4048,9 +4048,14 @@ bool rai::active_transactions::start (std::shared_ptr<rai::block> block_a, std::
 
 bool rai::active_transactions::start (std::pair<std::shared_ptr<rai::block>, std::shared_ptr<rai::block>> blocks_a, std::function<void(std::shared_ptr<rai::block>)> const & confirmation_action_a)
 {
+	std::lock_guard<std::mutex> lock (mutex);
+	return add (blocks_a, confirmation_action_a);
+}
+
+bool rai::active_transactions::add (std::pair<std::shared_ptr<rai::block>, std::shared_ptr<rai::block>> blocks_a, std::function<void(std::shared_ptr<rai::block>)> const & confirmation_action_a)
+{
 	assert (blocks_a.first != nullptr);
 	auto error (true);
-	std::lock_guard<std::mutex> lock (mutex);
 	if (!stopped)
 	{
 		auto primary_block (blocks_a.first);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3888,7 +3888,7 @@ void rai::active_transactions::announce_votes ()
 							auto previous (node.store.block_get (transaction, previous_hash));
 							if (previous != nullptr)
 							{
-								start (previous);
+								start (std::move (previous));
 							}
 						}
 						auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
@@ -3897,7 +3897,7 @@ void rai::active_transactions::announce_votes ()
 							auto source (node.store.block_get (transaction, source_hash));
 							if (source != nullptr)
 							{
-								start (source);
+								start (std::move (source));
 							}
 						}
 					}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3877,6 +3877,30 @@ void rai::active_transactions::announce_votes ()
 				{
 					auto tally_l (election_l->tally (transaction));
 					election_l->log_votes (tally_l);
+					/* Escalation for very long unconfirmed elections
+					Start new elections for previous block & source
+					if there are less than 100 active elections */
+					if (roots.size () < 100)
+					{
+						auto previous_hash (election_l->status.winner->previous ());
+						if (!previous_hash.is_zero ())
+						{
+							auto previous (node.store.block_get (transaction, previous_hash));
+							if (previous != nullptr)
+							{
+								start (previous);
+							}
+						}
+						auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
+						if (!source_hash.is_zero ())
+						{
+							auto source (node.store.block_get (transaction, source_hash));
+							if (source != nullptr)
+							{
+								start (source);
+							}
+						}
+					}
 				}
 			}
 			if (i->announcements < announcement_long || i->announcements % announcement_long == 1)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3877,28 +3877,28 @@ void rai::active_transactions::announce_votes ()
 				{
 					auto tally_l (election_l->tally (transaction));
 					election_l->log_votes (tally_l);
-					/* Escalation for very long unconfirmed elections
-					Start new elections for previous block & source
-					if there are less than 100 active elections */
-					if (roots.size () < 100)
+				}
+				/* Escalation for long unconfirmed elections
+				Start new elections for previous block & source
+				if there are less than 100 active elections */
+				if (i->announcements % announcement_long == 1 && roots.size () < 100)
+				{
+					auto previous_hash (election_l->status.winner->previous ());
+					if (!previous_hash.is_zero ())
 					{
-						auto previous_hash (election_l->status.winner->previous ());
-						if (!previous_hash.is_zero ())
+						auto previous (node.store.block_get (transaction, previous_hash));
+						if (previous != nullptr)
 						{
-							auto previous (node.store.block_get (transaction, previous_hash));
-							if (previous != nullptr)
-							{
-								start (std::move (previous));
-							}
+							start (std::move (previous));
 						}
-						auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
-						if (!source_hash.is_zero ())
+					}
+					auto source_hash (node.ledger.block_source (transaction, *election_l->status.winner));
+					if (!source_hash.is_zero ())
+					{
+						auto source (node.store.block_get (transaction, source_hash));
+						if (source != nullptr)
 						{
-							auto source (node.store.block_get (transaction, source_hash));
-							if (source != nullptr)
-							{
-								start (std::move (source));
-							}
+							start (std::move (source));
 						}
 					}
 				}

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -101,6 +101,7 @@ public:
 	// Should only be used for old elections
 	// The first block should be the one in the ledger
 	bool start (std::pair<std::shared_ptr<rai::block>, std::shared_ptr<rai::block>>, std::function<void(std::shared_ptr<rai::block>)> const & = [](std::shared_ptr<rai::block>) {});
+	bool add (std::pair<std::shared_ptr<rai::block>, std::shared_ptr<rai::block>>, std::function<void(std::shared_ptr<rai::block>)> const & = [](std::shared_ptr<rai::block>) {});
 	// If this returns true, the vote is a replay
 	// If this returns false, the vote may or may not be a replay
 	bool vote (std::shared_ptr<rai::vote>);


### PR DESCRIPTION
Replaces pull request #1237 

Start new elections for previous block & source if there are less than 100 active elections