### PR TITLE
removing std::endl from filter_request

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -3729,6 +3729,11 @@ std::string filter_request (boost::property_tree::ptree tree_a)
 	std::stringstream stream;
 	boost::property_tree::write_json (stream, tree_a, false);
 	result = stream.str ();
+	// removing std::endl
+	if (result.length () > 1)
+	{
+		result.pop_back ();
+	}
 	return result;
 }
 }


### PR DESCRIPTION
Fixes #1347 

Related to boost json library: https://github.com/boostorg/property_tree/blob/develop/include/boost/property_tree/json_parser/detail/write.hpp#L161