### PR TITLE
Make config upgrades more robust

### DIFF
--- a/rai/node/logging.cpp
+++ b/rai/node/logging.cpp
@@ -80,7 +80,6 @@ bool rai::logging::upgrade_json (unsigned version_a, boost::property_tree::ptree
 			result = true;
 		case 3:
 			tree_a.put ("network_node_id_handshake", "false");
-			tree_a.put ("version", "4");
 			result = true;
 		case 4:
 			tree_a.put ("upnp_details", "false");

--- a/rai/node/logging.cpp
+++ b/rai/node/logging.cpp
@@ -43,7 +43,7 @@ void rai::logging::init (boost::filesystem::path const & application_path_a)
 
 void rai::logging::serialize_json (boost::property_tree::ptree & tree_a) const
 {
-	tree_a.put ("version", "5");
+	tree_a.put ("version", std::to_string (json_version));
 	tree_a.put ("ledger", ledger_logging_value);
 	tree_a.put ("ledger_duplicate", ledger_duplicate_logging_value);
 	tree_a.put ("vote", vote_logging_value);
@@ -67,17 +67,16 @@ void rai::logging::serialize_json (boost::property_tree::ptree & tree_a) const
 
 bool rai::logging::upgrade_json (unsigned version_a, boost::property_tree::ptree & tree_a)
 {
+	tree_a.put ("version", std::to_string (json_version));
 	auto result (false);
 	switch (version_a)
 	{
 		case 1:
 			tree_a.put ("vote", vote_logging_value);
-			tree_a.put ("version", "2");
 			result = true;
 		case 2:
 			tree_a.put ("rotation_size", "4194304");
 			tree_a.put ("flush", "true");
-			tree_a.put ("version", "3");
 			result = true;
 		case 3:
 			tree_a.put ("network_node_id_handshake", "false");
@@ -85,7 +84,6 @@ bool rai::logging::upgrade_json (unsigned version_a, boost::property_tree::ptree
 			result = true;
 		case 4:
 			tree_a.put ("upnp_details", "false");
-			tree_a.put ("version", "5");
 			result = true;
 		case 5:
 			break;

--- a/rai/node/logging.hpp
+++ b/rai/node/logging.hpp
@@ -56,5 +56,6 @@ public:
 	uintmax_t max_size;
 	uintmax_t rotation_size;
 	boost::log::sources::logger_mt log;
+	static constexpr int json_version = 5;
 };
 }

--- a/rai/node/nodeconfig.cpp
+++ b/rai/node/nodeconfig.cpp
@@ -61,7 +61,7 @@ block_processor_batch_max_time (std::chrono::milliseconds (5000))
 
 void rai::node_config::serialize_json (boost::property_tree::ptree & tree_a) const
 {
-	tree_a.put ("version", "15");
+	tree_a.put ("version", std::to_string (json_version));
 	tree_a.put ("peering_port", std::to_string (peering_port));
 	tree_a.put ("bootstrap_fraction_numerator", std::to_string (bootstrap_fraction_numerator));
 	tree_a.put ("receive_minimum", receive_minimum.to_string_dec ());
@@ -108,10 +108,11 @@ void rai::node_config::serialize_json (boost::property_tree::ptree & tree_a) con
 	tree_a.put ("block_processor_batch_max_time", block_processor_batch_max_time.count ());
 }
 
-bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptree & tree_a)
+bool rai::node_config::upgrade_json (unsigned version_a, boost::property_tree::ptree & tree_a)
 {
+	tree_a.put ("version", std::to_string (json_version));
 	auto result (false);
-	switch (version)
+	switch (version_a)
 	{
 		case 1:
 		{
@@ -127,8 +128,6 @@ bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptr
 			}
 			tree_a.erase ("preconfigured_representatives");
 			tree_a.add_child ("preconfigured_representatives", reps);
-			tree_a.erase ("version");
-			tree_a.put ("version", "2");
 			result = true;
 		}
 		case 2:
@@ -137,87 +136,61 @@ bool rai::node_config::upgrade_json (unsigned version, boost::property_tree::ptr
 			tree_a.put ("password_fanout", std::to_string (1024));
 			tree_a.put ("io_threads", std::to_string (io_threads));
 			tree_a.put ("work_threads", std::to_string (work_threads));
-			tree_a.erase ("version");
-			tree_a.put ("version", "3");
 			result = true;
 		}
 		case 3:
 			tree_a.erase ("receive_minimum");
 			tree_a.put ("receive_minimum", rai::xrb_ratio.convert_to<std::string> ());
-			tree_a.erase ("version");
-			tree_a.put ("version", "4");
 			result = true;
 		case 4:
 			tree_a.erase ("receive_minimum");
 			tree_a.put ("receive_minimum", rai::xrb_ratio.convert_to<std::string> ());
-			tree_a.erase ("version");
-			tree_a.put ("version", "5");
 			result = true;
 		case 5:
 			tree_a.put ("enable_voting", enable_voting);
 			tree_a.erase ("packet_delay_microseconds");
 			tree_a.erase ("rebroadcast_delay");
 			tree_a.erase ("creation_rebroadcast");
-			tree_a.erase ("version");
-			tree_a.put ("version", "6");
 			result = true;
 		case 6:
 			tree_a.put ("bootstrap_connections", 16);
 			tree_a.put ("callback_address", "");
 			tree_a.put ("callback_port", "0");
 			tree_a.put ("callback_target", "");
-			tree_a.erase ("version");
-			tree_a.put ("version", "7");
 			result = true;
 		case 7:
 			tree_a.put ("lmdb_max_dbs", "128");
-			tree_a.erase ("version");
-			tree_a.put ("version", "8");
 			result = true;
 		case 8:
 			tree_a.put ("bootstrap_connections_max", "64");
-			tree_a.erase ("version");
-			tree_a.put ("version", "9");
 			result = true;
 		case 9:
 			tree_a.put ("state_block_parse_canary", rai::block_hash (0).to_string ());
 			tree_a.put ("state_block_generate_canary", rai::block_hash (0).to_string ());
-			tree_a.erase ("version");
-			tree_a.put ("version", "10");
 			result = true;
 		case 10:
 			tree_a.put ("online_weight_minimum", online_weight_minimum.to_string_dec ());
 			tree_a.put ("online_weight_quorom", std::to_string (online_weight_quorum));
 			tree_a.erase ("inactive_supply");
-			tree_a.erase ("version");
-			tree_a.put ("version", "11");
 			result = true;
 		case 11:
 		{
 			auto online_weight_quorum_l (tree_a.get<std::string> ("online_weight_quorom"));
 			tree_a.erase ("online_weight_quorom");
 			tree_a.put ("online_weight_quorum", online_weight_quorum_l);
-			tree_a.erase ("version");
-			tree_a.put ("version", "12");
 			result = true;
 		}
 		case 12:
 			tree_a.erase ("state_block_parse_canary");
 			tree_a.erase ("state_block_generate_canary");
-			tree_a.erase ("version");
-			tree_a.put ("version", "13");
 			result = true;
 		case 13:
 			tree_a.put ("generate_hash_votes_at", "0");
-			tree_a.erase ("version");
-			tree_a.put ("version", "14");
 			result = true;
 		case 14:
 			tree_a.put ("network_threads", std::to_string (network_threads));
 			tree_a.erase ("generate_hash_votes_at");
 			tree_a.put ("block_processor_batch_max_time", block_processor_batch_max_time.count ());
-			tree_a.erase ("version");
-			tree_a.put ("version", "15");
 			result = true;
 		case 15:
 			break;

--- a/rai/node/nodeconfig.hpp
+++ b/rai/node/nodeconfig.hpp
@@ -48,5 +48,6 @@ public:
 	static std::chrono::seconds constexpr keepalive_period = std::chrono::seconds (60);
 	static std::chrono::seconds constexpr keepalive_cutoff = keepalive_period * 5;
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);
+	static constexpr int json_version = 15;
 };
 }

--- a/rai/rai_node/daemon.cpp
+++ b/rai/rai_node/daemon.cpp
@@ -14,7 +14,7 @@ opencl_enable (false)
 
 void rai_daemon::daemon_config::serialize_json (boost::property_tree::ptree & tree_a)
 {
-	tree_a.put ("version", "2");
+	tree_a.put ("version", std::to_string (json_version));
 	tree_a.put ("rpc_enable", rpc_enable);
 	boost::property_tree::ptree rpc_l;
 	rpc.serialize_json (rpc_l);
@@ -66,6 +66,7 @@ bool rai_daemon::daemon_config::deserialize_json (bool & upgraded_a, boost::prop
 
 bool rai_daemon::daemon_config::upgrade_json (unsigned version_a, boost::property_tree::ptree & tree_a)
 {
+	tree_a.put ("version", std::to_string (json_version));
 	auto result (false);
 	switch (version_a)
 	{
@@ -83,7 +84,6 @@ bool rai_daemon::daemon_config::upgrade_json (unsigned version_a, boost::propert
 				opencl.serialize_json (opencl_l);
 				tree_a.put_child ("opencl", opencl_l);
 			}
-			tree_a.put ("version", "2");
 			result = true;
 		}
 		case 2:

--- a/rai/rai_node/daemon.hpp
+++ b/rai/rai_node/daemon.hpp
@@ -20,5 +20,6 @@ public:
 	rai::node_config node;
 	bool opencl_enable;
 	rai::opencl_config opencl;
+	static constexpr int json_version = 2;
 };
 }

--- a/rai/rai_wallet/entry.cpp
+++ b/rai/rai_wallet/entry.cpp
@@ -23,6 +23,7 @@ public:
 	}
 	bool upgrade_json (unsigned version_a, boost::property_tree::ptree & tree_a)
 	{
+		tree_a.put ("version", std::to_string (json_version));
 		auto result (false);
 		switch (version_a)
 		{
@@ -33,7 +34,6 @@ public:
 				tree_a.erase ("account");
 				tree_a.put ("account", account.to_account ());
 				tree_a.erase ("version");
-				tree_a.put ("version", "2");
 				result = true;
 			}
 			case 2:
@@ -43,7 +43,6 @@ public:
 				tree_a.put ("rpc_enable", "false");
 				tree_a.put_child ("rpc", rpc_l);
 				tree_a.erase ("version");
-				tree_a.put ("version", "3");
 				result = true;
 			}
 			case 3:
@@ -60,7 +59,6 @@ public:
 					opencl.serialize_json (opencl_l);
 					tree_a.put_child ("opencl", opencl_l);
 				}
-				tree_a.put ("version", "4");
 				result = true;
 			}
 			case 4:
@@ -119,7 +117,7 @@ public:
 	{
 		std::string wallet_string;
 		wallet.encode_hex (wallet_string);
-		tree_a.put ("version", "4");
+		tree_a.put ("version", std::to_string (json_version));
 		tree_a.put ("wallet", wallet_string);
 		tree_a.put ("account", account.to_account ());
 		boost::property_tree::ptree node_l;
@@ -159,6 +157,7 @@ public:
 	rai::rpc_config rpc;
 	bool opencl_enable;
 	rai::opencl_config opencl;
+	static constexpr int json_version = 4;
 };
 
 namespace


### PR DESCRIPTION
There's been a couple of instances where the version number haven't been changed in all places. This puts the json config version in a member so it's only one place to change it.