### PR TITLE
Remove endpoint_hash from std namespace

### DIFF
--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -19,7 +19,10 @@ bool parse_endpoint (std::string const &, rai::endpoint &);
 bool parse_tcp_endpoint (std::string const &, rai::tcp_endpoint &);
 bool reserved_address (rai::endpoint const &, bool);
 }
-static uint64_t endpoint_hash_raw (rai::endpoint const & endpoint_a)
+
+namespace
+{
+uint64_t endpoint_hash_raw (rai::endpoint const & endpoint_a)
 {
 	assert (endpoint_a.address ().is_v6 ());
 	rai::uint128_union address;
@@ -32,7 +35,7 @@ static uint64_t endpoint_hash_raw (rai::endpoint const & endpoint_a)
 	auto result (XXH64_digest (&hash));
 	return result;
 }
-static uint64_t ip_address_hash_raw (boost::asio::ip::address const & ip_a)
+uint64_t ip_address_hash_raw (boost::asio::ip::address const & ip_a)
 {
 	assert (ip_a.is_v6 ());
 	rai::uint128_union bytes;
@@ -44,8 +47,6 @@ static uint64_t ip_address_hash_raw (boost::asio::ip::address const & ip_a)
 	return result;
 }
 
-namespace std
-{
 template <size_t size>
 struct endpoint_hash
 {
@@ -68,6 +69,10 @@ struct endpoint_hash<4>
 		return result;
 	}
 };
+}
+
+namespace std
+{
 template <>
 struct hash<rai::endpoint>
 {


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/language/extending_std:
> It is undefined behavior to add declarations or definitions to namespace std or to any namespace nested within std, with a few exceptions

A struct template **endpoint_hash** and full explicit specializations were defined within the std namespace; I have moved them out. As they are only used within this file I have wrapped them in an unnamed namespace and moved the existing **endpoint_hash_raw** & **ip_address_hash_raw** static functions into that as well; using static for internal linkage should be avoided (see More Effective C++ Item 31).