### PR TITLE
Improve pending & unchecked search performance

### DIFF
--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -1771,9 +1771,8 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_get (rai::transaction const & tr
 std::vector<std::shared_ptr<rai::block>> rai::mdb_store::unchecked_get (rai::transaction const & transaction_a, rai::block_hash const & hash_a)
 {
 	std::vector<std::shared_ptr<rai::block>> result;
-	for (auto i (unchecked_begin (transaction_a, hash_a)), n (unchecked_begin (transaction_a, hash_a.number () + 1)); i != n; ++i)
+	for (auto i (unchecked_begin (transaction_a, hash_a)), n (unchecked_end ()); i != n && rai::block_hash (i->first) == hash_a; ++i)
 	{
-		assert (rai::block_hash (i->first) == hash_a);
 		std::shared_ptr<rai::block> block (i->second);
 		result.push_back (block);
 	}

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -769,8 +769,7 @@ void rai::rpc_handler::accounts_pending ()
 		if (!ec)
 		{
 			boost::property_tree::ptree peers_l;
-			rai::account end (account.number () + 1);
-			for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))), n (node.store.pending_begin (transaction, rai::pending_key (end, 0))); i != n && peers_l.size () < count; ++i)
+			for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))); rai::pending_key (i->first).account == account && peers_l.size () < count; ++i)
 			{
 				rai::pending_key key (i->first);
 				std::shared_ptr<rai::block> block (include_active ? nullptr : node.store.block_get (transaction, key.hash));
@@ -2068,8 +2067,7 @@ void rai::rpc_handler::pending ()
 	{
 		boost::property_tree::ptree peers_l;
 		auto transaction (node.store.tx_begin_read ());
-		rai::account end (account.number () + 1);
-		for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))), n (node.store.pending_begin (transaction, rai::pending_key (end, 0))); i != n && peers_l.size () < count; ++i)
+		for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))); rai::pending_key (i->first).account == account && peers_l.size () < count; ++i)
 		{
 			rai::pending_key key (i->first);
 			std::shared_ptr<rai::block> block (include_active ? nullptr : node.store.block_get (transaction, key.hash));
@@ -3256,8 +3254,7 @@ void rai::rpc_handler::wallet_pending ()
 		{
 			rai::account account (i->first);
 			boost::property_tree::ptree peers_l;
-			rai::account end (account.number () + 1);
-			for (auto ii (node.store.pending_begin (transaction, rai::pending_key (account, 0))), nn (node.store.pending_begin (transaction, rai::pending_key (end, 0))); ii != nn && peers_l.size () < count; ++ii)
+			for (auto ii (node.store.pending_begin (transaction, rai::pending_key (account, 0))); rai::pending_key (ii->first).account == account && peers_l.size () < count; ++ii)
 			{
 				rai::pending_key key (ii->first);
 				std::shared_ptr<rai::block> block (include_active ? nullptr : node.store.block_get (transaction, key.hash));

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1146,7 +1146,7 @@ bool rai::wallet::search_pending ()
 			// Don't search pending for watch-only accounts
 			if (!rai::wallet_value (i->second).key.is_zero ())
 			{
-				for (auto j (wallets.node.store.pending_begin (transaction, rai::pending_key (account, 0))), m (wallets.node.store.pending_begin (transaction, rai::pending_key (account.number () + 1, 0))); j != m; ++j)
+				for (auto j (wallets.node.store.pending_begin (transaction, rai::pending_key (account, 0))); rai::pending_key (j->first).account == account; ++j)
 				{
 					rai::pending_key key (j->first);
 					auto hash (key.hash);
@@ -1200,8 +1200,7 @@ rai::public_key rai::wallet::change_seed (rai::transaction const & transaction_a
 		else
 		{
 			// Check if there are pending blocks for account
-			rai::account end (pair.pub.number () + 1);
-			for (auto ii (wallets.node.store.pending_begin (transaction_a, rai::pending_key (pair.pub, 0))), nn (wallets.node.store.pending_begin (transaction_a, rai::pending_key (end, 0))); ii != nn; ++ii)
+			for (auto ii (wallets.node.store.pending_begin (transaction_a, rai::pending_key (pair.pub, 0))); rai::pending_key (ii->first).account == pair.pub; ++ii)
 			{
 				count = i;
 				n = i + 64 + (i / 64);


### PR DESCRIPTION
Up to 25-50% performance increase for large wallets search

1 request in for loop instead of 2 requests (if there are no pending/unchecked for given key - most likely scenario).