### PR TITLE
Move serialization to vector pattern into a base class function

### DIFF
--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -25,7 +25,7 @@ rai::message_header::message_header (bool & error_a, rai::stream & stream_a)
 	}
 }
 
-void rai::message_header::serialize (rai::stream & stream_a)
+void rai::message_header::serialize (rai::stream & stream_a) const
 {
 	rai::write (stream_a, rai::message_header::magic_number);
 	rai::write (stream_a, version_max);
@@ -352,7 +352,7 @@ void rai::keepalive::visit (rai::message_visitor & visitor_a) const
 	visitor_a.keepalive (*this);
 }
 
-void rai::keepalive::serialize (rai::stream & stream_a)
+void rai::keepalive::serialize (rai::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	for (auto i (peers.begin ()), j (peers.end ()); i != j; ++i)
@@ -413,7 +413,7 @@ bool rai::publish::deserialize (rai::stream & stream_a, rai::block_uniquer * uni
 	return result;
 }
 
-void rai::publish::serialize (rai::stream & stream_a)
+void rai::publish::serialize (rai::stream & stream_a) const
 {
 	assert (block != nullptr);
 	header.serialize (stream_a);
@@ -459,7 +459,7 @@ void rai::confirm_req::visit (rai::message_visitor & visitor_a) const
 	visitor_a.confirm_req (*this);
 }
 
-void rai::confirm_req::serialize (rai::stream & stream_a)
+void rai::confirm_req::serialize (rai::stream & stream_a) const
 {
 	assert (block != nullptr);
 	header.serialize (stream_a);
@@ -507,7 +507,7 @@ bool rai::confirm_ack::deserialize (rai::stream & stream_a, rai::vote_uniquer * 
 	return result;
 }
 
-void rai::confirm_ack::serialize (rai::stream & stream_a)
+void rai::confirm_ack::serialize (rai::stream & stream_a) const
 {
 	assert (header.block_type () == rai::block_type::not_a_block || header.block_type () == rai::block_type::send || header.block_type () == rai::block_type::receive || header.block_type () == rai::block_type::open || header.block_type () == rai::block_type::change || header.block_type () == rai::block_type::state);
 	header.serialize (stream_a);
@@ -554,7 +554,7 @@ bool rai::frontier_req::deserialize (rai::stream & stream_a)
 	return result;
 }
 
-void rai::frontier_req::serialize (rai::stream & stream_a)
+void rai::frontier_req::serialize (rai::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	write (stream_a, start.bytes);
@@ -602,7 +602,7 @@ bool rai::bulk_pull::deserialize (rai::stream & stream_a)
 	return result;
 }
 
-void rai::bulk_pull::serialize (rai::stream & stream_a)
+void rai::bulk_pull::serialize (rai::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	write (stream_a, start);
@@ -643,7 +643,7 @@ bool rai::bulk_pull_account::deserialize (rai::stream & stream_a)
 	return result;
 }
 
-void rai::bulk_pull_account::serialize (rai::stream & stream_a)
+void rai::bulk_pull_account::serialize (rai::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	write (stream_a, account);
@@ -689,7 +689,7 @@ bool rai::bulk_pull_blocks::deserialize (rai::stream & stream_a)
 	return result;
 }
 
-void rai::bulk_pull_blocks::serialize (rai::stream & stream_a)
+void rai::bulk_pull_blocks::serialize (rai::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	write (stream_a, min_hash);
@@ -714,7 +714,7 @@ bool rai::bulk_push::deserialize (rai::stream & stream_a)
 	return false;
 }
 
-void rai::bulk_push::serialize (rai::stream & stream_a)
+void rai::bulk_push::serialize (rai::stream & stream_a) const
 {
 	header.serialize (stream_a);
 }
@@ -780,7 +780,7 @@ bool rai::node_id_handshake::deserialize (rai::stream & stream_a)
 	return result;
 }
 
-void rai::node_id_handshake::serialize (rai::stream & stream_a)
+void rai::node_id_handshake::serialize (rai::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	if (query)

--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -160,7 +160,7 @@ class message_header
 public:
 	message_header (rai::message_type);
 	message_header (bool &, rai::stream &);
-	void serialize (rai::stream &);
+	void serialize (rai::stream &) const;
 	bool deserialize (rai::stream &);
 	rai::block_type block_type () const;
 	void block_type_set (rai::block_type);
@@ -190,8 +190,15 @@ public:
 	message (rai::message_type);
 	message (rai::message_header const &);
 	virtual ~message () = default;
-	virtual void serialize (rai::stream &) = 0;
+	virtual void serialize (rai::stream &) const = 0;
 	virtual void visit (rai::message_visitor &) const = 0;
+	virtual inline std::shared_ptr<std::vector<uint8_t>> to_bytes () const
+	{
+		std::shared_ptr<std::vector<uint8_t>> bytes (new std::vector<uint8_t>);
+		rai::vectorstream stream (*bytes);
+		serialize (stream);
+		return bytes;
+	}
 	rai::message_header header;
 };
 class work_pool;
@@ -236,7 +243,7 @@ public:
 	keepalive ();
 	void visit (rai::message_visitor &) const override;
 	bool deserialize (rai::stream &);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	bool operator== (rai::keepalive const &) const;
 	std::array<rai::endpoint, 8> peers;
 };
@@ -247,7 +254,7 @@ public:
 	publish (std::shared_ptr<rai::block>);
 	void visit (rai::message_visitor &) const override;
 	bool deserialize (rai::stream &, rai::block_uniquer * = nullptr);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	bool operator== (rai::publish const &) const;
 	std::shared_ptr<rai::block> block;
 };
@@ -257,7 +264,7 @@ public:
 	confirm_req (bool &, rai::stream &, rai::message_header const &, rai::block_uniquer * = nullptr);
 	confirm_req (std::shared_ptr<rai::block>);
 	bool deserialize (rai::stream &, rai::block_uniquer * = nullptr);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	void visit (rai::message_visitor &) const override;
 	bool operator== (rai::confirm_req const &) const;
 	std::shared_ptr<rai::block> block;
@@ -268,7 +275,7 @@ public:
 	confirm_ack (bool &, rai::stream &, rai::message_header const &, rai::vote_uniquer * = nullptr);
 	confirm_ack (std::shared_ptr<rai::vote>);
 	bool deserialize (rai::stream &, rai::vote_uniquer * = nullptr);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	void visit (rai::message_visitor &) const override;
 	bool operator== (rai::confirm_ack const &) const;
 	std::shared_ptr<rai::vote> vote;
@@ -279,7 +286,7 @@ public:
 	frontier_req ();
 	frontier_req (bool &, rai::stream &, rai::message_header const &);
 	bool deserialize (rai::stream &);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	void visit (rai::message_visitor &) const override;
 	bool operator== (rai::frontier_req const &) const;
 	rai::account start;
@@ -292,7 +299,7 @@ public:
 	bulk_pull ();
 	bulk_pull (bool &, rai::stream &, rai::message_header const &);
 	bool deserialize (rai::stream &);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	void visit (rai::message_visitor &) const override;
 	rai::uint256_union start;
 	rai::block_hash end;
@@ -303,7 +310,7 @@ public:
 	bulk_pull_account ();
 	bulk_pull_account (bool &, rai::stream &, rai::message_header const &);
 	bool deserialize (rai::stream &);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	void visit (rai::message_visitor &) const override;
 	rai::uint256_union account;
 	rai::uint128_union minimum_amount;
@@ -315,7 +322,7 @@ public:
 	bulk_pull_blocks ();
 	bulk_pull_blocks (bool &, rai::stream &, rai::message_header const &);
 	bool deserialize (rai::stream &);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	void visit (rai::message_visitor &) const override;
 	rai::block_hash min_hash;
 	rai::block_hash max_hash;
@@ -328,7 +335,7 @@ public:
 	bulk_push ();
 	bulk_push (rai::message_header const &);
 	bool deserialize (rai::stream &);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	void visit (rai::message_visitor &) const override;
 };
 class node_id_handshake : public message
@@ -337,7 +344,7 @@ public:
 	node_id_handshake (bool &, rai::stream &, rai::message_header const &);
 	node_id_handshake (boost::optional<rai::block_hash>, boost::optional<std::pair<rai::account, rai::signature>>);
 	bool deserialize (rai::stream &);
-	void serialize (rai::stream &) override;
+	void serialize (rai::stream &) const override;
 	void visit (rai::message_visitor &) const override;
 	bool operator== (rai::node_id_handshake const &) const;
 	boost::optional<rai::uint256_union> query;

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -154,11 +154,7 @@ void rai::network::send_keepalive (rai::endpoint const & endpoint_a)
 	assert (endpoint_a.address ().is_v6 ());
 	rai::keepalive message;
 	node.peers.random_fill (message.peers);
-	std::shared_ptr<std::vector<uint8_t>> bytes (new std::vector<uint8_t>);
-	{
-		rai::vectorstream stream (*bytes);
-		message.serialize (stream);
-	}
+	auto bytes = message.to_bytes ();
 	if (node.config.logging.network_keepalive_logging ())
 	{
 		BOOST_LOG (node.log) << boost::str (boost::format ("Keepalive req sent to %1%") % endpoint_a);
@@ -207,11 +203,7 @@ void rai::network::send_node_id_handshake (rai::endpoint const & endpoint_a, boo
 		assert (!rai::validate_message (response->first, *respond_to, response->second));
 	}
 	rai::node_id_handshake message (query, response);
-	std::shared_ptr<std::vector<uint8_t>> bytes (new std::vector<uint8_t>);
-	{
-		rai::vectorstream stream (*bytes);
-		message.serialize (stream);
-	}
+	auto bytes = message.to_bytes ();
 	if (node.config.logging.network_node_id_handshake_logging ())
 	{
 		BOOST_LOG (node.log) << boost::str (boost::format ("Node ID handshake sent with node ID %1% to %2%: query %3%, respond_to %4% (signature %5%)") % node.node_id.pub.to_account () % endpoint_a % (query ? query->to_string () : std::string ("[none]")) % (respond_to ? respond_to->to_string () : std::string ("[none]")) % (response ? response->second.to_string () : std::string ("[none]")));
@@ -262,17 +254,12 @@ bool confirm_block (rai::transaction const & transaction_a, rai::node & node_a, 
 			auto hash (block_a->hash ());
 			auto vote (node_a.store.vote_generate (transaction_a, pub_a, prv_a, std::vector<rai::block_hash> (1, hash)));
 			rai::confirm_ack confirm (vote);
-			std::shared_ptr<std::vector<uint8_t>> vote_bytes (new std::vector<uint8_t>);
-			{
-				rai::vectorstream stream (*vote_bytes);
-				confirm.serialize (stream);
-			}
+			auto vote_bytes = confirm.to_bytes ();
 			rai::publish publish (block_a);
-			std::shared_ptr<std::vector<uint8_t>> publish_bytes (new std::vector<uint8_t>);
+			std::shared_ptr<std::vector<uint8_t>> publish_bytes;
 			if (also_publish)
 			{
-				rai::vectorstream stream (*publish_bytes);
-				publish.serialize (stream);
+				publish_bytes = publish.to_bytes ();
 			}
 			for (auto j (list_a.begin ()), m (list_a.end ()); j != m; ++j)
 			{
@@ -301,11 +288,7 @@ void rai::network::republish_block (std::shared_ptr<rai::block> block)
 	auto hash (block->hash ());
 	auto list (node.peers.list_fanout ());
 	rai::publish message (block);
-	std::shared_ptr<std::vector<uint8_t>> bytes (new std::vector<uint8_t>);
-	{
-		rai::vectorstream stream (*bytes);
-		message.serialize (stream);
-	}
+	auto bytes = message.to_bytes ();
 	for (auto i (list.begin ()), n (list.end ()); i != n; ++i)
 	{
 		republish (hash, bytes, *i);
@@ -343,11 +326,7 @@ void rai::network::republish_block_batch (std::deque<std::shared_ptr<rai::block>
 void rai::network::republish_vote (std::shared_ptr<rai::vote> vote_a)
 {
 	rai::confirm_ack confirm (vote_a);
-	std::shared_ptr<std::vector<uint8_t>> bytes (new std::vector<uint8_t>);
-	{
-		rai::vectorstream stream (*bytes);
-		confirm.serialize (stream);
-	}
+	auto bytes = confirm.to_bytes ();
 	auto list (node.peers.list_fanout ());
 	for (auto j (list.begin ()), m (list.end ()); j != m; ++j)
 	{
@@ -413,11 +392,7 @@ void rai::network::broadcast_confirm_req_base (std::shared_ptr<rai::block> block
 void rai::network::send_confirm_req (rai::endpoint const & endpoint_a, std::shared_ptr<rai::block> block)
 {
 	rai::confirm_req message (block);
-	std::shared_ptr<std::vector<uint8_t>> bytes (new std::vector<uint8_t>);
-	{
-		rai::vectorstream stream (*bytes);
-		message.serialize (stream);
-	}
+	auto bytes = message.to_bytes ();
 	if (node.config.logging.network_message_logging ())
 	{
 		BOOST_LOG (node.log) << boost::str (boost::format ("Sending confirm req to %1%") % endpoint_a);
@@ -931,12 +906,7 @@ rai::vote_code rai::vote_processor::vote_blocking (rai::transaction const & tran
 				if (max_vote->sequence > vote_a->sequence + 10000)
 				{
 					rai::confirm_ack confirm (max_vote);
-					std::shared_ptr<std::vector<uint8_t>> bytes (new std::vector<uint8_t>);
-					{
-						rai::vectorstream stream (*bytes);
-						confirm.serialize (stream);
-					}
-					node.network.confirm_send (confirm, bytes, endpoint_a);
+					node.network.confirm_send (confirm, confirm.to_bytes (), endpoint_a);
 				}
 				break;
 			case rai::vote_code::invalid:


### PR DESCRIPTION
Turns this recurring pattern:

```
rai::confirm_req message (block);
std::shared_ptr<std::vector<uint8_t>> bytes (new std::vector<uint8_t>);
{
	rai::vectorstream stream (*bytes);
	message.serialize (stream);
}
```

into:

```
rai::confirm_req message (block);
auto bytes = message.to_bytes ();
```

Sometimes to_bytes () can be used directly in parameter position, simplifying the code further.

To make this work in const contexts, serialize functions are now `const`