### PR TITLE
Fix secure rpc build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${PLATFORM_LINK_FLAGS}" )
 
 if (RAIBLOCKS_SECURE_RPC)
 	find_package (OpenSSL 1.0 REQUIRED)
-	#include_directories(${OPENSSL_INCLUDE_DIR})
+	include_directories(${OPENSSL_INCLUDE_DIR})
 	add_definitions (-DRAIBLOCKS_SECURE_RPC)
 	message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
 	message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")

--- a/rai/node/CMakeLists.txt
+++ b/rai/node/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries (node
 	libminiupnpc-static
 	argon2
 	lmdb
+	${OPENSSL_LIBRARIES}
 	Boost::filesystem
 	Boost::log
 	Boost::log_setup


### PR DESCRIPTION
The cmake restructuring removed the linker reference.