### PR TITLE
Using QSettings to persist application settings for selected ratio scale

### DIFF
--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -1768,22 +1768,36 @@ wallet (wallet_a)
 	QObject::connect (mnano_unit, &QRadioButton::toggled, [this]() {
 		if (mnano_unit->isChecked ())
 		{
+			QSettings ().setValue (saved_ratio_key, ratio_group->id (mnano_unit));
 			this->wallet.change_rendering_ratio (rai::Mxrb_ratio);
 		}
 	});
 	QObject::connect (knano_unit, &QRadioButton::toggled, [this]() {
 		if (knano_unit->isChecked ())
 		{
+			QSettings ().setValue (saved_ratio_key, ratio_group->id (knano_unit));
 			this->wallet.change_rendering_ratio (rai::kxrb_ratio);
 		}
 	});
 	QObject::connect (nano_unit, &QRadioButton::toggled, [this]() {
 		if (nano_unit->isChecked ())
 		{
+			QSettings ().setValue (saved_ratio_key, ratio_group->id (nano_unit));
 			this->wallet.change_rendering_ratio (rai::xrb_ratio);
 		}
 	});
-	mnano_unit->click ();
+	auto selected_ratio_id (QSettings ().value (saved_ratio_key, ratio_group->id (mnano_unit)).toInt ());
+	auto selected_ratio_button = ratio_group->button (selected_ratio_id);
+	assert (selected_ratio_button != nullptr);
+
+	if (selected_ratio_button)
+	{
+		selected_ratio_button->click ();
+	}
+	else
+	{
+		mnano_unit->click ();
+	}
 	QObject::connect (wallet_refresh, &QPushButton::released, [this]() {
 		this->wallet.accounts.refresh ();
 		this->wallet.accounts.refresh_wallet_balance ();

--- a/rai/qt/qt.hpp
+++ b/rai/qt/qt.hpp
@@ -11,6 +11,7 @@
 
 namespace rai_qt
 {
+static const QString saved_ratio_key = "settings/ratio";
 class wallet;
 class eventloop_processor : public QObject
 {

--- a/rai/qt_system/entry.cpp
+++ b/rai/qt_system/entry.cpp
@@ -6,6 +6,9 @@
 int main (int argc, char ** argv)
 {
 	QApplication application (argc, argv);
+	QCoreApplication::setOrganizationName ("Nano");
+	QCoreApplication::setOrganizationDomain ("nano.org");
+	QCoreApplication::setApplicationName ("Nano Wallet");
 	rai_qt::eventloop_processor processor;
 	static int count (16);
 	rai::system system (24000, count);


### PR DESCRIPTION
Uses the QSettings class to provide persistence for QT Settings, in this case the XRB scale ratio as set by the radio button group in the Advanced tab.

Closes #511
