### PR TITLE
Ensure the block exists in account_history

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1751,7 +1751,7 @@ void rai::rpc_handler::account_history ()
 	{
 		if (!hash.decode_hex (*head_str))
 		{
-			if (node.store.block_get (transaction, hash))
+			if (node.store.block_exists (transaction, hash))
 			{
 				account = node.ledger.account (transaction, hash);
 			}

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1751,7 +1751,14 @@ void rai::rpc_handler::account_history ()
 	{
 		if (!hash.decode_hex (*head_str))
 		{
-			account = node.ledger.account (transaction, hash);
+			if (node.store.block_get (transaction, hash))
+			{
+				account = node.ledger.account (transaction, hash);
+			}
+			else
+			{
+				ec = nano::error_blocks::not_found;
+			}
 		}
 		else
 		{

--- a/rai/secure/ledger.cpp
+++ b/rai/secure/ledger.cpp
@@ -798,6 +798,7 @@ rai::account rai::ledger::account (rai::transaction const & transaction_a, rai::
 	rai::block_hash successor (1);
 	rai::block_info block_info;
 	auto block (store.block_get (transaction_a, hash));
+	assert (block);
 	while (!successor.is_zero () && block->type () != rai::block_type::state && store.block_info_get (transaction_a, successor, block_info))
 	{
 		successor = store.block_successor (transaction_a, hash);


### PR DESCRIPTION
When calling account_history with a block that does not exist, it currently fails to find the block resulting in dereferencing a NULL pointer.

This change makes it return an error.  Another option is to make it return an empty history for the hash.