### PR TITLE
Force macOS wallet to use aqua light mode whilst QT adds support for …

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -16,5 +16,7 @@
 	<string>RaiBlocks.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>net.raiblocks.rai_wallet</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
…Mojave Dark Mode

Dark mode for macOS won't be supported in QT until version 5.12 which is expected to be released in November. Until that time, this PR adds a patch to force the macOS client to use light mode and ignore the system setting of dark mode. References #1275