### PR TITLE
Remove function template specializations

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -275,7 +275,6 @@ bool confirm_block (rai::transaction const & transaction_a, rai::node & node_a, 
 	return result;
 }
 
-template <>
 bool confirm_block (rai::transaction const & transaction_a, rai::node & node_a, rai::endpoint & peer_a, std::shared_ptr<rai::block> block_a, bool also_publish)
 {
 	std::array<rai::endpoint, 1> endpoints;
@@ -456,7 +455,6 @@ void rep_query (rai::node & node_a, T const & peers_a)
 	});
 }
 
-template <>
 void rep_query (rai::node & node_a, rai::endpoint const & peers_a)
 {
 	std::array<rai::endpoint, 1> peers;


### PR DESCRIPTION
Function template specializations are not candidates for overload resolution, and should be avoided where possible. Herb Sutter describes the Dimov/Abrahams example explaining why:
http://www.gotw.ca/publications/mill17.htm

A recent detailed talk summarising the issues during CppCon2018 can be found [here](https://www.youtube.com/watch?v=NIDEjY5ywqU)

Typed template parameters can just have the type substituted directly using standard function overloading.