### PR TITLE
RPC confirmation_quorum: optionally include account/ip/rep weight

### DIFF
--- a/rai/node/peers.cpp
+++ b/rai/node/peers.cpp
@@ -325,9 +325,9 @@ size_t rai::peer_container::size_sqrt ()
 	return result;
 }
 
-rai::uint128_t rai::peer_container::total_weight ()
+std::vector<rai::peer_information> rai::peer_container::list_probable_rep_weights ()
 {
-	rai::uint128_t result (0);
+	std::vector<rai::peer_information> result;
 	std::unordered_set<rai::account> probable_reps;
 	std::lock_guard<std::mutex> lock (mutex);
 	for (auto i (peers.get<6> ().begin ()), n (peers.get<6> ().end ()); i != n; ++i)
@@ -335,9 +335,22 @@ rai::uint128_t rai::peer_container::total_weight ()
 		// Calculate if representative isn't recorded for several IP addresses
 		if (probable_reps.find (i->probable_rep_account) == probable_reps.end ())
 		{
-			result = result + i->rep_weight.number ();
+			if (!i->rep_weight.number ().is_zero ())
+			{
+				result.push_back (*i);
+			}
 			probable_reps.insert (i->probable_rep_account);
 		}
+	}
+	return result;
+}
+
+rai::uint128_t rai::peer_container::total_weight ()
+{
+	rai::uint128_t result (0);
+	for (auto & entry : list_probable_rep_weights ())
+	{
+		result = result + entry.rep_weight.number ();
 	}
 	return result;
 }

--- a/rai/node/peers.hpp
+++ b/rai/node/peers.hpp
@@ -83,6 +83,8 @@ public:
 	std::vector<peer_information> list_vector ();
 	// A list of random peers sized for the configured rebroadcast fanout
 	std::deque<rai::endpoint> list_fanout ();
+	// Returns a list of probable reps and their weight
+	std::vector<peer_information> list_probable_rep_weights ();
 	// Get the next peer for attempting bootstrap
 	rai::endpoint bootstrap_peer ();
 	// Purge any peer where last_contact < time_point and return what was left

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1483,6 +1483,19 @@ void rai::rpc_handler::confirmation_quorum ()
 	response_l.put ("online_weight_minimum", node.config.online_weight_minimum.to_string_dec ());
 	response_l.put ("online_stake_total", node.online_reps.online_stake_total.convert_to<std::string> ());
 	response_l.put ("peers_stake_total", node.peers.total_weight ().convert_to<std::string> ());
+	if (request.get<bool> ("peer_details", false))
+	{
+		boost::property_tree::ptree peers;
+		for (auto & peer : node.peers.list_probable_rep_weights ())
+		{
+			boost::property_tree::ptree peer_node;
+			peer_node.put ("account", peer.probable_rep_account.to_account ());
+			peer_node.put ("ip", peer.ip_address.to_string ());
+			peer_node.put ("weight", peer.rep_weight.to_string_dec ());
+			peers.push_back (std::make_pair ("", peer_node));
+		}
+		response_l.add_child ("peers", peers);
+	}
 	response_errors ();
 }
 


### PR DESCRIPTION
If `peer_details` is true, add account/ip/rep weight to the `confirmation_quorum` RPC call.