### PR TITLE
CLI wallet_import force wallet creation if requested

### DIFF
--- a/rai/node/cli.cpp
+++ b/rai/node/cli.cpp
@@ -574,8 +574,8 @@ std::error_code rai::handle_node_options (boost::program_options::variables_map 
 									std::cerr << "Unable to import wallet\n";
 									ec = rai::error_cli::invalid_arguments;
 								}
-								
-							}}
+							}
+						}
 					}
 					else
 					{


### PR DESCRIPTION
When using the wallet_import currently the wallet_id must be created, with this change passing --force 1 would allow it to create the wallet using the specified wallet_id and then import into that wallet from the json file