### PR TITLE
Close sockets gracefully

### DIFF
--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -83,6 +83,14 @@ void rai::socket::close ()
 {
 	if (socket_m.is_open ())
 	{
+		try
+		{
+			socket_m.shutdown (boost::asio::ip::tcp::socket::shutdown_both);
+		}
+		catch (...)
+		{
+			/* Ignore spurious exceptions; shutdown is best effort. */
+		}
 		socket_m.close ();
 	}
 }


### PR DESCRIPTION
The docs recommend shutdown before close [1] and most asio servers I've seen do this (the IPC patch does the same). Should evict pending io ops immediately/flush buffers properly on all platforms before closing.

[1] https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/basic_stream_socket/close/overload2.html