### PR TITLE
Extended bulk.offline_send

### DIFF
--- a/rai/core_test/network.cpp
+++ b/rai/core_test/network.cpp
@@ -807,19 +807,31 @@ TEST (bulk, offline_send)
 	rai::node_init init1;
 	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
-	node1->network.send_keepalive (system.nodes[0]->network.endpoint ());
 	node1->start ();
-	system.deadline_set (10s);
-	do
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	} while (system.nodes[0]->peers.empty () || node1->peers.empty ());
 	rai::keypair key2;
 	auto wallet (node1->wallets.create (rai::uint256_union ()));
 	wallet->insert_adhoc (key2.prv);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (rai::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_NE (std::numeric_limits<rai::uint256_t>::max (), system.nodes[0]->balance (rai::test_genesis_key.pub));
+	// Wait to finish election background tasks
+	system.deadline_set (10s);
+	while (!system.nodes[0]->active.roots.empty ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	// Initiate bootstrap
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
+	// Nodes should find each other
+	do
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	} while (system.nodes[0]->peers.empty () || node1->peers.empty ());
+	// Send block arrival via bootstrap
+	while (node1->balance (rai::test_genesis_key.pub) == std::numeric_limits<rai::uint256_t>::max ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	// Receiving send block
 	system.deadline_set (20s);
 	while (node1->balance (key2.pub) != system.nodes[0]->config.receive_minimum.number ())
 	{


### PR DESCRIPTION
Keepalive removed. Nodes should be unknown for each other until bootstrap (offline)
More intermediate checks to find issue parts

Currently should fail with https://github.com/nanocurrency/raiblocks/pull/1246