### PR TITLE
Bootstrap traffic stats

### DIFF
--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -37,6 +37,7 @@ void rai::socket::async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, si
 	auto this_l (shared_from_this ());
 	start ();
 	boost::asio::async_read (socket_m, boost::asio::buffer (buffer_a->data (), size_a), [this_l, callback_a](boost::system::error_code const & ec, size_t size_a) {
+		this_l->node->stats.add (rai::stat::type::traffic_bootstrap, rai::stat::dir::in, size_a);
 		this_l->stop ();
 		callback_a (ec, size_a);
 	});
@@ -47,6 +48,7 @@ void rai::socket::async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, s
 	auto this_l (shared_from_this ());
 	start ();
 	boost::asio::async_write (socket_m, boost::asio::buffer (buffer_a->data (), buffer_a->size ()), [this_l, callback_a, buffer_a](boost::system::error_code const & ec, size_t size_a) {
+		this_l->node->stats.add (rai::stat::type::traffic_bootstrap, rai::stat::dir::out, size_a);
 		this_l->stop ();
 		callback_a (ec, size_a);
 	});

--- a/rai/node/stats.cpp
+++ b/rai/node/stats.cpp
@@ -342,6 +342,9 @@ std::string rai::stat::type_to_string (uint32_t key)
 		case rai::stat::type::traffic:
 			res = "traffic";
 			break;
+		case rai::stat::type::traffic_bootstrap:
+			res = "traffic_bootstrap";
+			break;
 		case rai::stat::type::vote:
 			res = "vote";
 			break;

--- a/rai/node/stats.hpp
+++ b/rai/node/stats.hpp
@@ -176,6 +176,7 @@ public:
 	enum class type : uint8_t
 	{
 		traffic,
+		traffic_bootstrap,
 		error,
 		message,
 		block,

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -809,16 +809,18 @@ void rai_qt::stats_viewer::refresh_stats ()
 				detail = "total";
 			}
 
-			if (type == "traffic")
+			if (type == "traffic" || type == "traffic_bootstrap")
 			{
 				const std::vector<std::string> units = { " bytes", " KB", " MB", " GB", " TB", " PB" };
 				double bytes = std::stod (value);
-				auto index = std::min (units.size () - 1, static_cast<size_t> (std::floor (std::log2 (bytes) / 10)));
+				auto index = bytes == 0 ? 0 : std::min (units.size () - 1, static_cast<size_t> (std::floor (std::log2 (bytes) / 10)));
 				std::string unit = units[index];
 				bytes /= std::pow (1024, index);
 
+				// Only show decimals from MB and up
+				int precision = index < 2 ? 0 : 2;
 				std::stringstream numstream;
-				numstream << std::fixed << std::setprecision (2) << bytes;
+				numstream << std::fixed << std::setprecision (precision) << bytes;
 				value = numstream.str () + unit;
 			}
 


### PR DESCRIPTION
Payload traffic is currently only collected for udp. This PR adds stats for bootstrap traffic as well.