### PR TITLE
No longer decrement the count if the entry is empty during account_history RPC call.

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1782,8 +1782,8 @@ void rai::rpc_handler::account_history ()
 							entry.put ("signature", block->block_signature ().to_string ());
 						}
 						history.push_back (std::make_pair ("", entry));
+						--count;
 					}
-					--count;
 				}
 				hash = block->previous ();
 				block = node.store.block_get (transaction, hash);


### PR DESCRIPTION
This PR contains the changes to fix the behaviour described in #1270. In this fix, decrementing the count for the number of entries in an accounts history only occurs when the entry is not empty (i.e. when the history visitor visits the change block and it is not set to raw)