### PR TITLE
Pass wallet reference in to actions and check for wallet liveness

### DIFF
--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -863,6 +863,7 @@ void rai::wallet_store::destroy (rai::transaction const & transaction_a)
 {
 	auto status (mdb_drop (tx (transaction_a), handle, 1));
 	assert (status == 0);
+	handle = 0;
 }
 
 std::shared_ptr<rai::block> rai::wallet::receive_action (rai::block const & send_a, rai::account const & representative_a, rai::uint128_union const & amount_a, bool generate_work_a)
@@ -1065,8 +1066,8 @@ bool rai::wallet::change_sync (rai::account const & source_a, rai::account const
 
 void rai::wallet::change_async (rai::account const & source_a, rai::account const & representative_a, std::function<void(std::shared_ptr<rai::block>)> const & action_a, bool generate_work_a)
 {
-	wallets.node.wallets.queue_wallet_action (rai::wallets::high_priority, [this, source_a, representative_a, action_a, generate_work_a]() {
-		auto block (change_action (source_a, representative_a, generate_work_a));
+	wallets.node.wallets.queue_wallet_action (rai::wallets::high_priority, shared_from_this (), [source_a, representative_a, action_a, generate_work_a](rai::wallet & wallet_a) {
+		auto block (wallet_a.change_action (source_a, representative_a, generate_work_a));
 		action_a (block);
 	});
 }
@@ -1084,8 +1085,8 @@ bool rai::wallet::receive_sync (std::shared_ptr<rai::block> block_a, rai::accoun
 void rai::wallet::receive_async (std::shared_ptr<rai::block> block_a, rai::account const & representative_a, rai::uint128_t const & amount_a, std::function<void(std::shared_ptr<rai::block>)> const & action_a, bool generate_work_a)
 {
 	//assert (dynamic_cast<rai::send_block *> (block_a.get ()) != nullptr);
-	wallets.node.wallets.queue_wallet_action (amount_a, [this, block_a, representative_a, amount_a, action_a, generate_work_a]() {
-		auto block (receive_action (*static_cast<rai::block *> (block_a.get ()), representative_a, amount_a, generate_work_a));
+	wallets.node.wallets.queue_wallet_action (amount_a, shared_from_this (), [block_a, representative_a, amount_a, action_a, generate_work_a](rai::wallet & wallet_a) {
+		auto block (wallet_a.receive_action (*static_cast<rai::block *> (block_a.get ()), representative_a, amount_a, generate_work_a));
 		action_a (block);
 	});
 }
@@ -1102,8 +1103,8 @@ rai::block_hash rai::wallet::send_sync (rai::account const & source_a, rai::acco
 
 void rai::wallet::send_async (rai::account const & source_a, rai::account const & account_a, rai::uint128_t const & amount_a, std::function<void(std::shared_ptr<rai::block>)> const & action_a, bool generate_work_a, boost::optional<std::string> id_a)
 {
-	wallets.node.wallets.queue_wallet_action (rai::wallets::high_priority, [this, source_a, account_a, amount_a, action_a, generate_work_a, id_a]() {
-		auto block (send_action (source_a, account_a, amount_a, generate_work_a, id_a));
+	wallets.node.wallets.queue_wallet_action (rai::wallets::high_priority, shared_from_this (), [source_a, account_a, amount_a, action_a, generate_work_a, id_a](rai::wallet & wallet_a) {
+		auto block (wallet_a.send_action (source_a, account_a, amount_a, generate_work_a, id_a));
 		action_a (block);
 	});
 }
@@ -1126,9 +1127,8 @@ void rai::wallet::work_update (rai::transaction const & transaction_a, rai::acco
 
 void rai::wallet::work_ensure (rai::account const & account_a, rai::block_hash const & hash_a)
 {
-	auto this_l (shared_from_this ());
-	wallets.node.wallets.queue_wallet_action (rai::wallets::generate_priority, [this_l, account_a, hash_a] {
-		this_l->work_cache_blocking (account_a, hash_a);
+	wallets.node.wallets.queue_wallet_action (rai::wallets::generate_priority, shared_from_this (), [account_a, hash_a] (rai::wallet & wallet_a){
+		wallet_a.work_cache_blocking (account_a, hash_a);
 	});
 }
 
@@ -1215,6 +1215,11 @@ rai::public_key rai::wallet::change_seed (rai::transaction const & transaction_a
 	}
 
 	return account;
+}
+
+bool rai::wallet::live ()
+{
+	return store.handle != 0;
 }
 
 void rai::wallet::work_cache_blocking (rai::account const & account_a, rai::block_hash const & root_a)
@@ -1348,13 +1353,17 @@ void rai::wallets::do_wallet_actions ()
 		if (!actions.empty ())
 		{
 			auto first (actions.begin ());
-			auto current (std::move (first->second));
+			auto wallet (first->second.first);
+			auto current (std::move (first->second.second));
 			actions.erase (first);
-			lock.unlock ();
-			observer (true);
-			current ();
-			observer (false);
-			lock.lock ();
+			if (wallet->live ())
+			{
+				lock.unlock ();
+				observer (true);
+				current (*wallet);
+				observer (false);
+				lock.lock ();
+			}
 		}
 		else
 		{
@@ -1363,10 +1372,10 @@ void rai::wallets::do_wallet_actions ()
 	}
 }
 
-void rai::wallets::queue_wallet_action (rai::uint128_t const & amount_a, std::function<void()> const & action_a)
+void rai::wallets::queue_wallet_action (rai::uint128_t const & amount_a, std::shared_ptr<rai::wallet> wallet_a, std::function<void(rai::wallet &)> const & action_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	actions.insert (std::make_pair (amount_a, std::move (action_a)));
+	actions.insert (std::make_pair (amount_a, std::make_pair (wallet_a, std::move (action_a))));
 	condition.notify_all ();
 }
 

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1416,8 +1416,9 @@ void rai::wallets::stop ()
 	{
 		std::lock_guard<std::mutex> lock (mutex);
 		stopped = true;
-		condition.notify_all ();
+		actions.clear ();
 	}
+	condition.notify_all ();
 	if (thread.joinable ())
 	{
 		thread.join ();

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1127,7 +1127,7 @@ void rai::wallet::work_update (rai::transaction const & transaction_a, rai::acco
 
 void rai::wallet::work_ensure (rai::account const & account_a, rai::block_hash const & hash_a)
 {
-	wallets.node.wallets.queue_wallet_action (rai::wallets::generate_priority, shared_from_this (), [account_a, hash_a] (rai::wallet & wallet_a){
+	wallets.node.wallets.queue_wallet_action (rai::wallets::generate_priority, shared_from_this (), [account_a, hash_a](rai::wallet & wallet_a) {
 		wallet_a.work_cache_blocking (account_a, hash_a);
 	});
 }

--- a/rai/node/wallet.hpp
+++ b/rai/node/wallet.hpp
@@ -180,7 +180,7 @@ public:
 	void clear_send_ids (rai::transaction const &);
 	std::function<void(bool)> observer;
 	std::unordered_map<rai::uint256_union, std::shared_ptr<rai::wallet>> items;
-	std::multimap<rai::uint128_t, std::pair <std::shared_ptr<rai::wallet>, std::function<void(rai::wallet &)>>, std::greater<rai::uint128_t>> actions;
+	std::multimap<rai::uint128_t, std::pair<std::shared_ptr<rai::wallet>, std::function<void(rai::wallet &)>>, std::greater<rai::uint128_t>> actions;
 	std::mutex mutex;
 	std::condition_variable condition;
 	rai::kdf kdf;

--- a/rai/node/wallet.hpp
+++ b/rai/node/wallet.hpp
@@ -150,6 +150,7 @@ public:
 	void init_free_accounts (rai::transaction const &);
 	/** Changes the wallet seed and returns the first account */
 	rai::public_key change_seed (rai::transaction const & transaction_a, rai::raw_key const & prv_a);
+	bool live ();
 	std::unordered_set<rai::account> free_accounts;
 	std::function<void(bool, bool)> lock_observer;
 	rai::wallet_store store;
@@ -172,14 +173,14 @@ public:
 	void search_pending_all ();
 	void destroy (rai::uint256_union const &);
 	void do_wallet_actions ();
-	void queue_wallet_action (rai::uint128_t const &, std::function<void()> const &);
+	void queue_wallet_action (rai::uint128_t const &, std::shared_ptr<rai::wallet>, std::function<void(rai::wallet &)> const &);
 	void foreach_representative (rai::transaction const &, std::function<void(rai::public_key const &, rai::raw_key const &)> const &);
 	bool exists (rai::transaction const &, rai::public_key const &);
 	void stop ();
 	void clear_send_ids (rai::transaction const &);
 	std::function<void(bool)> observer;
 	std::unordered_map<rai::uint256_union, std::shared_ptr<rai::wallet>> items;
-	std::multimap<rai::uint128_t, std::function<void()>, std::greater<rai::uint128_t>> actions;
+	std::multimap<rai::uint128_t, std::pair <std::shared_ptr<rai::wallet>, std::function<void(rai::wallet &)>>, std::greater<rai::uint128_t>> actions;
 	std::mutex mutex;
 	std::condition_variable condition;
 	rai::kdf kdf;


### PR DESCRIPTION
Wallets were unsafely capturing this-pointers in wallet action lambdas and actions were not thread safe with respect to wallet_destroy actions.
This change puts a shared pointer to the wallet in to the call to queue a wallet action and checks liveness before calling the action.
This fixes an intermittent test failures with wallet_destroy and possible crashes while doing the same thing on a running node.