### PR TITLE
Update Confirmation Timers to be ms not sec

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2891,7 +2891,7 @@ void rai::election::confirm_once (rai::transaction const & transaction_a)
 {
 	if (!confirmed.exchange (true))
 	{
-		status.election_duration = std::chrono::duration_cast<std::chrono::duration<double>> (std::chrono::steady_clock::now () - election_start);
+		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
 		auto winner_l (status.winner);
 		auto node_l (node.shared ());
 		auto confirmation_action_l (confirmation_action);

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -29,7 +29,7 @@ class election_status
 public:
 	std::shared_ptr<rai::block> winner;
 	rai::amount tally;
-	std::chrono::duration<double> election_duration;
+	std::chrono::milliseconds election_duration;
 };
 class vote_info
 {

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1446,7 +1446,7 @@ void rai::rpc_handler::confirmation_history ()
 {
 	boost::property_tree::ptree elections;
 	boost::property_tree::ptree confirmation_stats;
-	std::chrono::duration<double> running_total (0);
+	std::chrono::milliseconds running_total (0);
 	{
 		std::lock_guard<std::mutex> lock (node.active.mutex);
 		for (auto i (node.active.confirmed.begin ()), n (node.active.confirmed.end ()); i != n; ++i)


### PR DESCRIPTION
Confirmation History avg and per block timers to be in MS as the rest of the timers are
declaration more easily readable