### PR TITLE
[v17] Lazy bootstrap improvements

### DIFF
--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1336,19 +1336,6 @@ bool rai::bootstrap_attempt::process_block (std::shared_ptr<rai::block> block_a,
 				{
 					stop_pull = true;
 				}
-				else
-				{
-					auto account (node->ledger.account (transaction, hash));
-					rai::account_info info;
-					if (!node->store.account_get (transaction, account, info))
-					{
-						// Force drop lazy bootstrap connection for long chains to prevent high bandwidth usage
-						if (info.block_count > 256)
-						{
-							stop_pull = true;
-						}
-					}
-				}
 			}
 			//Search unknown state blocks balances
 			auto find_state (lazy_state_unknown.find (hash));

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1355,7 +1355,7 @@ bool rai::bootstrap_attempt::process_block (std::shared_ptr<rai::block> block_a,
 							// Insert in unknown state blocks if previous wasn't already processed
 							else
 							{
-								lazy_state_unknown.insert (std::make_pair (previous, block_l));
+								lazy_state_unknown.insert (std::make_pair (previous, std::make_pair (link, balance)));
 							}
 						}
 					}
@@ -1393,18 +1393,18 @@ bool rai::bootstrap_attempt::process_block (std::shared_ptr<rai::block> block_a,
 				if (block_a->type () == rai::block_type::state)
 				{
 					std::shared_ptr<rai::state_block> block_l (std::static_pointer_cast<rai::state_block> (block_a));
-					if (block_l->hashables.balance.number () <= next_block->hashables.balance.number ())
+					if (block_l->hashables.balance.number () <= next_block.second)
 					{
-						lazy_add (next_block->hashables.link);
+						lazy_add (next_block.first);
 					}
 				}
 				// Retrieve balance for previous legacy send blocks
 				else if (block_a->type () == rai::block_type::send)
 				{
 					std::shared_ptr<rai::send_block> block_l (std::static_pointer_cast<rai::send_block> (block_a));
-					if (block_l->hashables.balance.number () <= next_block->hashables.balance.number ())
+					if (block_l->hashables.balance.number () <= next_block.second)
 					{
-						lazy_add (next_block->hashables.link);
+						lazy_add (next_block.first);
 					}
 				}
 				// Weak assumption for other legacy block types

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1215,7 +1215,7 @@ void rai::bootstrap_attempt::lazy_run ()
 {
 	populate_connections ();
 	auto start_time (std::chrono::steady_clock::now ());
-	auto max_time (std::chrono::minutes (30));
+	auto max_time (std::chrono::minutes (node->flags.disable_legacy_bootstrap ? 48 * 60 : 30));
 	std::unique_lock<std::mutex> lock (mutex);
 	while ((still_pulling () || !lazy_finished ()) && std::chrono::steady_clock::now () - start_time < max_time)
 	{

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1163,8 +1163,9 @@ void rai::bootstrap_attempt::add_bulk_push_target (rai::block_hash const & head,
 void rai::bootstrap_attempt::lazy_start (rai::block_hash const & hash_a)
 {
 	std::unique_lock<std::mutex> lock (lazy_mutex);
-	// Add start blocks, limit 1024
-	if (lazy_keys.size () < 1024 && lazy_keys.find (hash_a) == lazy_keys.end () && lazy_blocks.find (hash_a) == lazy_blocks.end ())
+	// Add start blocks, limit 1024 (32k with disabled legacy bootstrap)
+	size_t max_keys (node->flags.disable_legacy_bootstrap ? 32 * 1024 : 1024);
+	if (lazy_keys.size () < max_keys && lazy_keys.find (hash_a) == lazy_keys.end () && lazy_blocks.find (hash_a) == lazy_blocks.end ())
 	{
 		lazy_keys.insert (hash_a);
 		lazy_pulls.push_back (hash_a);

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1424,15 +1424,6 @@ bool rai::bootstrap_attempt::process_block (std::shared_ptr<rai::block> block_a,
 			{
 				stop_pull = true;
 			}
-			auto previous_cache (lazy_balances.find (previous));
-			if (previous_cache != lazy_balances.end ())
-			{
-				if (previous_cache->second <= balance)
-				{
-					lazy_add (link);
-				}
-				lazy_balances.erase (previous_cache);
-			}
 		}
 	}
 	else if (lazy_mode)

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -570,6 +570,10 @@ void rai::bulk_pull_client::received_block (boost::system::error_code const & ec
 				expected = pull.end;
 				connection->attempt->pool_connection (connection);
 			}
+			if (stop_pull)
+			{
+				connection->attempt->lazy_stopped++;
+			}
 		}
 		else
 		{
@@ -735,6 +739,7 @@ pulling (0),
 node (node_a),
 account_count (0),
 total_blocks (0),
+lazy_stopped (0),
 stopped (false),
 lazy_mode (false)
 {

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -743,14 +743,7 @@ lazy_stopped (0),
 stopped (false),
 lazy_mode (false)
 {
-	if (lazy_mode)
-	{
-		BOOST_LOG (node->log) << "Starting lazy-bootstrap attempt";
-	}
-	else
-	{
-		BOOST_LOG (node->log) << "Starting bootstrap attempt";
-	}
+	BOOST_LOG (node->log) << "Starting bootstrap attempt";
 	node->bootstrap_initiator.notify_listeners (true);
 }
 

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1203,6 +1203,11 @@ bool rai::bootstrap_attempt::lazy_finished ()
 			// No need to increment `it` as we break above.
 		}
 	}
+	// Finish lazy bootstrap without lazy pulls (in combination with still_pulling ())
+	if (!result)
+	{
+		result = lazy_pulls.empty ();
+	}
 	return result;
 }
 

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -837,7 +837,7 @@ void rai::bootstrap_attempt::request_pull (std::unique_lock<std::mutex> & lock_a
 void rai::bootstrap_attempt::request_push (std::unique_lock<std::mutex> & lock_a)
 {
 	bool error (false);
-	if (!stopped && auto connection_shared = connection_frontier_request.lock ())
+	if (auto connection_shared = connection_frontier_request.lock ())
 	{
 		auto client (std::make_shared<rai::bulk_push_client> (connection_shared));
 		client->start ();
@@ -911,6 +911,7 @@ void rai::bootstrap_attempt::run ()
 	if (!stopped)
 	{
 		BOOST_LOG (node->log) << "Completed pulls";
+		request_push (lock);
 		// Start lazy bootstrap if some lazy keys were inserted
 		if (!lazy_keys.empty ())
 		{
@@ -920,7 +921,6 @@ void rai::bootstrap_attempt::run ()
 			lock.lock ();
 		}
 	}
-	request_push (lock);
 	stopped = true;
 	condition.notify_all ();
 	idle.clear ();

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1304,23 +1304,25 @@ bool rai::bootstrap_attempt::process_block (std::shared_ptr<rai::block> block_a,
 						// If link is not epoch link or 0. And if block from link unknown
 						if (!link.is_zero () && link != node->ledger.epoch_link && lazy_blocks.find (link) == lazy_blocks.end () && !node->store.block_exists (transaction, link))
 						{
+							rai::block_hash previous (block_l->hashables.previous);
 							// If state block previous is 0 then source block required
-							if (block_l->hashables.previous.is_zero ())
+							if (previous.is_zero ())
 							{
 								lazy_add (link);
 							}
 							// In other cases previous block balance required to find out subtype of state block
-							else if (node->store.block_exists (transaction, block_l->hashables.previous))
+							else if (node->store.block_exists (transaction, previous))
 							{
-								rai::amount prev_balance (node->ledger.balance (transaction, block_l->hashables.previous));
+								rai::amount prev_balance (node->ledger.balance (transaction, previous));
 								if (prev_balance.number () <= block_l->hashables.balance.number ())
 								{
 									lazy_add (link);
 								}
 							}
-							else
+							// Insert in unknown state blocks if previous wasn't already processed
+							else if (lazy_blocks.find (previous) == lazy_blocks.end ())
 							{
-								lazy_state_unknown.insert (std::make_pair (block_l->hashables.previous, block_l));
+								lazy_state_unknown.insert (std::make_pair (previous, block_l));
 							}
 						}
 					}

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -403,7 +403,7 @@ pull (pull_a)
 rai::bulk_pull_client::~bulk_pull_client ()
 {
 	// If received end block is not expected end block
-	if (expected != pull.end)
+	if (expected != pull.end && (total_blocks < pull.count || pull.count == 0))
 	{
 		pull.head = expected;
 		connection->attempt->requeue_pull (pull);
@@ -1195,7 +1195,7 @@ void rai::bootstrap_attempt::lazy_pull_flush ()
 		// Recheck if block was already processed
 		if (lazy_blocks.find (pull_start) == lazy_blocks.end ())
 		{
-			add_pull (rai::pull_info (pull_start, pull_start, rai::block_hash (0)));
+			add_pull (rai::pull_info (pull_start, pull_start, rai::block_hash (0), lazy_max_pull_blocks));
 		}
 	}
 	lazy_pulls.clear ();
@@ -1339,7 +1339,7 @@ bool rai::bootstrap_attempt::process_block (std::shared_ptr<rai::block> block_a,
 				// Disabled until server rewrite
 				// stop_pull = true;
 				// Force drop lazy bootstrap connection for long bulk_pull
-				if (total_blocks > 512)
+				if (total_blocks > lazy_max_pull_blocks)
 				{
 					stop_pull = true;
 				}
@@ -1381,7 +1381,7 @@ bool rai::bootstrap_attempt::process_block (std::shared_ptr<rai::block> block_a,
 			// Disabled until server rewrite
 			// stop_pull = true;
 			// Force drop lazy bootstrap connection for long bulk_pull
-			if (total_blocks > 512)
+			if (total_blocks > lazy_max_pull_blocks)
 			{
 				stop_pull = true;
 			}

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -832,7 +832,7 @@ void rai::bootstrap_attempt::request_pull (std::unique_lock<std::mutex> & lock_a
 void rai::bootstrap_attempt::request_push (std::unique_lock<std::mutex> & lock_a)
 {
 	bool error (false);
-	if (auto connection_shared = connection_frontier_request.lock ())
+	if (!stopped && auto connection_shared = connection_frontier_request.lock ())
 	{
 		auto client (std::make_shared<rai::bulk_push_client> (connection_shared));
 		client->start ();
@@ -1201,7 +1201,7 @@ bool rai::bootstrap_attempt::lazy_finished ()
 	bool result (true);
 	auto transaction (node->store.tx_begin_read ());
 	std::unique_lock<std::mutex> lock (lazy_mutex);
-	for (auto it (lazy_keys.begin ()), end (lazy_keys.end ()); it != end;)
+	for (auto it (lazy_keys.begin ()), end (lazy_keys.end ()); it != end && !stopped;)
 	{
 		if (node->store.block_exists (transaction, *it))
 		{

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -109,7 +109,7 @@ public:
 	std::condition_variable condition;
 	// Lazy bootstrap
 	std::unordered_set<rai::block_hash> lazy_blocks;
-	std::unordered_map<rai::block_hash, std::shared_ptr<rai::state_block>> lazy_state_unknown;
+	std::unordered_map<rai::block_hash, std::pair<rai::block_hash, rai::uint128_t>> lazy_state_unknown;
 	std::unordered_map<rai::block_hash, rai::uint128_t> lazy_balances;
 	std::unordered_set<rai::block_hash> lazy_keys;
 	std::deque<rai::block_hash> lazy_pulls;

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -100,6 +100,7 @@ public:
 	std::shared_ptr<rai::node> node;
 	std::atomic<unsigned> account_count;
 	std::atomic<uint64_t> total_blocks;
+	std::atomic<uint64_t> lazy_stopped;
 	std::vector<std::pair<rai::block_hash, rai::block_hash>> bulk_push_targets;
 	bool stopped;
 	bool lazy_mode;

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -82,7 +82,7 @@ public:
 	unsigned target_connections (size_t pulls_remaining);
 	bool should_log ();
 	void add_bulk_push_target (rai::block_hash const &, rai::block_hash const &);
-	bool process_block (std::shared_ptr<rai::block>);
+	bool process_block (std::shared_ptr<rai::block>, uint64_t);
 	void lazy_run ();
 	void lazy_start (rai::block_hash const &);
 	void lazy_add (rai::block_hash const &);
@@ -149,6 +149,7 @@ public:
 	std::shared_ptr<rai::bootstrap_client> connection;
 	rai::block_hash expected;
 	rai::pull_info pull;
+	uint64_t total_blocks;
 };
 class bootstrap_client : public std::enable_shared_from_this<bootstrap_client>
 {

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -108,7 +108,7 @@ public:
 	std::mutex mutex;
 	std::condition_variable condition;
 	// Lazy bootstrap
-	std::unordered_set<rai::block_hash> lazy_blocks;
+	std::unordered_map<rai::block_hash, rai::uint128_t> lazy_blocks;
 	std::unordered_map<rai::block_hash, std::shared_ptr<rai::state_block>> lazy_state_unknown;
 	std::unordered_set<rai::block_hash> lazy_keys;
 	std::deque<rai::block_hash> lazy_pulls;

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -108,8 +108,9 @@ public:
 	std::mutex mutex;
 	std::condition_variable condition;
 	// Lazy bootstrap
-	std::unordered_map<rai::block_hash, rai::uint128_t> lazy_blocks;
+	std::unordered_set<rai::block_hash> lazy_blocks;
 	std::unordered_map<rai::block_hash, std::shared_ptr<rai::state_block>> lazy_state_unknown;
+	std::unordered_map<rai::block_hash, rai::uint128_t> lazy_balances;
 	std::unordered_set<rai::block_hash> lazy_keys;
 	std::deque<rai::block_hash> lazy_pulls;
 	std::atomic<uint64_t> lazy_stopped;

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -82,7 +82,7 @@ public:
 	unsigned target_connections (size_t pulls_remaining);
 	bool should_log ();
 	void add_bulk_push_target (rai::block_hash const &, rai::block_hash const &);
-	bool process_block (std::shared_ptr<rai::block>, uint64_t);
+	bool process_block (std::shared_ptr<rai::block>, uint64_t, bool);
 	void lazy_run ();
 	void lazy_start (rai::block_hash const &);
 	void lazy_add (rai::block_hash const &);

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -113,7 +113,7 @@ public:
 	std::unordered_set<rai::block_hash> lazy_keys;
 	std::deque<rai::block_hash> lazy_pulls;
 	std::atomic<uint64_t> lazy_stopped;
-	uint64_t lazy_max_pull_blocks = 512;
+	uint64_t lazy_max_pull_blocks = (rai::rai_network == rai::rai_networks::rai_test_network) ? 2 : 512;
 	std::mutex lazy_mutex;
 };
 class frontier_req_client : public std::enable_shared_from_this<rai::frontier_req_client>

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -102,7 +102,6 @@ public:
 	std::shared_ptr<rai::node> node;
 	std::atomic<unsigned> account_count;
 	std::atomic<uint64_t> total_blocks;
-	std::atomic<uint64_t> lazy_stopped;
 	std::vector<std::pair<rai::block_hash, rai::block_hash>> bulk_push_targets;
 	bool stopped;
 	bool lazy_mode;
@@ -113,6 +112,8 @@ public:
 	std::unordered_map<rai::block_hash, std::shared_ptr<rai::state_block>> lazy_state_unknown;
 	std::unordered_set<rai::block_hash> lazy_keys;
 	std::deque<rai::block_hash> lazy_pulls;
+	std::atomic<uint64_t> lazy_stopped;
+	uint64_t lazy_max_pull_blocks = 512;
 	std::mutex lazy_mutex;
 };
 class frontier_req_client : public std::enable_shared_from_this<rai::frontier_req_client>

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1747,7 +1747,7 @@ void rai::node::process_fork (rai::transaction const & transaction_a, std::share
 				    if (auto this_l = this_w.lock ())
 				    {
 					    auto attempt (this_l->bootstrap_initiator.current_attempt ());
-					    if (attempt)
+					    if (attempt && !attempt->lazy_mode)
 					    {
 						    auto transaction (this_l->store.tx_begin_read ());
 						    auto account (this_l->ledger.store.frontier_get (transaction, root));

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1906,7 +1906,10 @@ void rai::node::start ()
 	}
 	ongoing_store_flush ();
 	ongoing_rep_crawl ();
-	bootstrap.start ();
+	if (!flags.disable_bootstrap_listener)
+	{
+		bootstrap.start ();
+	}
 	backup_wallet ();
 	search_pending ();
 	online_reps.recalculate_stake ();

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1815,7 +1815,7 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 					tally += node.ledger.weight (transaction, voter);
 				}
 				bool start_bootstrap (false);
-				if (!node.config.disable_lazy_bootstrap)
+				if (!node.flags.disable_lazy_bootstrap || node.flags.disable_legacy_bootstrap)
 				{
 					if (tally >= node.config.online_weight_minimum.number ())
 					{
@@ -1838,7 +1838,7 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 							{
 								BOOST_LOG (node_l->log) << boost::str (boost::format ("Missing block %1% which has enough votes to warrant lazy bootstrapping it") % hash.to_string ());
 							}
-							if (!node_l->config.disable_lazy_bootstrap)
+							if (!node_l->flags.disable_lazy_bootstrap || node_l->flags.disable_legacy_bootstrap)
 							{
 								node_l->bootstrap_initiator.bootstrap_lazy (hash);
 							}
@@ -1900,7 +1900,10 @@ void rai::node::start ()
 	network.start ();
 	ongoing_keepalive ();
 	ongoing_syn_cookie_cleanup ();
-	ongoing_bootstrap ();
+	if (!flags.disable_legacy_bootstrap)
+	{
+		ongoing_bootstrap ();
+	}
 	ongoing_store_flush ();
 	ongoing_rep_crawl ();
 	bootstrap.start ();

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1815,14 +1815,14 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 					tally += node.ledger.weight (transaction, voter);
 				}
 				bool start_bootstrap (false);
-				if (!node.flags.disable_lazy_bootstrap || node.flags.disable_legacy_bootstrap)
+				if (!node.flags.disable_lazy_bootstrap)
 				{
 					if (tally >= node.config.online_weight_minimum.number ())
 					{
 						start_bootstrap = true;
 					}
 				}
-				else if (tally > bootstrap_threshold (transaction))
+				else if (!node.flags.disable_legacy_bootstrap && tally > bootstrap_threshold (transaction))
 				{
 					start_bootstrap = true;
 				}
@@ -1838,11 +1838,11 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 							{
 								BOOST_LOG (node_l->log) << boost::str (boost::format ("Missing block %1% which has enough votes to warrant lazy bootstrapping it") % hash.to_string ());
 							}
-							if (!node_l->flags.disable_lazy_bootstrap || node_l->flags.disable_legacy_bootstrap)
+							if (!node_l->flags.disable_lazy_bootstrap)
 							{
 								node_l->bootstrap_initiator.bootstrap_lazy (hash);
 							}
-							else
+							else if (!node_l->flags.disable_legacy_bootstrap)
 							{
 								node_l->bootstrap_initiator.bootstrap ();
 							}

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -481,6 +481,7 @@ public:
 	rai::uint128_t delta ();
 	boost::asio::io_service & service;
 	rai::node_config config;
+	rai::node_flags flags;
 	rai::alarm & alarm;
 	rai::work_pool & work;
 	boost::log::sources::logger_mt log;

--- a/rai/node/nodeconfig.cpp
+++ b/rai/node/nodeconfig.cpp
@@ -322,6 +322,7 @@ rai::account rai::node_config::random_representative ()
 }
 rai::node_flags::node_flags () :
 disable_lazy_bootstrap (false),
-disable_legacy_bootstrap (false)
+disable_legacy_bootstrap (false),
+disable_bootstrap_listener (false)
 {
 }

--- a/rai/node/nodeconfig.cpp
+++ b/rai/node/nodeconfig.cpp
@@ -24,8 +24,7 @@ bootstrap_connections (4),
 bootstrap_connections_max (64),
 callback_port (0),
 lmdb_max_dbs (128),
-block_processor_batch_max_time (std::chrono::milliseconds (5000)),
-disable_lazy_bootstrap (false)
+block_processor_batch_max_time (std::chrono::milliseconds (5000))
 {
 	const char * epoch_message ("epoch v1 block");
 	strncpy ((char *)epoch_block_link.bytes.data (), epoch_message, epoch_block_link.bytes.size ());
@@ -320,4 +319,9 @@ rai::account rai::node_config::random_representative ()
 	size_t index (rai::random_pool.GenerateWord32 (0, preconfigured_representatives.size () - 1));
 	auto result (preconfigured_representatives[index]);
 	return result;
+}
+rai::node_flags::node_flags () :
+disable_lazy_bootstrap (false),
+disable_legacy_bootstrap (false)
+{
 }

--- a/rai/node/nodeconfig.hpp
+++ b/rai/node/nodeconfig.hpp
@@ -57,5 +57,6 @@ public:
 	node_flags ();
 	bool disable_lazy_bootstrap;
 	bool disable_legacy_bootstrap;
+	bool disable_bootstrap_listener;
 };
 }

--- a/rai/node/nodeconfig.hpp
+++ b/rai/node/nodeconfig.hpp
@@ -45,10 +45,17 @@ public:
 	rai::uint256_union epoch_block_link;
 	rai::account epoch_block_signer;
 	std::chrono::milliseconds block_processor_batch_max_time;
-	bool disable_lazy_bootstrap;
 	static std::chrono::seconds constexpr keepalive_period = std::chrono::seconds (60);
 	static std::chrono::seconds constexpr keepalive_cutoff = keepalive_period * 5;
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);
 	static constexpr int json_version = 15;
+};
+
+class node_flags
+{
+public:
+	node_flags ();
+	bool disable_lazy_bootstrap;
+	bool disable_legacy_bootstrap;
 };
 }

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1373,6 +1373,7 @@ void rai::rpc_handler::bootstrap_status ()
 		response_l.put ("lazy_mode", attempt->lazy_mode);
 		response_l.put ("lazy_blocks", std::to_string (attempt->lazy_blocks.size ()));
 		response_l.put ("lazy_state_unknown", std::to_string (attempt->lazy_state_unknown.size ()));
+		response_l.put ("lazy_balances", std::to_string (attempt->lazy_balances.size ()));
 		response_l.put ("lazy_pulls", std::to_string (attempt->lazy_pulls.size ()));
 		response_l.put ("lazy_stopped", std::to_string (attempt->lazy_stopped));
 		response_l.put ("lazy_keys", std::to_string (attempt->lazy_keys.size ()));

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1374,6 +1374,7 @@ void rai::rpc_handler::bootstrap_status ()
 		response_l.put ("lazy_blocks", std::to_string (attempt->lazy_blocks.size ()));
 		response_l.put ("lazy_state_unknown", std::to_string (attempt->lazy_state_unknown.size ()));
 		response_l.put ("lazy_pulls", std::to_string (attempt->lazy_pulls.size ()));
+		response_l.put ("lazy_stopped", std::to_string (attempt->lazy_stopped));
 		response_l.put ("lazy_keys", std::to_string (attempt->lazy_keys.size ()));
 		if (!attempt->lazy_keys.empty ())
 		{

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1367,6 +1367,7 @@ void rai::rpc_handler::bootstrap_status ()
 		response_l.put ("connections", std::to_string (attempt->connections));
 		response_l.put ("idle", std::to_string (attempt->idle.size ()));
 		response_l.put ("target_connections", std::to_string (attempt->target_connections (attempt->pulls.size ())));
+		response_l.put ("total_blocks", std::to_string (attempt->total_blocks));
 		response_l.put ("lazy_mode", attempt->lazy_mode);
 		response_l.put ("lazy_blocks", std::to_string (attempt->lazy_blocks.size ()));
 		response_l.put ("lazy_state_unknown", std::to_string (attempt->lazy_state_unknown.size ()));

--- a/rai/rai_node/daemon.cpp
+++ b/rai/rai_node/daemon.cpp
@@ -94,7 +94,7 @@ bool rai_daemon::daemon_config::upgrade_json (unsigned version_a, boost::propert
 	return result;
 }
 
-void rai_daemon::daemon::run (boost::filesystem::path const & data_path, bool disable_lazy_bootstrap)
+void rai_daemon::daemon::run (boost::filesystem::path const & data_path, rai::node_flags const & flags)
 {
 	boost::system::error_code error_chmod;
 	boost::filesystem::create_directories (data_path);
@@ -122,13 +122,13 @@ void rai_daemon::daemon::run (boost::filesystem::path const & data_path, bool di
 			auto node (std::make_shared<rai::node> (init, service, data_path, alarm, config.node, opencl_work));
 			if (!init.error ())
 			{
+				node->flags = flags;
 				node->start ();
 				std::unique_ptr<rai::rpc> rpc = get_rpc (service, *node, config.rpc);
 				if (rpc && config.rpc_enable)
 				{
 					rpc->start ();
 				}
-				config.node.disable_lazy_bootstrap = disable_lazy_bootstrap;
 				runner = std::make_unique<rai::thread_runner> (service, node->config.io_threads);
 				runner->join ();
 			}

--- a/rai/rai_node/daemon.hpp
+++ b/rai/rai_node/daemon.hpp
@@ -6,7 +6,7 @@ namespace rai_daemon
 class daemon
 {
 public:
-	void run (boost::filesystem::path const &, bool = false);
+	void run (boost::filesystem::path const &, rai::node_flags const & flags);
 };
 class daemon_config
 {

--- a/rai/rai_node/entry.cpp
+++ b/rai/rai_node/entry.cpp
@@ -23,6 +23,7 @@ int main (int argc, char * const * argv)
 		("daemon", "Start node daemon")
 		("disable_lazy_bootstrap", "Disables lazy bootstrap")
 		("disable_legacy_bootstrap", "Disables legacy bootstrap")
+		("disable_bootstrap_listener", "Disables bootstrap listener (incoming connections)")
 		("debug_block_count", "Display the number of block")
 		("debug_bootstrap_generate", "Generate bootstrap sequence of blocks")
 		("debug_dump_representatives", "List representatives and weights")
@@ -65,6 +66,7 @@ int main (int argc, char * const * argv)
 			rai::node_flags flags;
 			flags.disable_lazy_bootstrap = (vm.count ("disable_lazy_bootstrap") > 0);
 			flags.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);
+			flags.disable_bootstrap_listener = (vm.count ("disable_bootstrap_listener") > 0);
 			daemon.run (data_path, flags);
 		}
 		else if (vm.count ("debug_block_count"))

--- a/rai/rai_node/entry.cpp
+++ b/rai/rai_node/entry.cpp
@@ -22,6 +22,7 @@ int main (int argc, char * const * argv)
 		("version", "Prints out version")
 		("daemon", "Start node daemon")
 		("disable_lazy_bootstrap", "Disables lazy bootstrap")
+		("disable_legacy_bootstrap", "Disables legacy bootstrap")
 		("debug_block_count", "Display the number of block")
 		("debug_bootstrap_generate", "Generate bootstrap sequence of blocks")
 		("debug_dump_representatives", "List representatives and weights")
@@ -61,7 +62,10 @@ int main (int argc, char * const * argv)
 		if (vm.count ("daemon") > 0)
 		{
 			rai_daemon::daemon daemon;
-			daemon.run (data_path, vm.count ("disable_lazy_bootstrap") > 0);
+			rai::node_flags flags;
+			flags.disable_lazy_bootstrap = (vm.count ("disable_lazy_bootstrap") > 0);
+			flags.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);
+			daemon.run (data_path, flags);
 		}
 		else if (vm.count ("debug_block_count"))
 		{


### PR DESCRIPTION
- Improve lazy_start function, limit lazy_keys size to 1024 (https://github.com/nanocurrency/raiblocks/pull/1422)
- Add lazy_mode flag before lazy_run if running after usual bootstrap (https://github.com/nanocurrency/raiblocks/pull/1423)
- ~Force drop lazy bootstrap connection for long chains to prevent high bandwidth usage (https://github.com/nanocurrency/raiblocks/pull/1424)~
- Force drop lazy bootstrap connection for long bulk_pull to prevent high bandwidth usage
- Force drop lazy bootstrap connection for unexpected block (unconfirmed)
- Lazy bootstrap timeout with active pulls (https://github.com/nanocurrency/raiblocks/pull/1425)
- Finish lazy bootstrap without lazy pulls (https://github.com/nanocurrency/raiblocks/pull/1428)
- Add launch flags --disable_legacy_bootstrap, --disable_bootstrap_listener
- Display total_blocks, lazy_stopped in RPC bootstrap_status
- Check if pull is obsolete (head was processed)
- Flush lazy pulls more often
- Add bootstrap stopped check to lazy_finished & request_push functions
- Support pulk_bull count parameter in lazy bootstrap
- Search balance of already processed previous blocks
- Disable process_fork requeue_pull for lazy bootstrap