### PR TITLE
Misc cleanup

### DIFF
--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -80,7 +80,7 @@ public:
 	operator MDB_val const & () const;
 	MDB_val value;
 	std::shared_ptr<std::vector<uint8_t>> buffer;
-	rai::epoch epoch;
+	rai::epoch epoch{ rai::epoch::unspecified };
 };
 class block_store;
 

--- a/rai/node/testing.cpp
+++ b/rai/node/testing.cpp
@@ -43,9 +43,9 @@ work (1, nullptr)
 	for (auto i (nodes.begin ()), j (nodes.begin () + 1), n (nodes.end ()); j != n; ++i, ++j)
 	{
 		auto starting1 ((*i)->peers.size ());
-		auto new1 (starting1);
+		decltype (starting1) new1;
 		auto starting2 ((*j)->peers.size ());
-		auto new2 (starting2);
+		decltype (starting2) new2;
 		(*j)->network.send_keepalive ((*i)->network.endpoint ());
 		do
 		{

--- a/rai/secure/ledger.hpp
+++ b/rai/secure/ledger.hpp
@@ -2,7 +2,6 @@
 
 #include <rai/secure/common.hpp>
 
-struct MDB_txn;
 namespace rai
 {
 class block_store;


### PR DESCRIPTION
Silence a few warnings/minor fixups:
* mdb_val#epoch wasn't initialized by all c'tors
* dead stores
* Unused forward declaration