### PR TITLE
Add more support for building boost with different options

### DIFF
--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -9,7 +9,7 @@ debugLevel=0
 buildCArgs=()
 buildCXXArgs=()
 buildLDArgs=()
-boostVersion='1.66'
+boostVersion='1.69'
 while getopts 'hmcCkpvB:' OPT; do
 	case "${OPT}" in
 		h)

--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o xtrace
-
 bootstrapArgs=()
 buildArgs=()
 useClang='false'
@@ -12,8 +9,20 @@ debugLevel=0
 buildCArgs=()
 buildCXXArgs=()
 buildLDArgs=()
-while getopts 'mcCkpv' OPT; do
+while getopts 'hmcCkpv' OPT; do
 	case "${OPT}" in
+		h)
+			echo "Usage: bootstrap_boost.sh [-hmcCkpv]"
+			echo "   -h                 This help"
+			echo "   -m                 Build a minimal set of libraries needed for Nano"
+			echo "   -c                 Use Clang"
+			echo "   -C                 Use libc++ when using Clang"
+			echo "   -k                 Keep the downloaded archive file"
+			echo "   -p                 Build a PIC version of the objects"
+			echo "   -v                 Increase debug level, may be repeated to increase it"
+			echo "                      further"
+			exit 0
+			;;
 		m)
 			bootstrapArgs+=('--with-libraries=thread,log,filesystem,program_options')
 			;;
@@ -33,8 +42,14 @@ while getopts 'mcCkpv' OPT; do
 		v)
 			debugLevel=$[$debugLevel + 1]
 			;;
+		B)
+			boostVersion="${OPTARG}"
+			;;
 	esac
 done
+
+set -o errexit
+set -o xtrace
 
 if ! c++ --version >/dev/null 2>/dev/null; then
 	useClang='true'

--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -13,7 +13,7 @@ boostVersion='1.66'
 while getopts 'hmcCkpvB:' OPT; do
 	case "${OPT}" in
 		h)
-			echo "Usage: bootstrap_boost.sh [-hmcCkpv]"
+			echo "Usage: bootstrap_boost.sh [-hmcCkpv] [-B <boostVersion>]"
 			echo "   -h                 This help"
 			echo "   -m                 Build a minimal set of libraries needed for Nano"
 			echo "   -c                 Use Clang"

--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -9,7 +9,8 @@ debugLevel=0
 buildCArgs=()
 buildCXXArgs=()
 buildLDArgs=()
-while getopts 'hmcCkpv' OPT; do
+boostVersion='1.66'
+while getopts 'hmcCkpvB:' OPT; do
 	case "${OPT}" in
 		h)
 			echo "Usage: bootstrap_boost.sh [-hmcCkpv]"
@@ -21,6 +22,7 @@ while getopts 'hmcCkpv' OPT; do
 			echo "   -p                 Build a PIC version of the objects"
 			echo "   -v                 Increase debug level, may be repeated to increase it"
 			echo "                      further"
+			echo "   -B <boostVersion>  Specify version of Boost to build"
 			exit 0
 			;;
 		m)
@@ -70,11 +72,24 @@ if [ "${useClang}" = 'true' ]; then
 	fi
 fi
 
-BOOST_BASENAME=boost_1_66_0
-BOOST_ROOT=${BOOST_ROOT-/usr/local/boost}
-BOOST_URL=https://downloads.sourceforge.net/project/boost/boost/1.66.0/${BOOST_BASENAME}.tar.bz2
+case "${boostVersion}" in
+	1.66)
+		BOOST_BASENAME=boost_1_66_0
+		BOOST_URL=https://downloads.sourceforge.net/project/boost/boost/1.66.0/${BOOST_BASENAME}.tar.bz2
+		BOOST_ARCHIVE_SHA256='5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9'
+		;;
+	1.69)
+		BOOST_BASENAME=boost_1_69_0
+		BOOST_URL=https://downloads.sourceforge.net/project/boost/boost/1.69.0/${BOOST_BASENAME}.tar.bz2
+		BOOST_ARCHIVE_SHA256='8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406'
+		;;
+	*)
+		echo "Unsupported Boost version: ${boostVersion}" >&2
+		exit 1
+		;;
+esac
 BOOST_ARCHIVE="${BOOST_BASENAME}.tar.bz2"
-BOOST_ARCHIVE_SHA256='5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9'
+BOOST_ROOT=${BOOST_ROOT-/usr/local/boost}
 
 if [ ! -f "${BOOST_ARCHIVE}" ]; then
 	wget --quiet -O "${BOOST_ARCHIVE}.new" "${BOOST_URL}"


### PR DESCRIPTION
Support more ways to build Boost, which may be required on some platforms.

This adds "-C" to build with clang's "libc++", as well as "-f" to build a PIC version of all the objects, which will be required for PIE executables on newer versions of Ubuntu.

Additionally a "-v" option is added so you can specify greater debug levels to, for example, see the compile strings.