### PR TITLE
Extend Confirmation History 

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2804,6 +2804,7 @@ rai::election::election (rai::node & node_a, std::shared_ptr<rai::block> block_a
 confirmation_action (confirmation_action_a),
 node (node_a),
 root (block_a->root ()),
+election_start (std::chrono::steady_clock::now ()),
 status ({ block_a, 0 }),
 confirmed (false),
 stopped (false),
@@ -2829,6 +2830,7 @@ void rai::election::confirm_once (rai::transaction const & transaction_a)
 {
 	if (!confirmed.exchange (true))
 	{
+		status.election_duration = std::chrono::duration_cast<std::chrono::duration<double>> (std::chrono::steady_clock::now () - election_start);
 		auto winner_l (status.winner);
 		auto node_l (node.shared ());
 		auto confirmation_action_l (confirmation_action);

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -29,6 +29,7 @@ class election_status
 public:
 	std::shared_ptr<rai::block> winner;
 	rai::amount tally;
+	std::chrono::duration<double> election_duration;
 };
 class vote_info
 {
@@ -68,6 +69,7 @@ public:
 	std::unordered_map<rai::account, std::shared_ptr<rai::vote>> our_last_votes;
 	std::unordered_map<rai::block_hash, std::shared_ptr<rai::block>> blocks;
 	rai::block_hash root;
+	std::chrono::steady_clock::time_point election_start;
 	rai::election_status status;
 	std::atomic<bool> confirmed;
 	bool stopped;


### PR DESCRIPTION
to include confirmation time per block and Avg
example response
```curl -sd {\"action\":\"confirmation_history\"} [::1]:55000                                                                                         {
    "confirmation_stats": {
        "count": "18",
        "average": "18.657268277833328"
    },
    "confirmations": [
        {
            "hash": "862AB923DA184D85D5719D8222463E6DA6D6DB33F026B079B5F628C0598C4645",
            "duration": "7.6989772170000004",
            "tally": "67004984199081277794346622015067693764"
        },
```
...