### PR TITLE
Check epoch_link before checking balance of state blocks

### DIFF
--- a/rai/secure/ledger.cpp
+++ b/rai/secure/ledger.cpp
@@ -196,7 +196,8 @@ void ledger_processor::state_block (rai::state_block const & block_a)
 				prev_balance = ledger.balance (transaction, block_a.hashables.previous);
 			}
 		}
-		if (block_a.hashables.balance == prev_balance) {
+		if (block_a.hashables.balance == prev_balance)
+		{
 			is_epoch_block = true;
 		}
 	}

--- a/rai/secure/ledger.cpp
+++ b/rai/secure/ledger.cpp
@@ -183,19 +183,26 @@ public:
 void ledger_processor::state_block (rai::state_block const & block_a)
 {
 	result.code = rai::process_result::progress;
+	auto is_epoch_block (false);
 	// Check if this is an epoch block
-	rai::amount prev_balance (0);
-	if (!block_a.hashables.previous.is_zero ())
+	if (!ledger.epoch_link.is_zero () && block_a.hashables.link == ledger.epoch_link)
 	{
-		result.code = ledger.store.block_exists (transaction, block_a.hashables.previous) ? rai::process_result::progress : rai::process_result::gap_previous;
-		if (result.code == rai::process_result::progress)
+		rai::amount prev_balance (0);
+		if (!block_a.hashables.previous.is_zero ())
 		{
-			prev_balance = ledger.balance (transaction, block_a.hashables.previous);
+			result.code = ledger.store.block_exists (transaction, block_a.hashables.previous) ? rai::process_result::progress : rai::process_result::gap_previous;
+			if (result.code == rai::process_result::progress)
+			{
+				prev_balance = ledger.balance (transaction, block_a.hashables.previous);
+			}
+		}
+		if (block_a.hashables.balance == prev_balance) {
+			is_epoch_block = true;
 		}
 	}
 	if (result.code == rai::process_result::progress)
 	{
-		if (block_a.hashables.balance == prev_balance && !ledger.epoch_link.is_zero () && block_a.hashables.link == ledger.epoch_link)
+		if (is_epoch_block)
 		{
 			epoch_block_impl (block_a);
 		}


### PR DESCRIPTION
Checking the balance of the previous block may be slow if the previous block is not a state block.

Therefore, re-order the epoch test to check the link codes first before the more expensive test of checking to see if the delta_balance is zero.