### PR TITLE
Verify more state blocks if blocks deque is empty

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1303,7 +1303,14 @@ void rai::block_processor::process_receive_many (std::unique_lock<std::mutex> & 
 			forced.pop_front ();
 			force = true;
 		}
+		/* Verify more state blocks if blocks deque is empty
+		Because verification is long process, avoid large deque verification inside of write transaction */
+		bool start_verification (blocks.empty () && !state_bocks.empty () && state_blocks.size () < 2048);
 		lock_a.unlock ();
+		if (start_verification)
+		{
+			verify_state_blocks (lock_a);
+		}
 		auto hash (block.first->hash ());
 		if (force)
 		{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1305,7 +1305,7 @@ void rai::block_processor::process_receive_many (std::unique_lock<std::mutex> & 
 		}
 		/* Verify more state blocks if blocks deque is empty
 		Because verification is long process, avoid large deque verification inside of write transaction */
-		bool start_verification (blocks.empty () && !state_bocks.empty () && state_blocks.size () < 2048);
+		bool start_verification (blocks.empty () && !state_blocks.empty () && state_blocks.size () < 2048);
 		lock_a.unlock ();
 		if (start_verification)
 		{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1233,6 +1233,7 @@ bool rai::block_processor::have_blocks ()
 
 void rai::block_processor::verify_state_blocks (std::unique_lock<std::mutex> & lock_a, size_t max_count)
 {
+	assert (!mutex.try_lock ());
 	std::deque<std::pair<std::shared_ptr<rai::block>, std::chrono::steady_clock::time_point>> items;
 	if (max_count == std::numeric_limits<size_t>::max () || max_count >= state_blocks.size ())
 	{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1305,11 +1305,11 @@ void rai::block_processor::process_receive_many (std::unique_lock<std::mutex> & 
 		}
 		/* Verify more state blocks if blocks deque is empty
 		Because verification is long process, avoid large deque verification inside of write transaction */
-		bool start_verification (blocks.empty () && !state_blocks.empty () && state_blocks.size () < 2048);
+		bool start_verification (blocks.empty () && !state_blocks.empty ());
 		lock_a.unlock ();
 		if (start_verification)
 		{
-			verify_state_blocks (lock_a);
+			verify_state_blocks (lock_a, 2048);
 		}
 		auto hash (block.first->hash ());
 		if (force)

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -425,7 +425,7 @@ public:
 
 private:
 	void queue_unchecked (rai::transaction const &, rai::block_hash const &);
-	void verify_state_blocks (std::unique_lock<std::mutex> &);
+	void verify_state_blocks (std::unique_lock<std::mutex> &, size_t = std::numeric_limits<size_t>::max ());
 	void process_receive_many (std::unique_lock<std::mutex> &);
 	bool stopped;
 	bool active;


### PR DESCRIPTION
This may be temporary solution as initially all unchecked state blocks should be placed in blocks deque (second verification is not required)