### PR TITLE
 Disable batch signature check for unchecked state blocks

### DIFF
--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -1842,11 +1842,6 @@ TEST (node, block_processor_signatures)
 	auto send5 (std::make_shared<rai::state_block> (rai::test_genesis_key.pub, send3->hash (), rai::test_genesis_key.pub, rai::genesis_amount - 5 * rai::Gxrb_ratio, key3.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send5);
 	send5->signature.bytes[31] ^= 0x1;
-	// Invalid signature to unchecked
-	{
-		auto transaction (node1.store.tx_begin_write ());
-		node1.store.unchecked_put (transaction, send5->previous (), send5);
-	}
 	auto receive1 (std::make_shared<rai::state_block> (key1.pub, 0, rai::test_genesis_key.pub, rai::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, 0));
 	node1.work_generate_blocking (*receive1);
 	auto receive2 (std::make_shared<rai::state_block> (key2.pub, 0, rai::test_genesis_key.pub, rai::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, 0));

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -420,7 +420,7 @@ public:
 	void stop ();
 	void flush ();
 	bool full ();
-	void add (std::shared_ptr<rai::block>, std::chrono::steady_clock::time_point);
+	void add (std::shared_ptr<rai::block>, std::chrono::steady_clock::time_point, bool = false);
 	void force (std::shared_ptr<rai::block>);
 	bool should_log ();
 	bool have_blocks ();

--- a/rai/secure/ledger.cpp
+++ b/rai/secure/ledger.cpp
@@ -228,6 +228,7 @@ void ledger_processor::state_block_impl (rai::state_block const & block_a)
 		}
 		if (result.code == rai::process_result::progress)
 		{
+			assert (!validate_message (block_a.hashables.account, hash, block_a.signature));
 			result.code = block_a.hashables.account.is_zero () ? rai::process_result::opened_burn_account : rai::process_result::progress; // Is this for the burn account? (Unambiguous)
 			if (result.code == rai::process_result::progress)
 			{


### PR DESCRIPTION
Because all of these blocks should be verified  before insertion into unchecked table
Improving write block_processor performance with state blocks chains at bootstrap