### PR TITLE
Pessimisation fix for condition_variable notify_*

### DIFF
--- a/rai/core_test/processor_service.cpp
+++ b/rai/core_test/processor_service.cpp
@@ -54,8 +54,10 @@ TEST (alarm, one)
 	std::mutex mutex;
 	std::condition_variable condition;
 	alarm.add (std::chrono::steady_clock::now (), [&]() {
-		std::lock_guard<std::mutex> lock (mutex);
-		done = true;
+		{
+			std::lock_guard<std::mutex> lock (mutex);
+			done = true;
+		}
 		condition.notify_one ();
 	});
 	boost::asio::io_service::work work (service);
@@ -76,8 +78,10 @@ TEST (alarm, many)
 	for (auto i (0); i < 50; ++i)
 	{
 		alarm.add (std::chrono::steady_clock::now (), [&]() {
-			std::lock_guard<std::mutex> lock (mutex);
-			count += 1;
+			{
+				std::lock_guard<std::mutex> lock (mutex);
+				count += 1;
+			}
 			condition.notify_one ();
 		});
 	}

--- a/rai/lib/work.cpp
+++ b/rai/lib/work.cpp
@@ -154,8 +154,10 @@ void rai::work_pool::cancel (rai::uint256_union const & root_a)
 
 void rai::work_pool::stop ()
 {
-	std::lock_guard<std::mutex> lock (mutex);
-	done = true;
+	{
+		std::lock_guard<std::mutex> lock (mutex);
+		done = true;
+	}
 	producer_condition.notify_all ();
 }
 
@@ -169,8 +171,10 @@ void rai::work_pool::generate (rai::uint256_union const & root_a, std::function<
 	}
 	if (!result)
 	{
-		std::lock_guard<std::mutex> lock (mutex);
-		pending.push_back ({ root_a, callback_a, difficulty_a });
+		{
+			std::lock_guard<std::mutex> lock (mutex);
+			pending.push_back ({ root_a, callback_a, difficulty_a });
+		}
 		producer_condition.notify_all ();
 	}
 	else

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1533,11 +1533,11 @@ void rai::bootstrap_initiator::bootstrap_lazy (rai::block_hash const & hash_a, b
 		std::unique_lock<std::mutex> lock (mutex);
 		if (force)
 		{
-				while (attempt != nullptr)
-				{
-						attempt->stop ();
-						condition.wait (lock);
-				}
+			while (attempt != nullptr)
+			{
+				attempt->stop ();
+				condition.wait (lock);
+			}
 		}
 		node.stats.inc (rai::stat::type::bootstrap, rai::stat::detail::initiate_lazy, rai::stat::dir::out);
 		if (attempt == nullptr)

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1377,8 +1377,10 @@ void rai::wallets::do_wallet_actions ()
 
 void rai::wallets::queue_wallet_action (rai::uint128_t const & amount_a, std::shared_ptr<rai::wallet> wallet_a, std::function<void(rai::wallet &)> const & action_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
-	actions.insert (std::make_pair (amount_a, std::make_pair (wallet_a, std::move (action_a))));
+	{
+		std::lock_guard<std::mutex> lock (mutex);
+		actions.insert (std::make_pair (amount_a, std::make_pair (wallet_a, std::move (action_a))));
+	}
 	condition.notify_all ();
 }
 


### PR DESCRIPTION
This should fix #1284. Some of these locks are for setting `stopped` and `started` flags, those functions could get a cleaner look by using `std::atomic_bool` on those flags and avoiding the explicit lock/unlock.