### PR TITLE
Add support for lazily bootstrapping

### DIFF
--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -2382,3 +2382,21 @@ void rai::frontier_req_server::next ()
 		current.clear ();
 	}
 }
+
+/*
+ * Lazy Bootstrapping Client
+ */
+rai::bootstrap_lazy::bootstrap_lazy ()
+{
+	return;
+}
+
+rai::bootstrap_lazy::~bootstrap_lazy ()
+{
+	return;
+}
+
+void rai::bootstrap_lazy::add_confirmed_block (std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a)
+{
+	return;
+}

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -2386,8 +2386,13 @@ void rai::frontier_req_server::next ()
 /*
  * Lazy Bootstrapping Client
  */
-rai::bootstrap_lazy::bootstrap_lazy ()
+rai::bootstrap_lazy::bootstrap_lazy (rai::node & node_a, int thread_count) :
+node (node_a)
 {
+	int thread_number;
+
+	
+
 	return;
 }
 
@@ -2397,6 +2402,11 @@ rai::bootstrap_lazy::~bootstrap_lazy ()
 }
 
 void rai::bootstrap_lazy::add_confirmed_block (std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a)
+{
+	return;
+}
+
+void rai::bootstrap_lazy::start_thread (void)
 {
 	return;
 }

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -58,13 +58,6 @@ public:
 	rai::block_hash end;
 	unsigned attempts;
 };
-class bootstrap_lazy
-{
-public:
-	bootstrap_lazy ();
-	~bootstrap_lazy ();
-	void add_confirmed_block (std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a);
-};
 class frontier_req_client;
 class bulk_push_client;
 class bootstrap_attempt : public std::enable_shared_from_this<bootstrap_attempt>
@@ -318,5 +311,15 @@ public:
 	std::unique_ptr<rai::frontier_req> request;
 	std::shared_ptr<std::vector<uint8_t>> send_buffer;
 	size_t count;
+};
+class bootstrap_lazy
+{
+public:
+	bootstrap_lazy (rai::node & node_a, int thread_count);
+	~bootstrap_lazy ();
+	void add_confirmed_block (std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a);
+private:
+	rai::node & node;
+	void start_thread (void);
 };
 }

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -58,6 +58,13 @@ public:
 	rai::block_hash end;
 	unsigned attempts;
 };
+class bootstrap_lazy
+{
+public:
+	bootstrap_lazy ();
+	~bootstrap_lazy ();
+	void add_confirmed_block (std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a);
+};
 class frontier_req_client;
 class bulk_push_client;
 class bootstrap_attempt : public std::enable_shared_from_this<bootstrap_attempt>

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1586,6 +1586,7 @@ ledger (store, stats, config.epoch_block_link, config.epoch_block_signer),
 active (*this),
 network (*this, config.peering_port),
 bootstrap_initiator (*this),
+bootstrap_lazy (*this, config_a.bootstrap_connections /* XXX:TODO: Move this to its own config option */),
 bootstrap (service_a, config.peering_port, *this),
 peers (network.endpoint ()),
 application_path (application_path_a),
@@ -1611,6 +1612,7 @@ stats (config.stat_config)
 		observers.disconnect.notify ();
 	};
 	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a, bool is_state_send_a) {
+		/* XXX:TODO: Determine if the block is confirmed at this point */
 		this->bootstrap_lazy.add_confirmed_block (block_a, account_a, amount_a);
 
 		if (this->block_arrival.recent (block_a->hash ()))

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1611,6 +1611,8 @@ stats (config.stat_config)
 		observers.disconnect.notify ();
 	};
 	observers.blocks.add ([this](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const & amount_a, bool is_state_send_a) {
+		this->bootstrap_lazy.add_confirmed_block (block_a, account_a, amount_a);
+
 		if (this->block_arrival.recent (block_a->hash ()))
 		{
 			auto node_l (shared_from_this ());
@@ -2317,16 +2319,7 @@ void rai::node::ongoing_rep_crawl ()
 
 void rai::node::ongoing_bootstrap ()
 {
-	auto next_wakeup (300);
-	if (warmed_up < 3)
-	{
-		// Re-attempt bootstrapping more aggressively on startup
-		next_wakeup = 5;
-		if (!bootstrap_initiator.in_progress () && !peers.empty ())
-		{
-			++warmed_up;
-		}
-	}
+	auto next_wakeup (3600);
 	bootstrap_initiator.bootstrap ();
 	std::weak_ptr<rai::node> node_w (shared_from_this ());
 	alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (next_wakeup), [node_w]() {

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -610,6 +610,7 @@ public:
 	rai::network network;
 	rai::bootstrap_initiator bootstrap_initiator;
 	rai::bootstrap_listener bootstrap;
+	rai::bootstrap_lazy bootstrap_lazy;
 	rai::peer_container peers;
 	boost::filesystem::path application_path;
 	rai::node_observers observers;


### PR DESCRIPTION
Closes #995 

Issue #995 goes into how it should work, but basically it will passively listen for votes on the real-time network, as soon as a block hits an irreversible threshold, the entire merkle tree can be confirmed and we can recursively (iteratively) add blocks to a queue to pull down using `bulk_pull` which supports the "start" parameter as a block.

For now the existing bootstrap client will still run to fill in the rest, but much less frequently.

For accounts in local wallets, we will support pulling those chains pro-actively (optionally without confirmation -- do you trust yourself to use this seed on only one node?) using `bulk_pull_account`.