### PR TITLE
 Add config option for minimum local representative weight

### DIFF
--- a/rai/core_test/wallets.cpp
+++ b/rai/core_test/wallets.cpp
@@ -95,3 +95,31 @@ TEST (wallets, DISABLED_wallet_create_max)
 	auto existing = wallets.items.find (key.pub);
 	ASSERT_TRUE (existing == wallets.items.end ());
 }
+
+TEST (wallets, vote_minimum)
+{
+	rai::system system (24000, 1);
+	auto & node1 (*system.nodes[0]);
+	bool error (false);
+	rai::wallets wallets (error, node1);
+	ASSERT_FALSE (error);
+	rai::keypair key1;
+	rai::keypair key2;
+	rai::genesis genesis;
+	rai::state_block send1 (rai::test_genesis_key.pub, genesis.hash (), rai::test_genesis_key.pub, std::numeric_limits<rai::uint128_t>::max () - node1.config.vote_minimum.number (), key1.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.work.generate (genesis.hash ()));
+	ASSERT_EQ (rai::process_result::progress, node1.process (send1).code);
+	rai::state_block open1 (key1.pub, 0, key1.pub, node1.config.vote_minimum.number (), send1.hash (), key1.prv, key1.pub, system.work.generate (key1.pub));
+	ASSERT_EQ (rai::process_result::progress, node1.process (open1).code);
+	// send2 with amount vote_minimum - 1 (not voting representative)
+	rai::state_block send2 (rai::test_genesis_key.pub, send1.hash (), rai::test_genesis_key.pub, std::numeric_limits<rai::uint128_t>::max () - 2 * node1.config.vote_minimum.number () + 1, key2.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.work.generate (send1.hash ()));
+	ASSERT_EQ (rai::process_result::progress, node1.process (send2).code);
+	rai::state_block open2 (key2.pub, 0, key2.pub, node1.config.vote_minimum.number () - 1, send2.hash (), key2.prv, key2.pub, system.work.generate (key2.pub));
+	ASSERT_EQ (rai::process_result::progress, node1.process (open2).code);
+	auto wallet (wallets.items.begin ()->second);
+	ASSERT_EQ (0, wallet->representatives.size ());
+	wallet->insert_adhoc (rai::test_genesis_key.prv);
+	wallet->insert_adhoc (key1.prv);
+	wallet->insert_adhoc (key2.prv);
+	wallets.compute_reps ();
+	ASSERT_EQ (2, wallet->representatives.size ());
+}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -788,7 +788,8 @@ bootstrap_connections (4),
 bootstrap_connections_max (64),
 callback_port (0),
 lmdb_max_dbs (128),
-block_processor_batch_max_time (std::chrono::milliseconds (5000))
+block_processor_batch_max_time (std::chrono::milliseconds (5000)),
+vote_minimum (rai::Gxrb_ratio)
 {
 	const char * epoch_message ("epoch v1 block");
 	strncpy ((char *)epoch_block_link.bytes.data (), epoch_message, epoch_block_link.bytes.size ());
@@ -869,6 +870,7 @@ void rai::node_config::serialize_json (boost::property_tree::ptree & tree_a) con
 	tree_a.put ("callback_target", callback_target);
 	tree_a.put ("lmdb_max_dbs", lmdb_max_dbs);
 	tree_a.put ("block_processor_batch_max_time", block_processor_batch_max_time.count ());
+	tree_a.put ("vote_minimum", vote_minimum.to_string_dec ());
 }
 
 bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptree & tree_a)
@@ -978,6 +980,7 @@ bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptr
 		case 14:
 			tree_a.erase ("generate_hash_votes_at");
 			tree_a.put ("block_processor_batch_max_time", block_processor_batch_max_time.count ());
+			tree_a.put ("vote_minimum", vote_minimum.to_string_dec ());
 			tree_a.erase ("version");
 			tree_a.put ("version", "15");
 			result = true;
@@ -1068,6 +1071,7 @@ bool rai::node_config::deserialize_json (bool & upgraded_a, boost::property_tree
 		auto lmdb_max_dbs_l = tree_a.get<std::string> ("lmdb_max_dbs");
 		result |= parse_port (callback_port_l, callback_port);
 		auto block_processor_batch_max_time_l = tree_a.get<std::string> ("block_processor_batch_max_time");
+		auto vote_minimum_l (tree_a.get<std::string> ("vote_minimum"));
 		try
 		{
 			peering_port = std::stoul (peering_port_l);
@@ -1083,6 +1087,7 @@ bool rai::node_config::deserialize_json (bool & upgraded_a, boost::property_tree
 			result |= peering_port > std::numeric_limits<uint16_t>::max ();
 			result |= logging.deserialize_json (upgraded_a, logging_l);
 			result |= receive_minimum.decode_dec (receive_minimum_l);
+			result |= vote_minimum.decode_dec (vote_minimum_l);
 			result |= online_weight_minimum.decode_dec (online_weight_minimum_l);
 			result |= online_weight_quorum > 100;
 			result |= password_fanout < 16;

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -461,6 +461,7 @@ public:
 	std::vector<rai::account> preconfigured_representatives;
 	unsigned bootstrap_fraction_numerator;
 	rai::amount receive_minimum;
+	rai::amount vote_minimum;
 	rai::amount online_weight_minimum;
 	unsigned online_weight_quorum;
 	unsigned password_fanout;

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1468,7 +1468,7 @@ void rai::wallets::compute_reps ()
 		for (auto ii (wallet.store.begin (transaction)), nn (wallet.store.end ()); ii != nn; ++ii)
 		{
 			auto account (ii->first);
-			if (node.ledger.weight (ledger_transaction, account) >= node.config.vote_minimum)
+			if (node.ledger.weight (ledger_transaction, account) >= node.config.vote_minimum.number ())
 			{
 				representatives_l.insert (account);
 			}

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1468,7 +1468,7 @@ void rai::wallets::compute_reps ()
 		for (auto ii (wallet.store.begin (transaction)), nn (wallet.store.end ()); ii != nn; ++ii)
 		{
 			auto account (ii->first);
-			if (!node.ledger.weight (ledger_transaction, account).is_zero ())
+			if (node.ledger.weight (ledger_transaction, account) >= node.config.vote_minimum)
 			{
 				representatives_l.insert (account);
 			}


### PR DESCRIPTION
Default 1000 Nano
Large services can set higher values to limit votes CPU load, while singe users willing to have small working representative can set it lower