### PR TITLE
Confirm dependent active elections

### DIFF
--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -1944,3 +1944,33 @@ TEST (node, confirm_req_active)
 		ASSERT_LT (vote->sequence, 20);
 	}
 }
+
+TEST (node, confirm_back)
+{
+	rai::system system (24000, 1);
+	rai::keypair key;
+	auto & node (*system.nodes[0]);
+	rai::genesis genesis;
+	auto genesis_start_balance (node.balance (rai::test_genesis_key.pub));
+	auto send1 (std::make_shared<rai::send_block> (genesis.hash (), key.pub, genesis_start_balance - 1, rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.work.generate (genesis.hash ())));
+	auto open (std::make_shared<rai::state_block> (key.pub, 0, key.pub, 1, send1->hash (), key.prv, key.pub, system.work.generate (key.pub)));
+	auto send2 (std::make_shared<rai::state_block> (key.pub, open->hash (), key.pub, 0, rai::test_genesis_key.pub, key.prv, key.pub, system.work.generate (open->hash ())));
+	node.process_active (send1);
+	node.process_active (open);
+	node.process_active (send2);
+	node.block_processor.flush ();
+	ASSERT_EQ (3, node.active.roots.size ());
+	std::vector<rai::block_hash> vote_blocks;
+	vote_blocks.push_back (send2->hash ());
+	auto vote (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 0, vote_blocks));
+	{
+		auto transaction (node.store.tx_begin_read ());
+		std::unique_lock<std::mutex> lock (node.active.mutex);
+		node.vote_processor.vote_blocking (transaction, vote, node.network.endpoint ());
+	}
+	system.deadline_set (10s);
+	while (!node.active.roots.empty ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2844,6 +2844,23 @@ void rai::election::confirm_once (rai::transaction const & transaction_a)
 			node_l->process_confirmed (winner_l);
 			confirmation_action_l (winner_l);
 		});
+		confirm_back (transaction_a);
+	}
+}
+
+void rai::election::confirm_back (rai::transaction const & transaction_a)
+{
+	std::vector<rai::block_hash> hashes = {status.winner->previous (), status.winner->source (), status.winner->link ()};
+	for (auto & hash : hashes)
+	{
+		if (!hash.is_zero () && !node.ledger.is_epoch_link (hash))
+		{
+			auto existing (node.active.successors.find (hash));
+			if (existing != node.active.successors.end () && !existing->second->confirmed && !existing->second->stopped && existing->second->blocks.size () == 1)
+			{
+				existing->second->confirm_once (transaction_a);
+			}
+		}
 	}
 }
 
@@ -2973,13 +2990,10 @@ rai::election_vote_result rai::election::vote (rai::account rep, uint64_t sequen
 				replay = true;
 			}
 		}
-		if (should_process)
+		if (should_process && !confirmed)
 		{
 			last_votes[rep] = { std::chrono::steady_clock::now (), sequence, block_hash };
-			if (!confirmed)
-			{
-				confirm_if_quorum (transaction);
-			}
+			confirm_if_quorum (transaction);
 		}
 	}
 	return rai::election_vote_result (replay, should_process);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2850,7 +2850,7 @@ void rai::election::confirm_once (rai::transaction const & transaction_a)
 
 void rai::election::confirm_back (rai::transaction const & transaction_a)
 {
-	std::vector<rai::block_hash> hashes = {status.winner->previous (), status.winner->source (), status.winner->link ()};
+	std::vector<rai::block_hash> hashes = { status.winner->previous (), status.winner->source (), status.winner->link () };
 	for (auto & hash : hashes)
 	{
 		if (!hash.is_zero () && !node.ledger.is_epoch_link (hash))
@@ -2990,10 +2990,13 @@ rai::election_vote_result rai::election::vote (rai::account rep, uint64_t sequen
 				replay = true;
 			}
 		}
-		if (should_process && !confirmed)
+		if (should_process)
 		{
 			last_votes[rep] = { std::chrono::steady_clock::now (), sequence, block_hash };
-			confirm_if_quorum (transaction);
+			if (!confirmed)
+			{
+				confirm_if_quorum (transaction);
+			}
 		}
 	}
 	return rai::election_vote_result (replay, should_process);

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -50,6 +50,7 @@ class election : public std::enable_shared_from_this<rai::election>
 {
 	std::function<void(std::shared_ptr<rai::block>)> confirmation_action;
 	void confirm_once (rai::transaction const &);
+	void confirm_back (rai::transaction const &);
 
 public:
 	election (rai::node &, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>)> const &);


### PR DESCRIPTION
If possible. Confirm elections for: previous block, source or link