### PR TITLE
Separate vote generation process

### DIFF
--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -198,11 +198,14 @@ TEST (node, node_receive_quorum)
 		done = info->announcements > rai::active_transactions::announcement_min;
 		ASSERT_NO_ERROR (system.poll ());
 	}
+	rai::system system2 (24001, 1);
+	system2.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	ASSERT_TRUE (system.nodes[0]->balance (key.pub).is_zero ());
-	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
+	system.nodes[0]->network.send_keepalive (system2.nodes[0]->network.endpoint ());
 	while (system.nodes[0]->balance (key.pub).is_zero ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
+		ASSERT_NO_ERROR (system2.poll ());
 	}
 }
 
@@ -1542,15 +1545,15 @@ TEST (node, block_confirm)
 	rai::keypair key;
 	system.wallet (1)->insert_adhoc (rai::test_genesis_key.prv);
 	auto send1 (std::make_shared<rai::state_block> (rai::test_genesis_key.pub, genesis.hash (), rai::test_genesis_key.pub, rai::genesis_amount - rai::Gxrb_ratio, key.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	system.nodes[0]->block_processor.add(send1, std::chrono::steady_clock::now ());
-	system.nodes[1]->block_processor.add(send1, std::chrono::steady_clock::now ());
-	system.deadline_set(std::chrono::seconds(5));
-	while (!system.nodes[0]->ledger.block_exists(send1->hash ()) || !system.nodes[1]->ledger.block_exists(send1->hash ()))
+	system.nodes[0]->block_processor.add (send1, std::chrono::steady_clock::now ());
+	system.nodes[1]->block_processor.add (send1, std::chrono::steady_clock::now ());
+	system.deadline_set (std::chrono::seconds (5));
+	while (!system.nodes[0]->ledger.block_exists (send1->hash ()) || !system.nodes[1]->ledger.block_exists (send1->hash ()))
 	{
-		ASSERT_NO_ERROR (system.poll());
+		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_TRUE (system.nodes[0]->ledger.block_exists(send1->hash ()));
-	ASSERT_TRUE (system.nodes[1]->ledger.block_exists(send1->hash ()));
+	ASSERT_TRUE (system.nodes[0]->ledger.block_exists (send1->hash ()));
+	ASSERT_TRUE (system.nodes[1]->ledger.block_exists (send1->hash ()));
 	auto send2 (std::make_shared<rai::state_block> (rai::test_genesis_key.pub, send1->hash (), rai::test_genesis_key.pub, rai::genesis_amount - rai::Gxrb_ratio * 2, key.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (send1->hash ())));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin (true));

--- a/rai/lib/utility.cpp
+++ b/rai/lib/utility.cpp
@@ -52,6 +52,9 @@ namespace thread_role
 			case rai::thread_role::name::bootstrap_initiator:
 				thread_role_name_string = "Bootstrap init";
 				break;
+			case rai::thread_role::name::voting:
+				thread_role_name_string = "Voting";
+				break;
 		}
 
 		/*

--- a/rai/lib/utility.hpp
+++ b/rai/lib/utility.hpp
@@ -40,6 +40,7 @@ namespace thread_role
 		announce_loop,
 		wallet_actions,
 		bootstrap_initiator,
+		voting,
 	};
 	rai::thread_role::name get (void);
 	void set (rai::thread_role::name);

--- a/rai/node/CMakeLists.txt
+++ b/rai/node/CMakeLists.txt
@@ -42,6 +42,8 @@ add_library (node
 	wallet.cpp
 	stats.hpp
 	stats.cpp
+	voting.hpp
+	voting.cpp
 	working.hpp
 	xorshift.hpp)
 

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1086,7 +1086,7 @@ rai::process_return rai::block_processor::process_receive_one (rai::transaction 
 		{
 			if (node.config.enable_voting)
 			{
-				generator.add(hash);
+				generator.add (hash);
 			}
 			if (node.config.logging.ledger_logging ())
 			{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1124,10 +1124,6 @@ rai::process_return rai::block_processor::process_receive_one (rai::transaction 
 	{
 		case rai::process_result::progress:
 		{
-			if (node.config.enable_voting)
-			{
-				generator.add (hash);
-			}
 			if (node.config.logging.ledger_logging ())
 			{
 				std::string block;
@@ -1137,6 +1133,10 @@ rai::process_return rai::block_processor::process_receive_one (rai::transaction 
 			if (node.block_arrival.recent (hash))
 			{
 				node.active.start (block_a);
+				if (node.config.enable_voting)
+				{
+					generator.add (hash);
+				}
 			}
 			queue_unchecked (transaction_a, hash);
 			break;

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -6,6 +6,7 @@
 #include <rai/node/nodeconfig.hpp>
 #include <rai/node/portmapping.hpp>
 #include <rai/node/stats.hpp>
+#include <rai/node/voting.hpp>
 #include <rai/node/wallet.hpp>
 #include <rai/secure/ledger.hpp>
 
@@ -517,6 +518,7 @@ private:
 	std::deque<std::shared_ptr<rai::block>> processed_active;
 	std::condition_variable condition;
 	rai::node & node;
+	rai::vote_generator generator;
 	std::mutex mutex;
 };
 class node : public std::enable_shared_from_this<rai::node>

--- a/rai/node/voting.cpp
+++ b/rai/node/voting.cpp
@@ -45,11 +45,13 @@ void rai::vote_generator::send (std::unique_lock<std::mutex> & lock_a)
 		hashes.pop_front ();
 	}
 	lock_a.unlock ();
-	auto transaction (node.store.tx_begin_write ());
-	node.wallets.foreach_representative (transaction, [this, &hashes_l, &transaction](rai::public_key const & pub_a, rai::raw_key const & prv_a) {
-		auto vote (this->node.store.vote_generate (transaction, pub_a, prv_a, hashes_l));
-		this->node.vote_processor.vote (vote, this->node.network.endpoint ());
-	});
+	{
+		auto transaction (node.store.tx_begin_read ());
+		node.wallets.foreach_representative (transaction, [this, &hashes_l, &transaction](rai::public_key const & pub_a, rai::raw_key const & prv_a) {
+			auto vote (this->node.store.vote_generate (transaction, pub_a, prv_a, hashes_l));
+			this->node.vote_processor.vote (vote, this->node.network.endpoint ());
+		});
+	}
 	lock_a.lock ();
 }
 

--- a/rai/node/voting.cpp
+++ b/rai/node/voting.cpp
@@ -78,12 +78,15 @@ void rai::vote_generator::run ()
 		}
 		else // now >= cutoff && hashes.size () < 12
 		{
+			cutoff = min;
 			if (!hashes.empty ())
 			{
 				send (lock);
 			}
-			cutoff = min;
-			condition.wait (lock);
+			else
+			{
+				condition.wait (lock);
+			}
 		}
 	}
 }

--- a/rai/node/voting.cpp
+++ b/rai/node/voting.cpp
@@ -1,0 +1,79 @@
+#include <rai/node/voting.hpp>
+
+#include <rai/node/node.hpp>
+
+rai::vote_generator::vote_generator (rai::node & node_a, std::chrono::milliseconds wait_a) :
+node (node_a),
+thread ([this] () {run ();}),
+wait (wait_a),
+stopped (false)
+{
+}
+
+void rai::vote_generator::add (rai::block_hash const & hash_a)
+{
+	std::unique_lock <std::mutex> lock (mutex);
+	hashes.push_back (hash_a);
+	lock.unlock ();
+	condition.notify_all();
+}
+
+void rai::vote_generator::stop ()
+{
+	std::unique_lock <std::mutex> lock (mutex);
+	stopped = false;
+	lock.unlock ();
+	condition.notify_all ();
+	thread.join ();
+}
+
+void rai::vote_generator::send (std::unique_lock<std::mutex> & lock_a)
+{
+	std::vector <rai::block_hash> hashes_l;
+	hashes_l.reserve (12);
+	while (!hashes.empty () && hashes.size () < 12)
+	{
+		hashes_l.push_back (hashes.front ());
+		hashes.pop_front ();
+	}
+	lock_a.unlock ();
+	auto transaction (node.store.tx_begin_write ());
+	node.wallets.foreach_representative (transaction, [this, &hashes_l, &transaction](rai::public_key const & pub_a, rai::raw_key const & prv_a) {
+		auto vote (this->node.store.vote_generate (transaction, pub_a, prv_a, hashes_l));
+		this->node.vote_processor.vote (vote, this->node.network.endpoint ());
+	});
+	lock_a.lock ();
+}
+
+void rai::vote_generator::run ()
+{
+	std::unique_lock <std::mutex> lock (mutex);
+	auto min (std::numeric_limits<std::chrono::steady_clock::time_point>::min ());
+	auto cutoff (min);
+	while (!stopped)
+	{
+		auto now (std::chrono::steady_clock::now ());
+		if (hashes.size () >= 12)
+		{
+			send (lock);
+		}
+		else if (cutoff == min) // && hashes.size () < 12
+		{
+			cutoff = now + wait;
+			condition.wait_until (lock, cutoff);
+		}
+		else if (now < cutoff) // && hashes.size () < 12
+		{
+			condition.wait_until (lock, cutoff);
+		}
+		else // now >= cutoff && hashes.size () < 12
+		{
+			if (!hashes.empty ())
+			{
+				send (lock);
+			}
+			cutoff = min;
+			condition.wait (lock);
+		}
+	}
+}

--- a/rai/node/voting.cpp
+++ b/rai/node/voting.cpp
@@ -7,9 +7,9 @@ node (node_a),
 wait (wait_a),
 stopped (false),
 started (false),
-thread ([this] () {run ();})
+thread ([this]() { run (); })
 {
-	std::unique_lock<std::mutex>lock(mutex);
+	std::unique_lock<std::mutex> lock (mutex);
 	while (!started)
 	{
 		condition.wait (lock);
@@ -18,14 +18,14 @@ thread ([this] () {run ();})
 
 void rai::vote_generator::add (rai::block_hash const & hash_a)
 {
-	std::lock_guard <std::mutex> lock (mutex);
+	std::lock_guard<std::mutex> lock (mutex);
 	hashes.push_back (hash_a);
-	condition.notify_all();
+	condition.notify_all ();
 }
 
 void rai::vote_generator::stop ()
 {
-	std::unique_lock <std::mutex> lock (mutex);
+	std::unique_lock<std::mutex> lock (mutex);
 	stopped = true;
 	condition.notify_all ();
 	lock.unlock ();
@@ -37,7 +37,7 @@ void rai::vote_generator::stop ()
 
 void rai::vote_generator::send (std::unique_lock<std::mutex> & lock_a)
 {
-	std::vector <rai::block_hash> hashes_l;
+	std::vector<rai::block_hash> hashes_l;
 	hashes_l.reserve (12);
 	while (!hashes.empty () && hashes.size () < 12)
 	{
@@ -55,7 +55,7 @@ void rai::vote_generator::send (std::unique_lock<std::mutex> & lock_a)
 
 void rai::vote_generator::run ()
 {
-	std::unique_lock <std::mutex> lock (mutex);
+	std::unique_lock<std::mutex> lock (mutex);
 	started = true;
 	condition.notify_all ();
 	auto min (std::numeric_limits<std::chrono::steady_clock::time_point>::min ());

--- a/rai/node/voting.cpp
+++ b/rai/node/voting.cpp
@@ -39,7 +39,7 @@ void rai::vote_generator::send (std::unique_lock<std::mutex> & lock_a)
 {
 	std::vector<rai::block_hash> hashes_l;
 	hashes_l.reserve (12);
-	while (!hashes.empty () && hashes.size () < 12)
+	while (!hashes.empty () && hashes_l.size () < 12)
 	{
 		hashes_l.push_back (hashes.front ());
 		hashes.pop_front ();

--- a/rai/node/voting.cpp
+++ b/rai/node/voting.cpp
@@ -57,6 +57,7 @@ void rai::vote_generator::send (std::unique_lock<std::mutex> & lock_a)
 
 void rai::vote_generator::run ()
 {
+	rai::thread_role::set (rai::thread_role::name::voting);
 	std::unique_lock<std::mutex> lock (mutex);
 	started = true;
 	condition.notify_all ();

--- a/rai/node/voting.hpp
+++ b/rai/node/voting.hpp
@@ -19,11 +19,12 @@ private:
 	void run ();
 	void send (std::unique_lock<std::mutex> &);
 	rai::node & node;
-	std::thread thread;
 	std::mutex mutex;
 	std::condition_variable condition;
 	std::deque<rai::block_hash> hashes;
 	std::chrono::milliseconds wait;
 	bool stopped;
+	bool started;
+	std::thread thread;
 };
 }

--- a/rai/node/voting.hpp
+++ b/rai/node/voting.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <rai/lib/numbers.hpp>
+
+#include <deque>
+#include <mutex>
+#include <thread>
+
+namespace rai
+{
+class node;
+class vote_generator
+{
+public:
+	vote_generator (rai::node &, std::chrono::milliseconds);
+	void add (rai::block_hash const &);
+	void stop ();
+private:
+	void run ();
+	void send (std::unique_lock<std::mutex> &);
+	rai::node & node;
+	std::thread thread;
+	std::mutex mutex;
+	std::condition_variable condition;
+	std::deque<rai::block_hash> hashes;
+	std::chrono::milliseconds wait;
+	bool stopped;
+};
+}

--- a/rai/node/voting.hpp
+++ b/rai/node/voting.hpp
@@ -2,10 +2,11 @@
 
 #include <rai/lib/numbers.hpp>
 
+#include <boost/thread.hpp>
+
 #include <condition_variable>
 #include <deque>
 #include <mutex>
-#include <thread>
 
 namespace rai
 {
@@ -27,6 +28,6 @@ private:
 	std::chrono::milliseconds wait;
 	bool stopped;
 	bool started;
-	std::thread thread;
+	boost::thread thread;
 };
 }

--- a/rai/node/voting.hpp
+++ b/rai/node/voting.hpp
@@ -15,6 +15,7 @@ public:
 	vote_generator (rai::node &, std::chrono::milliseconds);
 	void add (rai::block_hash const &);
 	void stop ();
+
 private:
 	void run ();
 	void send (std::unique_lock<std::mutex> &);

--- a/rai/node/voting.hpp
+++ b/rai/node/voting.hpp
@@ -2,6 +2,7 @@
 
 #include <rai/lib/numbers.hpp>
 
+#include <condition_variable>
 #include <deque>
 #include <mutex>
 #include <thread>

--- a/rai/secure/common.cpp
+++ b/rai/secure/common.cpp
@@ -466,6 +466,7 @@ sequence (sequence_a),
 account (account_a)
 {
 	assert (blocks_a.size () > 0);
+	assert (blocks_a.size () <= 12);
 	for (auto hash : blocks_a)
 	{
 		blocks.push_back (hash);

--- a/rai/slow_test/node.cpp
+++ b/rai/slow_test/node.cpp
@@ -397,3 +397,23 @@ TEST (store, vote_load)
 		node.vote_processor.vote (vote, system.nodes[0]->network.endpoint ());
 	}
 }
+
+TEST (node, mass_vote_by_hash)
+{
+	rai::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
+	rai::genesis genesis;
+	rai::block_hash previous (genesis.hash ());
+	rai::keypair key;
+	std::vector<std::shared_ptr<rai::state_block>> blocks;
+	for (auto i (0); i < 10000; ++i)
+	{
+		auto block (std::make_shared<rai::state_block> (rai::test_genesis_key.pub, previous, rai::test_genesis_key.pub, rai::genesis_amount - (i + 1) * rai::Gxrb_ratio, key.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.work.generate (previous)));
+		previous = block->hash ();
+		blocks.push_back (block);
+	}
+	for (auto i (blocks.begin ()), n (blocks.end ()); i != n; ++i)
+	{
+		system.nodes[0]->block_processor.add (*i, std::chrono::steady_clock::now ());
+	}
+}


### PR DESCRIPTION
This patch decouples vote generation from quorum solicitation. Previously both were done in one large announce loop which on average would delay vote generation by 1/2 the announcement interval.

Now we announce votes as soon as a local decision is made i.e. a block is inserted in to the ledger.