### PR TITLE
Using decode_account instead of decode_hex in account_move RPC handler

### DIFF
--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -683,7 +683,7 @@ TEST (rpc, account_move)
 	request.put ("source", source_id.pub.to_string ());
 	boost::property_tree::ptree keys;
 	boost::property_tree::ptree entry;
-	entry.put ("", key.pub.to_string ());
+	entry.put ("", key.pub.to_account ());
 	keys.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", keys);
 	test_response response (request, rpc, system.service);

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -545,7 +545,7 @@ void rai::rpc_handler::account_move ()
 				for (auto i (accounts_text.begin ()), n (accounts_text.end ()); i != n; ++i)
 				{
 					rai::public_key account;
-					account.decode_hex (i->second.get<std::string> (""));
+					account.decode_account (i->second.get<std::string> (""));
 					accounts.push_back (account);
 				}
 				auto transaction (node.store.tx_begin_write ());


### PR DESCRIPTION
This patch resolves an issue with the RPC handler for `account_move` incorrectly decoding accounts by hex. According to https://github.com/nanocurrency/raiblocks/wiki/RPC-protocol#account-move this method should accept addresses rather than public keys and therefore needed `decode_account` instead.  

Closes #666

