### PR TITLE
Log common exceptions before asserting

### DIFF
--- a/rai/node/logging.hpp
+++ b/rai/node/logging.hpp
@@ -6,6 +6,8 @@
 #include <boost/property_tree/ptree.hpp>
 #include <cstdint>
 
+#define FATAL_LOG_PREFIX "FATAL ERROR: "
+
 namespace rai
 {
 class logging

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -51,8 +51,24 @@ on (true)
 			{
 				process_packets ();
 			}
+			catch (boost::system::error_code & ec)
+			{
+				BOOST_LOG (this->node.log) << FATAL_LOG_PREFIX << ec.message ();
+				release_assert (false);
+			}
+			catch (std::error_code & ec)
+			{
+				BOOST_LOG (this->node.log) << FATAL_LOG_PREFIX << ec.message ();
+				release_assert (false);
+			}
+			catch (std::runtime_error & err)
+			{
+				BOOST_LOG (this->node.log) << FATAL_LOG_PREFIX << err.what ();
+				release_assert (false);
+			}
 			catch (...)
 			{
+				BOOST_LOG (this->node.log) << FATAL_LOG_PREFIX << "Unknown exception";
 				release_assert (false);
 			}
 			if (this->node.config.logging.network_packet_logging ())


### PR DESCRIPTION
This gives more information in places where we don't catch (an example I've seen before is buggy log statements, i.e. lacking arguments for the format specifier, which throws boost::system::error_code)