### PR TITLE
Minimum blocks in ledger to start effective lazy bootstrap

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1815,11 +1815,13 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 					tally += node.ledger.weight (transaction, voter);
 				}
 				bool start_bootstrap (false);
+				bool lazy_bootstrap (false);
 				if (!node.flags.disable_lazy_bootstrap)
 				{
-					if (tally >= node.config.online_weight_minimum.number ())
+					if (tally >= node.config.online_weight_minimum.number () && (node.flags.disable_legacy_bootstrap || node.ledger.store.block_count (transaction).sum () > lazy_min_blocks))
 					{
 						start_bootstrap = true;
+						lazy_bootstrap = true;
 					}
 				}
 				else if (!node.flags.disable_legacy_bootstrap && tally > bootstrap_threshold (transaction))
@@ -1830,7 +1832,7 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 				{
 					auto node_l (node.shared ());
 					auto now (std::chrono::steady_clock::now ());
-					node.alarm.add (rai::rai_network == rai::rai_networks::rai_test_network ? now + std::chrono::milliseconds (5) : now + std::chrono::seconds (5), [node_l, hash]() {
+					node.alarm.add (rai::rai_network == rai::rai_networks::rai_test_network ? now + std::chrono::milliseconds (5) : now + std::chrono::seconds (5), [node_l, hash, lazy_bootstrap]() {
 						auto transaction (node_l->store.tx_begin_read ());
 						if (!node_l->store.block_exists (transaction, hash))
 						{
@@ -1838,11 +1840,11 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 							{
 								BOOST_LOG (node_l->log) << boost::str (boost::format ("Missing block %1% which has enough votes to warrant lazy bootstrapping it") % hash.to_string ());
 							}
-							if (!node_l->flags.disable_lazy_bootstrap)
+							if (lazy_bootstrap)
 							{
 								node_l->bootstrap_initiator.bootstrap_lazy (hash);
 							}
-							else if (!node_l->flags.disable_legacy_bootstrap)
+							else
 							{
 								node_l->bootstrap_initiator.bootstrap ();
 							}

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -176,6 +176,7 @@ public:
 	boost::multi_index::hashed_unique<boost::multi_index::member<gap_information, rai::block_hash, &gap_information::hash>>>>
 	blocks;
 	size_t const max = 256;
+	size_t const lazy_min_blocks = (rai::rai_network == rai::rai_networks::rai_live_network) ? 15000000 : (rai::rai_network == rai::rai_networks::rai_beta_network) ? 4475000 : 0;
 	std::mutex mutex;
 	rai::node & node;
 };


### PR DESCRIPTION
15,000,000 for live network
4,475,000 for beta network

Preventing start of lazy bootstrap on fresh node without launch flags