### PR TITLE
Add unreachable host stats

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2535,6 +2535,10 @@ void rai::network::send_buffer (uint8_t const * data_a, size_t size_a, rai::endp
 	socket.async_send_to (boost::asio::buffer (data_a, size_a), endpoint_a, [this, callback_a](boost::system::error_code const & ec, size_t size_a) {
 		callback_a (ec, size_a);
 		this->node.stats.add (rai::stat::type::traffic, rai::stat::dir::out, size_a);
+		if (ec == boost::system::errc::host_unreachable)
+		{
+			this->node.stats.inc (rai::stat::type::error, rai::stat::detail::unreachable_host, rai::stat::dir::out);
+		}
 		if (this->node.config.logging.network_packet_logging ())
 		{
 			BOOST_LOG (this->node.log) << "Packet send complete";

--- a/rai/node/stats.cpp
+++ b/rai/node/stats.cpp
@@ -439,6 +439,9 @@ std::string rai::stat::detail_to_string (uint32_t key)
 		case rai::stat::detail::overflow:
 			res = "overflow";
 			break;
+		case rai::stat::detail::unreachable_host:
+			res = "unreachable_host";
+			break;
 		case rai::stat::detail::invalid_magic:
 			res = "invalid_magic";
 			break;

--- a/rai/node/stats.hpp
+++ b/rai/node/stats.hpp
@@ -197,6 +197,7 @@ public:
 		bad_sender,
 		insufficient_work,
 		http_callback,
+		unreachable_host,
 
 		// ledger, block, bootstrap
 		send,


### PR DESCRIPTION
This catches ICMP rejects from firewalls too.

Seems like we keep trying to send to quite a few endpoints that we'll probably never be able to contact. Should maybe add a backoff on these endpoint (they may be down and get back up)

Adding stats for now.