### PR TITLE
Dedicate a full r hash block to attacker unknown bytes

### DIFF
--- a/ed25519-donna/ed25519.c
+++ b/ed25519-donna/ed25519.c
@@ -62,6 +62,7 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 	ge25519 ALIGN(16) R;
 	hash_512bits extsk, hashr, hram;
 	unsigned char randr[32];
+	static const unsigned char rzero[64] = {0};
 
 	ed25519_extsk(extsk, sk);
 
@@ -70,6 +71,11 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 	ed25519_hash_update(&ctx, extsk + 32, 32);
 	ed25519_randombytes_unsafe(randr, 32);
 	ed25519_hash_update(&ctx, randr, 32);
+	/*
+		Fill up the rest of the hash block.
+		This puts the message (possibly known to a side channel attacker) in a separate block.
+	*/
+	ed25519_hash_update(&ctx, rzero, 64);
 	ed25519_hash_update(&ctx, m, mlen);
 	ed25519_hash_final(&ctx, hashr);
 	expand256_modm(r, hashr, 64);

--- a/ed25519-donna/ed25519.c
+++ b/ed25519-donna/ed25519.c
@@ -66,13 +66,13 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 
 	ed25519_extsk(extsk, sk);
 
-	/* r = H(aExt[32..64], randr[0..31], zero[0..31], m) */
+	/* r = H(aExt[32..64], randr[0..31], zero[0..63], m) */
 	ed25519_hash_init(&ctx);
 	ed25519_hash_update(&ctx, extsk + 32, 32);
 	ed25519_randombytes_unsafe(randr, 32);
 	ed25519_hash_update(&ctx, randr, 32);
 	/*
-	 * Fill up the rest of the hash block.
+	 * Pad with zeros the rest of the hash block.
 	 * This puts the message (possibly known to a side
 	 * channel attacker) in a separate block.
 	 */

--- a/ed25519-donna/ed25519.c
+++ b/ed25519-donna/ed25519.c
@@ -72,7 +72,8 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 	ed25519_randombytes_unsafe(randr, 32);
 	ed25519_hash_update(&ctx, randr, 32);
 	/*
-	 * Pad with zeros the rest of the hash block.
+	 * Pad the rest of the hash block (which is 128
+	 * bytes in size in our case) with zeros.
 	 * This puts the message (possibly known to a side
 	 * channel attacker) in a separate block.
 	 */

--- a/ed25519-donna/ed25519.c
+++ b/ed25519-donna/ed25519.c
@@ -66,7 +66,7 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 
 	ed25519_extsk(extsk, sk);
 
-	/* r = H(aExt[32..64], randr[0..31], zero[0..63], m) */
+	/* r = H(aExt[32..63], randr[0..31], zero[0..63], m) */
 	ed25519_hash_init(&ctx);
 	ed25519_hash_update(&ctx, extsk + 32, 32);
 	ed25519_randombytes_unsafe(randr, 32);

--- a/ed25519-donna/ed25519.c
+++ b/ed25519-donna/ed25519.c
@@ -66,15 +66,16 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 
 	ed25519_extsk(extsk, sk);
 
-	/* r = H(aExt[32..64], randr, m) */
+	/* r = H(aExt[32..64], randr[0..31], zero[0..31], m) */
 	ed25519_hash_init(&ctx);
 	ed25519_hash_update(&ctx, extsk + 32, 32);
 	ed25519_randombytes_unsafe(randr, 32);
 	ed25519_hash_update(&ctx, randr, 32);
 	/*
-		Fill up the rest of the hash block.
-		This puts the message (possibly known to a side channel attacker) in a separate block.
-	*/
+	 * Fill up the rest of the hash block.
+	 * This puts the message (possibly known to a side
+	 * channel attacker) in a separate block.
+	 */
 	ed25519_hash_update(&ctx, rzero, 64);
 	ed25519_hash_update(&ctx, m, mlen);
 	ed25519_hash_final(&ctx, hashr);


### PR DESCRIPTION
Follow up to #1353. I noticed that https://eprint.iacr.org/2017/985.pdf recommended dedicating a full hash block to the key and random bytes to prevent side channel attacks (I don't recall that from the paper I had previously read). This is also similar to how keys work in blake2b, and again there's really no reason not to do it.