### PR TITLE
Make signatures non-deterministic

### DIFF
--- a/ed25519-donna/ed25519.c
+++ b/ed25519-donna/ed25519.c
@@ -61,12 +61,15 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 	bignum256modm r, S, a;
 	ge25519 ALIGN(16) R;
 	hash_512bits extsk, hashr, hram;
+	unsigned char randr[32];
 
 	ed25519_extsk(extsk, sk);
 
-	/* r = H(aExt[32..64], m) */
+	/* r = H(aExt[32..64], randr, m) */
 	ed25519_hash_init(&ctx);
 	ed25519_hash_update(&ctx, extsk + 32, 32);
+	ed25519_randombytes_unsafe(randr, 32);
+	ed25519_hash_update(&ctx, randr, 32);
 	ed25519_hash_update(&ctx, m, mlen);
 	ed25519_hash_final(&ctx, hashr);
 	expand256_modm(r, hashr, 64);

--- a/rai/core_test/interface.cpp
+++ b/rai/core_test/interface.cpp
@@ -103,7 +103,8 @@ TEST (interface, sign_transaction)
 	ASSERT_FALSE (rai::validate_message (pub, send.hash (), send.signature));
 	send.signature.bytes[0] ^= 1;
 	ASSERT_TRUE (rai::validate_message (pub, send.hash (), send.signature));
-	auto transaction (xrb_sign_transaction (send.to_json ().c_str (), key.data.bytes.data ()));
+	auto send_json (send.to_json ());
+	auto transaction (xrb_sign_transaction (send_json.c_str (), key.data.bytes.data ()));
 	boost::property_tree::ptree block_l;
 	std::string transaction_l (transaction);
 	std::stringstream block_stream (transaction_l);
@@ -113,7 +114,11 @@ TEST (interface, sign_transaction)
 	auto send1 (dynamic_cast<rai::send_block *> (block.get ()));
 	ASSERT_NE (nullptr, send1);
 	ASSERT_FALSE (rai::validate_message (pub, send.hash (), send1->signature));
+	// Signatures should be non-deterministic
+	auto transaction2 (xrb_sign_transaction (send_json.c_str (), key.data.bytes.data ()));
+	ASSERT_NE (0, strcmp (transaction, transaction2));
 	free (transaction);
+	free (transaction2);
 }
 
 TEST (interface, fail_sign_transaction)


### PR DESCRIPTION
Advantage: resistance to side channel attacks
Disadvantage: signatures will be non-deterministic