### PR TITLE
Remove virtual function specifiers where override is used

### DIFF
--- a/rai/node/rpc_secure.hpp
+++ b/rai/node/rpc_secure.hpp
@@ -14,7 +14,7 @@ public:
 	rpc_secure (boost::asio::io_service & service_a, rai::node & node_a, rai::rpc_config const & config_a);
 
 	/** Starts accepting connections */
-	virtual void accept () override;
+	void accept () override;
 
 	/** Installs the server certificate, key and DH, and optionally sets up client certificate verification */
 	void load_certs (boost::asio::ssl::context & ctx);
@@ -37,8 +37,8 @@ class rpc_connection_secure : public rpc_connection
 {
 public:
 	rpc_connection_secure (rai::node &, rai::rpc_secure &);
-	virtual void parse_connection () override;
-	virtual void read () override;
+	void parse_connection () override;
+	void read () override;
 	/** The TLS handshake callback */
 	void handle_handshake (const boost::system::error_code & error);
 	/** The TLS async shutdown callback */


### PR DESCRIPTION
Virtual function specifiers have always been implicitly inherited from their base classes. So the use of the virtual keyword in these cases has been redundant but was recommended in pre-modern C++ so that it was more easily distinguishable from non-virtual functions when reading derived class definitions. However since C++11, the override specifier has superseded this with compile time safety, and so explicitly writing both in a derived class is not required. 

I propose that the virtual specifier is removed in any function declaration where both the override and virtual function specifiers are used. 

The following command was used in the root directory to find and replace all instances where virtual and override specifiers were used.
find -type f -print0 | xargs -0 sed -ri 's/(virtual\s+)(.*override)/\2/g'

There were 2 files which were affected, one was rai/lib/expected.hpp but as this is third party code it has been left as is.

This change has not checked whether there are places override should be used where it is currently not.