### PR TITLE
Move from deprecated io_service to io_context

### DIFF
--- a/rai/core_test/ledger.cpp
+++ b/rai/core_test/ledger.cpp
@@ -568,7 +568,7 @@ TEST (ledger, DISABLED_checksum_range)
 TEST (system, DISABLED_generate_send_existing)
 {
 	rai::system system (24000, 1);
-	rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
+	rai::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	rai::keypair stake_preserver;
 	auto send_block (system.wallet (0)->send_action (rai::genesis_account, stake_preserver.pub, rai::genesis_amount / 3 * 2, true));
@@ -614,7 +614,7 @@ TEST (system, DISABLED_generate_send_existing)
 TEST (system, generate_send_new)
 {
 	rai::system system (24000, 1);
-	rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
+	rai::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	{
 		auto transaction (system.nodes[0]->store.tx_begin ());

--- a/rai/core_test/network.cpp
+++ b/rai/core_test/network.cpp
@@ -7,14 +7,14 @@ using namespace std::chrono_literals;
 
 TEST (network, tcp_connection)
 {
-	boost::asio::io_service service;
-	boost::asio::ip::tcp::acceptor acceptor (service);
+	boost::asio::io_context io_ctx;
+	boost::asio::ip::tcp::acceptor acceptor (io_ctx);
 	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v4::any (), 24000);
 	acceptor.open (endpoint.protocol ());
 	acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
 	acceptor.bind (endpoint);
 	acceptor.listen ();
-	boost::asio::ip::tcp::socket incoming (service);
+	boost::asio::ip::tcp::socket incoming (io_ctx);
 	auto done1 (false);
 	std::string message1;
 	acceptor.async_accept (incoming,
@@ -25,7 +25,7 @@ TEST (network, tcp_connection)
 			   std::cerr << message1;
 		   }
 		   done1 = true; });
-	boost::asio::ip::tcp::socket connector (service);
+	boost::asio::ip::tcp::socket connector (io_ctx);
 	auto done2 (false);
 	std::string message2;
 	connector.async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), 24000),
@@ -39,7 +39,7 @@ TEST (network, tcp_connection)
 	});
 	while (!done1 || !done2)
 	{
-		service.poll ();
+		io_ctx.poll ();
 	}
 	ASSERT_EQ (0, message1.size ());
 	ASSERT_EQ (0, message2.size ());
@@ -68,7 +68,7 @@ TEST (network, send_node_id_handshake)
 	auto list1 (system.nodes[0]->peers.list ());
 	ASSERT_EQ (0, list1.size ());
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto initial (system.nodes[0]->stats.count (rai::stat::type::message, rai::stat::detail::node_id_handshake, rai::stat::dir::in));
@@ -103,7 +103,7 @@ TEST (network, keepalive_ipv4)
 	auto list1 (system.nodes[0]->peers.list ());
 	ASSERT_EQ (0, list1.size ());
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
 	node1->send_keepalive (rai::endpoint (boost::asio::ip::address_v4::loopback (), 24000));
@@ -122,7 +122,7 @@ TEST (network, multi_keepalive)
 	auto list1 (system.nodes[0]->peers.list ());
 	ASSERT_EQ (0, list1.size ());
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->start ();
 	system.nodes.push_back (node1);
@@ -136,7 +136,7 @@ TEST (network, multi_keepalive)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	rai::node_init init2;
-	auto node2 (std::make_shared<rai::node> (init2, system.service, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node2 (std::make_shared<rai::node> (init2, system.io_ctx, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init2.error ());
 	node2->start ();
 	system.nodes.push_back (node2);
@@ -550,13 +550,13 @@ TEST (bootstrap_processor, DISABLED_process_none)
 {
 	rai::system system (24000, 1);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	auto done (false);
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
 	while (!done)
 	{
-		system.service.run_one ();
+		system.io_ctx.run_one ();
 	}
 	node1->stop ();
 }
@@ -568,7 +568,7 @@ TEST (bootstrap_processor, process_one)
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (rai::test_genesis_key.pub, rai::test_genesis_key.pub, 100));
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	rai::block_hash hash1 (system.nodes[0]->latest (rai::test_genesis_key.pub));
 	rai::block_hash hash2 (node1->latest (rai::test_genesis_key.pub));
 	ASSERT_NE (hash1, hash2);
@@ -596,7 +596,7 @@ TEST (bootstrap_processor, process_two)
 	ASSERT_NE (hash1, hash3);
 	ASSERT_NE (hash2, hash3);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
 	ASSERT_NE (node1->latest (rai::test_genesis_key.pub), system.nodes[0]->latest (rai::test_genesis_key.pub));
@@ -622,7 +622,7 @@ TEST (bootstrap_processor, process_state)
 	node0->process (*block1);
 	node0->process (*block2);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_EQ (node0->latest (rai::test_genesis_key.pub), block2->hash ());
 	ASSERT_NE (node1->latest (rai::test_genesis_key.pub), block2->hash ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
@@ -651,7 +651,7 @@ TEST (bootstrap_processor, process_new)
 	rai::uint128_t balance1 (system.nodes[0]->balance (rai::test_genesis_key.pub));
 	rai::uint128_t balance2 (system.nodes[0]->balance (key2.pub));
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
 	system.deadline_set (10s);
@@ -676,7 +676,7 @@ TEST (bootstrap_processor, pull_diamond)
 	auto receive (std::make_shared<rai::receive_block> (send1->hash (), send2->hash (), rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.work.generate (send1->hash ())));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->process (*receive).code);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
 	system.deadline_set (10s);
@@ -693,7 +693,7 @@ TEST (bootstrap_processor, push_diamond)
 	rai::system system (24000, 1);
 	rai::keypair key;
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24002, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	auto wallet1 (node1->wallets.create (100));
 	wallet1->insert_adhoc (rai::test_genesis_key.prv);
@@ -721,7 +721,7 @@ TEST (bootstrap_processor, push_one)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	rai::keypair key1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	auto wallet (node1->wallets.create (rai::uint256_union ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (rai::test_genesis_key.prv);
@@ -756,7 +756,7 @@ TEST (bootstrap_processor, lazy_hash)
 	system.nodes[0]->block_processor.add (receive2, std::chrono::steady_clock::time_point ());
 	system.nodes[0]->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	node1->peers.insert (system.nodes[0]->network.endpoint (), rai::protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash ());
 	// Check processed blocks
@@ -793,7 +793,7 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	system.nodes[0]->block_processor.add (change3, std::chrono::steady_clock::time_point ());
 	system.nodes[0]->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	node1->peers.insert (system.nodes[0]->network.endpoint (), rai::protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (change3->hash ());
 	// Check processed blocks
@@ -808,7 +808,7 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 TEST (frontier_req_response, DISABLED_destruction)
 {
 	{
-		std::shared_ptr<rai::frontier_req_server> hold; // Destructing tcp acceptor on non-existent io_service
+		std::shared_ptr<rai::frontier_req_server> hold; // Destructing tcp acceptor on non-existent io_context
 		{
 			rai::system system (24000, 1);
 			auto connection (std::make_shared<rai::bootstrap_server> (nullptr, system.nodes[0]));
@@ -928,7 +928,7 @@ TEST (bulk, genesis)
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	rai::block_hash latest1 (system.nodes[0]->latest (rai::test_genesis_key.pub));
 	rai::block_hash latest2 (node1->latest (rai::test_genesis_key.pub));
@@ -952,7 +952,7 @@ TEST (bulk, offline_send)
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->start ();
 	system.nodes.push_back (node1);
@@ -1022,19 +1022,19 @@ TEST (network, ipv6_from_ipv4)
 
 TEST (network, ipv6_bind_send_ipv4)
 {
-	boost::asio::io_service service;
+	boost::asio::io_context io_ctx;
 	rai::endpoint endpoint1 (boost::asio::ip::address_v6::any (), 24000);
 	rai::endpoint endpoint2 (boost::asio::ip::address_v4::any (), 24001);
 	std::array<uint8_t, 16> bytes1;
 	auto finish1 (false);
 	rai::endpoint endpoint3;
-	boost::asio::ip::udp::socket socket1 (service, endpoint1);
+	boost::asio::ip::udp::socket socket1 (io_ctx, endpoint1);
 	socket1.async_receive_from (boost::asio::buffer (bytes1.data (), bytes1.size ()), endpoint3, [&finish1](boost::system::error_code const & error, size_t size_a) {
 		ASSERT_FALSE (error);
 		ASSERT_EQ (16, size_a);
 		finish1 = true;
 	});
-	boost::asio::ip::udp::socket socket2 (service, endpoint2);
+	boost::asio::ip::udp::socket socket2 (io_ctx, endpoint2);
 	rai::endpoint endpoint5 (boost::asio::ip::address_v4::loopback (), 24000);
 	rai::endpoint endpoint6 (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4::loopback ()), 24001);
 	socket2.async_send_to (boost::asio::buffer (std::array<uint8_t, 16>{}, 16), endpoint5, [](boost::system::error_code const & error, size_t size_a) {
@@ -1044,7 +1044,7 @@ TEST (network, ipv6_bind_send_ipv4)
 	auto iterations (0);
 	while (!finish1)
 	{
-		service.poll ();
+		io_ctx.poll ();
 		++iterations;
 		ASSERT_LT (iterations, 200);
 	}

--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -13,14 +13,14 @@ TEST (node, stop)
 	rai::system system (24000, 1);
 	ASSERT_NE (system.nodes[0]->wallets.items.end (), system.nodes[0]->wallets.items.begin ());
 	system.nodes[0]->stop ();
-	system.service.run ();
+	system.io_ctx.run ();
 	ASSERT_TRUE (true);
 }
 
 TEST (node, block_store_path_failure)
 {
 	rai::node_init init;
-	auto service (boost::make_shared<boost::asio::io_service> ());
+	auto service (boost::make_shared<boost::asio::io_context> ());
 	rai::alarm alarm (*service);
 	auto path (rai::unique_path ());
 	rai::logging logging;
@@ -34,7 +34,7 @@ TEST (node, block_store_path_failure)
 TEST (node, password_fanout)
 {
 	rai::node_init init;
-	auto service (boost::make_shared<boost::asio::io_service> ());
+	auto service (boost::make_shared<boost::asio::io_context> ());
 	rai::alarm alarm (*service);
 	auto path (rai::unique_path ());
 	rai::node_config config;
@@ -222,7 +222,7 @@ TEST (node, auto_bootstrap)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	node1->network.send_keepalive (system.nodes[0]->network.endpoint ());
 	node1->start ();
@@ -251,7 +251,7 @@ TEST (node, auto_bootstrap_reverse)
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (init1.error ());
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (rai::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 	system.nodes[0]->network.send_keepalive (node1->network.endpoint ());
@@ -380,7 +380,7 @@ TEST (node, connect_after_junk)
 {
 	rai::system system (24000, 1);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	uint64_t junk (0);
 	node1->network.socket.async_send_to (boost::asio::buffer (&junk, sizeof (junk)), system.nodes[0]->network.endpoint (), [](boost::system::error_code const &, size_t) {});
 	system.deadline_set (10s);

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -15,9 +15,9 @@ using namespace std::chrono_literals;
 class test_response
 {
 public:
-	test_response (boost::property_tree::ptree const & request_a, rai::rpc & rpc_a, boost::asio::io_service & service_a) :
+	test_response (boost::property_tree::ptree const & request_a, rai::rpc & rpc_a, boost::asio::io_context & io_ctx) :
 	request (request_a),
-	sock (service_a),
+	sock (io_ctx),
 	status (0)
 	{
 		sock.async_connect (rai::tcp_endpoint (boost::asio::ip::address_v6::loopback (), rpc_a.config.port), [this](boost::system::error_code const & ec) {
@@ -78,12 +78,12 @@ public:
 TEST (rpc, account_balance)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_balance");
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -99,12 +99,12 @@ TEST (rpc, account_balance)
 TEST (rpc, account_block_count)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_block_count");
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -118,12 +118,12 @@ TEST (rpc, account_block_count)
 TEST (rpc, account_create)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_create");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -144,12 +144,12 @@ TEST (rpc, account_weight)
 	auto & node1 (*system.nodes[0]);
 	rai::change_block block (latest, key.pub, rai::test_genesis_key.prv, rai::test_genesis_key.pub, node1.work_generate_blocking (latest));
 	ASSERT_EQ (rai::process_result::progress, node1.process (block).code);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_weight");
 	request.put ("account", key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -163,7 +163,7 @@ TEST (rpc, account_weight)
 TEST (rpc, wallet_contains)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	boost::property_tree::ptree request;
@@ -172,7 +172,7 @@ TEST (rpc, wallet_contains)
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_contains");
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -186,7 +186,7 @@ TEST (rpc, wallet_contains)
 TEST (rpc, wallet_doesnt_contain)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
@@ -194,7 +194,7 @@ TEST (rpc, wallet_doesnt_contain)
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_contains");
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -208,13 +208,13 @@ TEST (rpc, wallet_doesnt_contain)
 TEST (rpc, validate_account_number)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	boost::property_tree::ptree request;
 	request.put ("action", "validate_account_number");
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -227,7 +227,7 @@ TEST (rpc, validate_account_number)
 TEST (rpc, validate_account_invalid)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	std::string account;
 	rai::test_genesis_key.pub.encode_account (account);
@@ -236,7 +236,7 @@ TEST (rpc, validate_account_invalid)
 	boost::property_tree::ptree request;
 	request.put ("action", "validate_account_number");
 	request.put ("account", account);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -250,7 +250,7 @@ TEST (rpc, validate_account_invalid)
 TEST (rpc, send)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	boost::property_tree::ptree request;
@@ -268,7 +268,7 @@ TEST (rpc, send)
 			ASSERT_NO_ERROR (system.poll ());
 		}
 	});
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -286,7 +286,7 @@ TEST (rpc, send)
 TEST (rpc, send_fail)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
@@ -304,7 +304,7 @@ TEST (rpc, send_fail)
 			ASSERT_NO_ERROR (system.poll ());
 		}
 	});
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -318,7 +318,7 @@ TEST (rpc, send_fail)
 TEST (rpc, send_work)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	boost::property_tree::ptree request;
@@ -330,7 +330,7 @@ TEST (rpc, send_work)
 	request.put ("destination", rai::test_genesis_key.pub.to_account ());
 	request.put ("amount", "100");
 	request.put ("work", "1");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (10s);
 	while (response.status == 0)
 	{
@@ -339,7 +339,7 @@ TEST (rpc, send_work)
 	ASSERT_EQ (response.json.get<std::string> ("error"), "Invalid work");
 	request.erase ("work");
 	request.put ("work", rai::to_string_hex (system.nodes[0]->work_generate_blocking (system.nodes[0]->latest (rai::test_genesis_key.pub))));
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (10s);
 	while (response2.status == 0)
 	{
@@ -356,7 +356,7 @@ TEST (rpc, send_work)
 TEST (rpc, send_idempotent)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	boost::property_tree::ptree request;
@@ -368,7 +368,7 @@ TEST (rpc, send_idempotent)
 	request.put ("destination", rai::account (0).to_account ());
 	request.put ("amount", (rai::genesis_amount - (rai::genesis_amount / 4)).convert_to<std::string> ());
 	request.put ("id", "123abc");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -380,7 +380,7 @@ TEST (rpc, send_idempotent)
 	ASSERT_FALSE (block.decode_hex (block_text));
 	ASSERT_TRUE (system.nodes[0]->ledger.block_exists (block));
 	ASSERT_EQ (system.nodes[0]->balance (rai::test_genesis_key.pub), rai::genesis_amount / 4);
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -392,7 +392,7 @@ TEST (rpc, send_idempotent)
 	ASSERT_EQ (system.nodes[0]->balance (rai::test_genesis_key.pub), rai::genesis_amount / 4);
 	request.erase ("id");
 	request.put ("id", "456def");
-	test_response response3 (request, rpc, system.service);
+	test_response response3 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response3.status == 0)
 	{
@@ -405,11 +405,11 @@ TEST (rpc, send_idempotent)
 TEST (rpc, stop)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "stop");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -421,7 +421,7 @@ TEST (rpc, stop)
 TEST (rpc, wallet_add)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	rai::keypair key1;
 	std::string key_text;
@@ -432,7 +432,7 @@ TEST (rpc, wallet_add)
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_add");
 	request.put ("key", key_text);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -447,14 +447,14 @@ TEST (rpc, wallet_add)
 TEST (rpc, wallet_password_valid)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
 	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "password_valid");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -468,7 +468,7 @@ TEST (rpc, wallet_password_valid)
 TEST (rpc, wallet_password_change)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
@@ -476,7 +476,7 @@ TEST (rpc, wallet_password_change)
 	request.put ("wallet", wallet);
 	request.put ("action", "password_change");
 	request.put ("password", "test");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -504,7 +504,7 @@ TEST (rpc, wallet_password_enter)
 		ASSERT_NO_ERROR (system.poll ());
 		system.wallet (0)->store.password.value (password_l);
 	}
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
@@ -512,7 +512,7 @@ TEST (rpc, wallet_password_enter)
 	request.put ("wallet", wallet);
 	request.put ("action", "password_enter");
 	request.put ("password", "");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -526,14 +526,14 @@ TEST (rpc, wallet_password_enter)
 TEST (rpc, wallet_representative)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
 	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_representative");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -547,7 +547,7 @@ TEST (rpc, wallet_representative)
 TEST (rpc, wallet_representative_set)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
@@ -556,7 +556,7 @@ TEST (rpc, wallet_representative_set)
 	rai::keypair key;
 	request.put ("action", "wallet_representative_set");
 	request.put ("representative", key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -570,7 +570,7 @@ TEST (rpc, wallet_representative_set)
 TEST (rpc, account_list)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	rai::keypair key2;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
@@ -580,7 +580,7 @@ TEST (rpc, account_list)
 	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "account_list");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -606,7 +606,7 @@ TEST (rpc, account_list)
 TEST (rpc, wallet_key_valid)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	boost::property_tree::ptree request;
@@ -614,7 +614,7 @@ TEST (rpc, wallet_key_valid)
 	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_key_valid");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -628,11 +628,11 @@ TEST (rpc, wallet_key_valid)
 TEST (rpc, wallet_create)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_create");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -648,13 +648,13 @@ TEST (rpc, wallet_create)
 TEST (rpc, wallet_export)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_export");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -674,13 +674,13 @@ TEST (rpc, wallet_destroy)
 {
 	rai::system system (24000, 1);
 	auto wallet_id (system.nodes[0]->wallets.items.begin ()->first);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_destroy");
 	request.put ("wallet", wallet_id.to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -694,7 +694,7 @@ TEST (rpc, account_move)
 {
 	rai::system system (24000, 1);
 	auto wallet_id (system.nodes[0]->wallets.items.begin ()->first);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	auto destination (system.wallet (0));
 	rai::keypair key;
@@ -711,7 +711,7 @@ TEST (rpc, account_move)
 	entry.put ("", key.pub.to_account ());
 	keys.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", keys);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -728,12 +728,12 @@ TEST (rpc, account_move)
 TEST (rpc, block)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "block");
 	request.put ("hash", system.nodes[0]->latest (rai::genesis_account).to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -747,13 +747,13 @@ TEST (rpc, block)
 TEST (rpc, block_account)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	rai::genesis genesis;
 	boost::property_tree::ptree request;
 	request.put ("action", "block_account");
 	request.put ("hash", genesis.hash ().to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -774,13 +774,13 @@ TEST (rpc, chain)
 	ASSERT_FALSE (genesis.is_zero ());
 	auto block (system.wallet (0)->send_action (rai::test_genesis_key.pub, key.pub, 1));
 	ASSERT_NE (nullptr, block);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "chain");
 	request.put ("block", block->hash ().to_string ());
 	request.put ("count", std::to_string (std::numeric_limits<uint64_t>::max ()));
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -807,13 +807,13 @@ TEST (rpc, chain_limit)
 	ASSERT_FALSE (genesis.is_zero ());
 	auto block (system.wallet (0)->send_action (rai::test_genesis_key.pub, key.pub, 1));
 	ASSERT_NE (nullptr, block);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "chain");
 	request.put ("block", block->hash ().to_string ());
 	request.put ("count", 1);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -844,13 +844,13 @@ TEST (rpc, frontier)
 		}
 	}
 	rai::keypair key;
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "frontiers");
 	request.put ("account", rai::account (0).to_account ());
 	request.put ("count", std::to_string (std::numeric_limits<uint64_t>::max ()));
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -885,13 +885,13 @@ TEST (rpc, frontier_limited)
 		}
 	}
 	rai::keypair key;
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "frontiers");
 	request.put ("account", rai::account (0).to_account ());
 	request.put ("count", std::to_string (100));
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -916,13 +916,13 @@ TEST (rpc, frontier_startpoint)
 		}
 	}
 	rai::keypair key;
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "frontiers");
 	request.put ("account", source.begin ()->first.to_account ());
 	request.put ("count", std::to_string (1));
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -955,13 +955,13 @@ TEST (rpc, history)
 		ASSERT_EQ (rai::process_result::progress, node0->ledger.process (transaction, ureceive).code);
 		ASSERT_EQ (rai::process_result::progress, node0->ledger.process (transaction, uchange).code);
 	}
-	rai::rpc rpc (system.service, *node0, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *node0, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "history");
 	request.put ("hash", uchange.hash ().to_string ());
 	request.put ("count", 100);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1008,13 +1008,13 @@ TEST (rpc, history_count)
 	ASSERT_NE (nullptr, send);
 	auto receive (system.wallet (0)->receive_action (*send, rai::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, receive);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "history");
 	request.put ("hash", receive->hash ().to_string ());
 	request.put ("count", 1);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1032,14 +1032,14 @@ TEST (rpc, process_block)
 	auto latest (system.nodes[0]->latest (rai::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
 	rai::send_block send (latest, key.pub, 100, rai::test_genesis_key.prv, rai::test_genesis_key.pub, node1.work_generate_blocking (latest));
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "process");
 	std::string json;
 	send.serialize_json (json);
 	request.put ("block", json);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1063,14 +1063,14 @@ TEST (rpc, process_block_no_work)
 	auto & node1 (*system.nodes[0]);
 	rai::send_block send (latest, key.pub, 100, rai::test_genesis_key.prv, rai::test_genesis_key.pub, node1.work_generate_blocking (latest));
 	send.block_work_set (0);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "process");
 	std::string json;
 	send.serialize_json (json);
 	request.put ("block", json);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1087,14 +1087,14 @@ TEST (rpc, process_republish)
 	auto latest (system.nodes[0]->latest (rai::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
 	rai::send_block send (latest, key.pub, 100, rai::test_genesis_key.prv, rai::test_genesis_key.pub, node1.work_generate_blocking (latest));
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "process");
 	std::string json;
 	send.serialize_json (json);
 	request.put ("block", json);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1112,10 +1112,10 @@ TEST (rpc, keepalive)
 {
 	rai::system system (24000, 1);
 	rai::node_init init1;
-	auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "keepalive");
@@ -1125,7 +1125,7 @@ TEST (rpc, keepalive)
 	request.put ("port", port);
 	ASSERT_FALSE (system.nodes[0]->peers.known_peer (node1->network.endpoint ()));
 	ASSERT_EQ (0, system.nodes[0]->peers.size ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1149,12 +1149,12 @@ TEST (rpc, payment_init)
 	rai::keypair wallet_id;
 	auto wallet (node1->wallets.create (wallet_id.pub));
 	ASSERT_TRUE (node1->wallets.items.find (wallet_id.pub) != node1->wallets.items.end ());
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "payment_init");
 	request.put ("wallet", wallet_id.pub.to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1172,12 +1172,12 @@ TEST (rpc, payment_begin_end)
 	rai::keypair wallet_id;
 	auto wallet (node1->wallets.create (wallet_id.pub));
 	ASSERT_TRUE (node1->wallets.items.find (wallet_id.pub) != node1->wallets.items.end ());
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "payment_begin");
 	request1.put ("wallet", wallet_id.pub.to_string ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1212,7 +1212,7 @@ TEST (rpc, payment_begin_end)
 	request2.put ("action", "payment_end");
 	request2.put ("wallet", wallet_id.pub.to_string ());
 	request2.put ("account", account.to_account ());
-	test_response response2 (request2, rpc, system.service);
+	test_response response2 (request2, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -1234,13 +1234,13 @@ TEST (rpc, payment_end_nonempty)
 	auto transaction (node1->store.tx_begin ());
 	system.wallet (0)->init_free_accounts (transaction);
 	auto wallet_id (node1->wallets.items.begin ()->first);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "payment_end");
 	request1.put ("wallet", wallet_id.to_string ());
 	request1.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1259,12 +1259,12 @@ TEST (rpc, payment_zero_balance)
 	auto transaction (node1->store.tx_begin ());
 	system.wallet (0)->init_free_accounts (transaction);
 	auto wallet_id (node1->wallets.items.begin ()->first);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "payment_begin");
 	request1.put ("wallet", wallet_id.to_string ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1285,12 +1285,12 @@ TEST (rpc, payment_begin_reuse)
 	rai::keypair wallet_id;
 	auto wallet (node1->wallets.create (wallet_id.pub));
 	ASSERT_TRUE (node1->wallets.items.find (wallet_id.pub) != node1->wallets.items.end ());
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "payment_begin");
 	request1.put ("wallet", wallet_id.pub.to_string ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1306,7 +1306,7 @@ TEST (rpc, payment_begin_reuse)
 	request2.put ("action", "payment_end");
 	request2.put ("wallet", wallet_id.pub.to_string ());
 	request2.put ("account", account.to_account ());
-	test_response response2 (request2, rpc, system.service);
+	test_response response2 (request2, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -1315,7 +1315,7 @@ TEST (rpc, payment_begin_reuse)
 	ASSERT_EQ (200, response2.status);
 	ASSERT_TRUE (wallet->exists (account));
 	ASSERT_NE (wallet->free_accounts.end (), wallet->free_accounts.find (account));
-	test_response response3 (request1, rpc, system.service);
+	test_response response3 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response3.status == 0)
 	{
@@ -1341,12 +1341,12 @@ TEST (rpc, payment_begin_locked)
 		ASSERT_TRUE (wallet->store.attempt_password (transaction, ""));
 	}
 	ASSERT_TRUE (node1->wallets.items.find (wallet_id.pub) != node1->wallets.items.end ());
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "payment_begin");
 	request1.put ("wallet", wallet_id.pub.to_string ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1364,14 +1364,14 @@ TEST (rpc, payment_wait)
 	rai::keypair key;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "payment_wait");
 	request1.put ("account", key.pub.to_account ());
 	request1.put ("amount", rai::amount (rai::Mxrb_ratio).to_string_dec ());
 	request1.put ("timeout", "100");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1384,7 +1384,7 @@ TEST (rpc, payment_wait)
 	system.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (500), [&]() {
 		system.wallet (0)->send_action (rai::test_genesis_key.pub, key.pub, rai::Mxrb_ratio);
 	});
-	test_response response2 (request1, rpc, system.service);
+	test_response response2 (request1, rpc, system.io_ctx);
 	while (response2.status == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
@@ -1392,7 +1392,7 @@ TEST (rpc, payment_wait)
 	ASSERT_EQ (200, response2.status);
 	ASSERT_EQ ("success", response2.json.get<std::string> ("status"));
 	request1.put ("amount", rai::amount (rai::Mxrb_ratio * 2).to_string_dec ());
-	test_response response3 (request1, rpc, system.service);
+	test_response response3 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response3.status == 0)
 	{
@@ -1406,11 +1406,11 @@ TEST (rpc, peers)
 {
 	rai::system system (24000, 2);
 	system.nodes[0]->peers.insert (rai::endpoint (boost::asio::ip::address_v6::from_string ("::ffff:80.80.80.80"), 4000), rai::protocol_version);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "peers");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1432,13 +1432,13 @@ TEST (rpc, pending)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "pending");
 	request.put ("account", key1.pub.to_account ());
 	request.put ("count", "100");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1450,7 +1450,7 @@ TEST (rpc, pending)
 	rai::block_hash hash1 (blocks_node.begin ()->second.get<std::string> (""));
 	ASSERT_EQ (block1->hash (), hash1);
 	request.put ("threshold", "100"); // Threshold test
-	test_response response0 (request, rpc, system.service);
+	test_response response0 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response0.status == 0)
 	{
@@ -1474,7 +1474,7 @@ TEST (rpc, pending)
 	}
 	ASSERT_EQ (blocks[block1->hash ()], 100);
 	request.put ("threshold", "101");
-	test_response response1 (request, rpc, system.service);
+	test_response response1 (request, rpc, system.io_ctx);
 	while (response1.status == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
@@ -1485,7 +1485,7 @@ TEST (rpc, pending)
 	request.put ("threshold", "0");
 	request.put ("source", "true");
 	request.put ("min_version", "true");
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -1540,12 +1540,12 @@ TEST (rpc, search_pending)
 	rai::send_block block (system.nodes[0]->latest (rai::test_genesis_key.pub), rai::test_genesis_key.pub, rai::genesis_amount - system.nodes[0]->config.receive_minimum.number (), rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0);
 	auto transaction (system.nodes[0]->store.tx_begin (true));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "search_pending");
 	request.put ("wallet", wallet);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1567,11 +1567,11 @@ TEST (rpc, version)
 	rai::keypair key;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "version");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1601,13 +1601,13 @@ TEST (rpc, work_generate)
 	rai::keypair key;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	rai::block_hash hash1 (1);
 	boost::property_tree::ptree request1;
 	request1.put ("action", "work_generate");
 	request1.put ("hash", hash1.to_string ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1628,7 +1628,7 @@ TEST (rpc, work_cancel)
 	rai::keypair key;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	rai::block_hash hash1 (1);
 	boost::property_tree::ptree request1;
@@ -1641,7 +1641,7 @@ TEST (rpc, work_cancel)
 		system.work.generate (hash1, [&done](boost::optional<uint64_t> work_a) {
 			done = !work_a;
 		});
-		test_response response1 (request1, rpc, system.service);
+		test_response response1 (request1, rpc, system.io_ctx);
 		std::error_code ec;
 		while (response1.status == 0)
 		{
@@ -1661,7 +1661,7 @@ TEST (rpc, work_peer_bad)
 	rai::keypair key;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	node2.config.work_peers.push_back (std::make_pair (boost::asio::ip::address_v6::any ().to_string (), 0));
 	rai::block_hash hash1 (1);
@@ -1685,7 +1685,7 @@ TEST (rpc, work_peer_one)
 	rai::keypair key;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	node2.config.work_peers.push_back (std::make_pair (node1.network.endpoint ().address ().to_string (), rpc.config.port));
 	rai::keypair key1;
@@ -1714,15 +1714,15 @@ TEST (rpc, work_peer_many)
 	rai::keypair key;
 	rai::rpc_config config2 (true);
 	config2.port += 0;
-	rai::rpc rpc2 (system2.service, node2, config2);
+	rai::rpc rpc2 (system2.io_ctx, node2, config2);
 	rpc2.start ();
 	rai::rpc_config config3 (true);
 	config3.port += 1;
-	rai::rpc rpc3 (system3.service, node3, config3);
+	rai::rpc rpc3 (system3.io_ctx, node3, config3);
 	rpc3.start ();
 	rai::rpc_config config4 (true);
 	config4.port += 2;
-	rai::rpc rpc4 (system4.service, node4, config4);
+	rai::rpc rpc4 (system4.io_ctx, node4, config4);
 	rpc4.start ();
 	node1.config.work_peers.push_back (std::make_pair (node2.network.endpoint ().address ().to_string (), rpc2.config.port));
 	node1.config.work_peers.push_back (std::make_pair (node3.network.endpoint ().address ().to_string (), rpc3.config.port));
@@ -1749,11 +1749,11 @@ TEST (rpc, block_count)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "block_count");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1769,11 +1769,11 @@ TEST (rpc, frontier_count)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "frontier_count");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1788,11 +1788,11 @@ TEST (rpc, account_count)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "account_count");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1807,11 +1807,11 @@ TEST (rpc, available_supply)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "available_supply");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1822,7 +1822,7 @@ TEST (rpc, available_supply)
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	rai::keypair key;
 	auto block (system.wallet (0)->send_action (rai::test_genesis_key.pub, key.pub, 1));
-	test_response response2 (request1, rpc, system.service);
+	test_response response2 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -1831,7 +1831,7 @@ TEST (rpc, available_supply)
 	ASSERT_EQ (200, response2.status);
 	ASSERT_EQ ("1", response2.json.get<std::string> ("available"));
 	auto block2 (system.wallet (0)->send_action (rai::test_genesis_key.pub, 0, 100)); // Sending to burning 0 account
-	test_response response3 (request1, rpc, system.service);
+	test_response response3 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response3.status == 0)
 	{
@@ -1846,12 +1846,12 @@ TEST (rpc, mrai_to_raw)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "mrai_to_raw");
 	request1.put ("amount", "1");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1866,12 +1866,12 @@ TEST (rpc, mrai_from_raw)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "mrai_from_raw");
 	request1.put ("amount", rai::Mxrb_ratio.convert_to<std::string> ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1886,12 +1886,12 @@ TEST (rpc, krai_to_raw)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "krai_to_raw");
 	request1.put ("amount", "1");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1906,12 +1906,12 @@ TEST (rpc, krai_from_raw)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "krai_from_raw");
 	request1.put ("amount", rai::kxrb_ratio.convert_to<std::string> ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1926,12 +1926,12 @@ TEST (rpc, rai_to_raw)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "rai_to_raw");
 	request1.put ("amount", "1");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1946,12 +1946,12 @@ TEST (rpc, rai_from_raw)
 	rai::system system (24000, 1);
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request1;
 	request1.put ("action", "rai_from_raw");
 	request1.put ("amount", rai::xrb_ratio.convert_to<std::string> ());
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -1964,13 +1964,13 @@ TEST (rpc, rai_from_raw)
 TEST (rpc, account_representative)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
 	request.put ("account", rai::genesis_account.to_account ());
 	request.put ("action", "account_representative");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -1985,7 +1985,7 @@ TEST (rpc, account_representative_set)
 {
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	rai::keypair rep;
@@ -1993,7 +1993,7 @@ TEST (rpc, account_representative_set)
 	request.put ("representative", rep.pub.to_account ());
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("action", "account_representative_set");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2019,13 +2019,13 @@ TEST (rpc, bootstrap)
 		auto transaction (system1.nodes[0]->store.tx_begin (true));
 		ASSERT_EQ (rai::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
 	}
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "bootstrap");
 	request.put ("address", "::ffff:127.0.0.1");
 	request.put ("port", system1.nodes[0]->network.endpoint ().port ());
-	test_response response (request, rpc, system0.service);
+	test_response response (request, rpc, system0.io_ctx);
 	while (response.status == 0)
 	{
 		system0.poll ();
@@ -2043,13 +2043,13 @@ TEST (rpc, account_remove)
 	rai::system system0 (24000, 1);
 	auto key1 (system0.wallet (0)->deterministic_insert ());
 	ASSERT_TRUE (system0.wallet (0)->exists (key1));
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_remove");
 	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("account", key1.to_account ());
-	test_response response (request, rpc, system0.service);
+	test_response response (request, rpc, system0.io_ctx);
 	while (response.status == 0)
 	{
 		system0.poll ();
@@ -2060,11 +2060,11 @@ TEST (rpc, account_remove)
 TEST (rpc, representatives)
 {
 	rai::system system0 (24000, 1);
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "representatives");
-	test_response response (request, rpc, system0.service);
+	test_response response (request, rpc, system0.io_ctx);
 	while (response.status == 0)
 	{
 		system0.poll ();
@@ -2092,13 +2092,13 @@ TEST (rpc, wallet_change_seed)
 		system0.wallet (0)->store.seed (seed0, transaction);
 		ASSERT_NE (seed.pub, seed0.data);
 	}
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_change_seed");
 	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("seed", seed.pub.to_string ());
-	test_response response (request, rpc, system0.service);
+	test_response response (request, rpc, system0.io_ctx);
 	while (response.status == 0)
 	{
 		system0.poll ();
@@ -2116,12 +2116,12 @@ TEST (rpc, wallet_frontiers)
 {
 	rai::system system0 (24000, 1);
 	system0.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_frontiers");
 	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
-	test_response response (request, rpc, system0.service);
+	test_response response (request, rpc, system0.io_ctx);
 	while (response.status == 0)
 	{
 		system0.poll ();
@@ -2145,7 +2145,7 @@ TEST (rpc, work_validate)
 	rai::keypair key;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	rai::block_hash hash (1);
 	uint64_t work1 (node1.work_generate_blocking (hash));
@@ -2153,7 +2153,7 @@ TEST (rpc, work_validate)
 	request.put ("action", "work_validate");
 	request.put ("hash", hash.to_string ());
 	request.put ("work", rai::to_string_hex (work1));
-	test_response response1 (request, rpc, system.service);
+	test_response response1 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -2164,7 +2164,7 @@ TEST (rpc, work_validate)
 	ASSERT_EQ ("1", validate_text1);
 	uint64_t work2 (0);
 	request.put ("work", rai::to_string_hex (work2));
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -2184,13 +2184,13 @@ TEST (rpc, successors)
 	ASSERT_FALSE (genesis.is_zero ());
 	auto block (system.wallet (0)->send_action (rai::test_genesis_key.pub, key.pub, 1));
 	ASSERT_NE (nullptr, block);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "successors");
 	request.put ("block", genesis.to_string ());
 	request.put ("count", std::to_string (std::numeric_limits<uint64_t>::max ()));
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2218,11 +2218,11 @@ TEST (rpc, bootstrap_any)
 		auto transaction (system1.nodes[0]->store.tx_begin (true));
 		ASSERT_EQ (rai::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
 	}
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "bootstrap_any");
-	test_response response (request, rpc, system0.service);
+	test_response response (request, rpc, system0.io_ctx);
 	while (response.status == 0)
 	{
 		system0.poll ();
@@ -2242,12 +2242,12 @@ TEST (rpc, republish)
 	system.nodes[0]->process (send);
 	rai::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->process (open).code);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "republish");
 	request.put ("hash", send.hash ().to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2270,7 +2270,7 @@ TEST (rpc, republish)
 
 	request.put ("hash", genesis.hash ().to_string ());
 	request.put ("count", 1);
-	test_response response1 (request, rpc, system.service);
+	test_response response1 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	system.deadline_set (5s);
 	while (response1.status == 0)
@@ -2289,7 +2289,7 @@ TEST (rpc, republish)
 
 	request.put ("hash", open.hash ().to_string ());
 	request.put ("sources", 2);
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	while (response2.status == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
@@ -2318,13 +2318,13 @@ TEST (rpc, deterministic_key)
 	rai::account account0 (system0.wallet (0)->deterministic_insert ());
 	rai::account account1 (system0.wallet (0)->deterministic_insert ());
 	rai::account account2 (system0.wallet (0)->deterministic_insert ());
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "deterministic_key");
 	request.put ("seed", seed.data.to_string ());
 	request.put ("index", "0");
-	test_response response0 (request, rpc, system0.service);
+	test_response response0 (request, rpc, system0.io_ctx);
 	while (response0.status == 0)
 	{
 		system0.poll ();
@@ -2333,7 +2333,7 @@ TEST (rpc, deterministic_key)
 	std::string validate_text (response0.json.get<std::string> ("account"));
 	ASSERT_EQ (account0.to_account (), validate_text);
 	request.put ("index", "2");
-	test_response response1 (request, rpc, system0.service);
+	test_response response1 (request, rpc, system0.io_ctx);
 	while (response1.status == 0)
 	{
 		system0.poll ();
@@ -2347,7 +2347,7 @@ TEST (rpc, deterministic_key)
 TEST (rpc, accounts_balances)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "accounts_balances");
@@ -2356,7 +2356,7 @@ TEST (rpc, accounts_balances)
 	entry.put ("", rai::test_genesis_key.pub.to_account ());
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", peers_l);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2378,7 +2378,7 @@ TEST (rpc, accounts_frontiers)
 {
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "accounts_frontiers");
@@ -2387,7 +2387,7 @@ TEST (rpc, accounts_frontiers)
 	entry.put ("", rai::test_genesis_key.pub.to_account ());
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", peers_l);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2415,7 +2415,7 @@ TEST (rpc, accounts_pending)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "accounts_pending");
@@ -2425,7 +2425,7 @@ TEST (rpc, accounts_pending)
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", peers_l);
 	request.put ("count", "100");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2440,7 +2440,7 @@ TEST (rpc, accounts_pending)
 		ASSERT_EQ (block1->hash (), hash1);
 	}
 	request.put ("threshold", "100"); // Threshold test
-	test_response response1 (request, rpc, system.service);
+	test_response response1 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -2465,7 +2465,7 @@ TEST (rpc, accounts_pending)
 	}
 	ASSERT_EQ (blocks[block1->hash ()], 100);
 	request.put ("source", "true");
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -2493,7 +2493,7 @@ TEST (rpc, accounts_pending)
 TEST (rpc, blocks)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "blocks");
@@ -2502,7 +2502,7 @@ TEST (rpc, blocks)
 	entry.put ("", system.nodes[0]->latest (rai::genesis_account).to_string ());
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("hashes", peers_l);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2531,12 +2531,12 @@ TEST (rpc, wallet_info)
 		system.wallet (0)->store.erase (transaction, account);
 	}
 	account = system.wallet (0)->deterministic_insert ();
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_info");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2561,12 +2561,12 @@ TEST (rpc, wallet_balances)
 {
 	rai::system system0 (24000, 1);
 	system0.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_balances");
 	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
-	test_response response (request, rpc, system0.service);
+	test_response response (request, rpc, system0.io_ctx);
 	while (response.status == 0)
 	{
 		system0.poll ();
@@ -2585,7 +2585,7 @@ TEST (rpc, wallet_balances)
 	system0.wallet (0)->insert_adhoc (key.prv);
 	auto send (system0.wallet (0)->send_action (rai::test_genesis_key.pub, key.pub, 1));
 	request.put ("threshold", "2");
-	test_response response1 (request, rpc, system0.service);
+	test_response response1 (request, rpc, system0.io_ctx);
 	while (response1.status == 0)
 	{
 		system0.poll ();
@@ -2614,12 +2614,12 @@ TEST (rpc, pending_exists)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "pending_exists");
 	request.put ("hash", hash0.to_string ());
-	test_response response0 (request, rpc, system.service);
+	test_response response0 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response0.status == 0)
 	{
@@ -2629,7 +2629,7 @@ TEST (rpc, pending_exists)
 	std::string exists_text (response0.json.get<std::string> ("exists"));
 	ASSERT_EQ ("0", exists_text);
 	request.put ("hash", block1->hash ().to_string ());
-	test_response response1 (request, rpc, system.service);
+	test_response response1 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -2654,13 +2654,13 @@ TEST (rpc, wallet_pending)
 		++iterations;
 		ASSERT_LT (iterations, 200);
 	}
-	rai::rpc rpc (system0.service, *system0.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system0.io_ctx, *system0.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_pending");
 	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("count", "100");
-	test_response response (request, rpc, system0.service);
+	test_response response (request, rpc, system0.io_ctx);
 	while (response.status == 0)
 	{
 		system0.poll ();
@@ -2675,7 +2675,7 @@ TEST (rpc, wallet_pending)
 		ASSERT_EQ (block1->hash (), hash1);
 	}
 	request.put ("threshold", "100"); // Threshold test
-	test_response response0 (request, rpc, system0.service);
+	test_response response0 (request, rpc, system0.io_ctx);
 	while (response0.status == 0)
 	{
 		system0.poll ();
@@ -2702,7 +2702,7 @@ TEST (rpc, wallet_pending)
 	}
 	ASSERT_EQ (blocks[block1->hash ()], 100);
 	request.put ("threshold", "101");
-	test_response response1 (request, rpc, system0.service);
+	test_response response1 (request, rpc, system0.io_ctx);
 	while (response1.status == 0)
 	{
 		system0.poll ();
@@ -2713,7 +2713,7 @@ TEST (rpc, wallet_pending)
 	request.put ("threshold", "0");
 	request.put ("source", "true");
 	request.put ("min_version", "true");
-	test_response response2 (request, rpc, system0.service);
+	test_response response2 (request, rpc, system0.io_ctx);
 	while (response2.status == 0)
 	{
 		system0.poll ();
@@ -2742,11 +2742,11 @@ TEST (rpc, wallet_pending)
 TEST (rpc, receive_minimum)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "receive_minimum");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2760,13 +2760,13 @@ TEST (rpc, receive_minimum)
 TEST (rpc, receive_minimum_set)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "receive_minimum_set");
 	request.put ("amount", "100");
 	ASSERT_NE (system.nodes[0]->config.receive_minimum.to_string_dec (), "100");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2783,13 +2783,13 @@ TEST (rpc, work_get)
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->work_cache_blocking (rai::test_genesis_key.pub, system.nodes[0]->latest (rai::test_genesis_key.pub));
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "work_get");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2808,12 +2808,12 @@ TEST (rpc, wallet_work_get)
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	system.wallet (0)->work_cache_blocking (rai::test_genesis_key.pub, system.nodes[0]->latest (rai::test_genesis_key.pub));
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_work_get");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2837,14 +2837,14 @@ TEST (rpc, work_set)
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	uint64_t work0 (100);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "work_set");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
 	request.put ("work", rai::to_string_hex (work0));
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2866,11 +2866,11 @@ TEST (rpc, search_pending_all)
 	rai::send_block block (system.nodes[0]->latest (rai::test_genesis_key.pub), rai::test_genesis_key.pub, rai::genesis_amount - system.nodes[0]->config.receive_minimum.number (), rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0);
 	auto transaction (system.nodes[0]->store.tx_begin (true));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "search_pending_all");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2903,13 +2903,13 @@ TEST (rpc, wallet_republish)
 	system.nodes[0]->process (send);
 	rai::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->process (open).code);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_republish");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("count", 1);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2939,12 +2939,12 @@ TEST (rpc, delegators)
 	system.nodes[0]->process (send);
 	rai::open_block open (send.hash (), rai::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->process (open).code);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "delegators");
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -2974,12 +2974,12 @@ TEST (rpc, delegators_count)
 	system.nodes[0]->process (send);
 	rai::open_block open (send.hash (), rai::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->process (open).code);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "delegators_count");
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3003,12 +3003,12 @@ TEST (rpc, account_info)
 	system.nodes[0]->process (send);
 	auto time (rai::seconds_since_epoch ());
 
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_info");
 	request.put ("account", rai::test_genesis_key.pub.to_account ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3038,7 +3038,7 @@ TEST (rpc, account_info)
 	request.put ("weight", "true");
 	request.put ("pending", "1");
 	request.put ("representative", "1");
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -3055,7 +3055,7 @@ TEST (rpc, account_info)
 TEST (rpc, blocks_info)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "blocks_info");
@@ -3064,7 +3064,7 @@ TEST (rpc, blocks_info)
 	entry.put ("", system.nodes[0]->latest (rai::genesis_account).to_string ());
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("hashes", peers_l);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3092,7 +3092,7 @@ TEST (rpc, blocks_info)
 	request.put ("source", "true");
 	request.put ("pending", "1");
 	request.put ("balance", "true");
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -3116,13 +3116,13 @@ TEST (rpc, work_peers_all)
 	rai::node_init init1;
 	auto & node1 (*system.nodes[0]);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "work_peer_add");
 	request.put ("address", "::1");
 	request.put ("port", "0");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3133,7 +3133,7 @@ TEST (rpc, work_peers_all)
 	ASSERT_TRUE (success.empty ());
 	boost::property_tree::ptree request1;
 	request1.put ("action", "work_peers");
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -3150,7 +3150,7 @@ TEST (rpc, work_peers_all)
 	ASSERT_EQ ("::1:0", peers[0]);
 	boost::property_tree::ptree request2;
 	request2.put ("action", "work_peers_clear");
-	test_response response2 (request2, rpc, system.service);
+	test_response response2 (request2, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -3159,7 +3159,7 @@ TEST (rpc, work_peers_all)
 	ASSERT_EQ (200, response2.status);
 	success = response2.json.get<std::string> ("success", "");
 	ASSERT_TRUE (success.empty ());
-	test_response response3 (request1, rpc, system.service);
+	test_response response3 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response3.status == 0)
 	{
@@ -3178,11 +3178,11 @@ TEST (rpc, block_count_type)
 	ASSERT_NE (nullptr, send);
 	auto receive (system.wallet (0)->receive_action (*send, rai::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, receive);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "block_count_type");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3215,13 +3215,13 @@ TEST (rpc, ledger)
 	rai::open_block open (send.hash (), rai::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->process (open).code);
 	auto time (rai::seconds_since_epoch ());
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "ledger");
 	request.put ("sorting", "1");
 	request.put ("count", "1");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3254,7 +3254,7 @@ TEST (rpc, ledger)
 	request.put ("weight", "1");
 	request.put ("pending", "1");
 	request.put ("representative", "true");
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -3277,13 +3277,13 @@ TEST (rpc, ledger)
 TEST (rpc, accounts_create)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "accounts_create");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("count", "8");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3314,7 +3314,7 @@ TEST (rpc, block_create)
 	rai::send_block send (latest, key.pub, 100, rai::test_genesis_key.prv, rai::test_genesis_key.pub, send_work);
 	auto open_work = node1.work_generate_blocking (key.pub);
 	rai::open_block open (send.hash (), rai::test_genesis_key.pub, key.pub, key.prv, key.pub, open_work);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
@@ -3325,7 +3325,7 @@ TEST (rpc, block_create)
 	request.put ("amount", "340282366920938463463374607431768211355");
 	request.put ("destination", key.pub.to_account ());
 	request.put ("work", rai::to_string_hex (send_work));
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3350,7 +3350,7 @@ TEST (rpc, block_create)
 	request1.put ("representative", rai::test_genesis_key.pub.to_account ());
 	request1.put ("source", send.hash ().to_string ());
 	request1.put ("work", rai::to_string_hex (open_work));
-	test_response response1 (request1, rpc, system.service);
+	test_response response1 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response1.status == 0)
 	{
@@ -3366,7 +3366,7 @@ TEST (rpc, block_create)
 	ASSERT_EQ (open.hash (), open_block->hash ());
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->process (open).code);
 	request1.put ("representative", key.pub.to_account ());
-	test_response response2 (request1, rpc, system.service);
+	test_response response2 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -3379,7 +3379,7 @@ TEST (rpc, block_create)
 	rai::change_block change (open.hash (), key.pub, key.prv, key.pub, change_work);
 	request1.put ("type", "change");
 	request1.put ("work", rai::to_string_hex (change_work));
-	test_response response4 (request1, rpc, system.service);
+	test_response response4 (request1, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response4.status == 0)
 	{
@@ -3404,7 +3404,7 @@ TEST (rpc, block_create)
 	request2.put ("source", send2.hash ().to_string ());
 	request2.put ("previous", change.hash ().to_string ());
 	request2.put ("work", rai::to_string_hex (node1.work_generate_blocking (change.hash ())));
-	test_response response5 (request2, rpc, system.service);
+	test_response response5 (request2, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response5.status == 0)
 	{
@@ -3438,9 +3438,9 @@ TEST (rpc, block_create_state)
 	request.put ("balance", (rai::genesis_amount - rai::Gxrb_ratio).convert_to<std::string> ());
 	request.put ("link", key.pub.to_account ());
 	request.put ("work", rai::to_string_hex (system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3478,9 +3478,9 @@ TEST (rpc, block_create_state_open)
 	request.put ("balance", rai::Gxrb_ratio.convert_to<std::string> ());
 	request.put ("link", send_block->hash ().to_string ());
 	request.put ("work", rai::to_string_hex (system.nodes[0]->work_generate_blocking (send_block->hash ())));
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3525,9 +3525,9 @@ TEST (rpc, block_create_state_request_work)
 		request.put ("balance", (rai::genesis_amount - rai::Gxrb_ratio).convert_to<std::string> ());
 		request.put ("link", key.pub.to_account ());
 		request.put ("previous", previous);
-		rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+		rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 		rpc.start ();
-		test_response response (request, rpc, system.service);
+		test_response response (request, rpc, system.io_ctx);
 		system.deadline_set (5s);
 		while (response.status == 0)
 		{
@@ -3550,14 +3550,14 @@ TEST (rpc, block_hash)
 	auto latest (system.nodes[0]->latest (rai::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
 	rai::send_block send (latest, key.pub, 100, rai::test_genesis_key.prv, rai::test_genesis_key.pub, node1.work_generate_blocking (latest));
-	rai::rpc rpc (system.service, node1, rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, node1, rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "block_hash");
 	std::string json;
 	send.serialize_json (json);
 	request.put ("block", json);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3571,7 +3571,7 @@ TEST (rpc, block_hash)
 TEST (rpc, wallet_lock)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
@@ -3582,7 +3582,7 @@ TEST (rpc, wallet_lock)
 	}
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_lock");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3598,14 +3598,14 @@ TEST (rpc, wallet_lock)
 TEST (rpc, wallet_locked)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
 	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_locked");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3619,7 +3619,7 @@ TEST (rpc, wallet_locked)
 TEST (rpc, wallet_create_fail)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	auto node = system.nodes[0];
 	// lmdb_max_dbs should be removed once the wallet store is refactored to support more wallets.
 	for (int i = 0; i < 113; i++)
@@ -3630,7 +3630,7 @@ TEST (rpc, wallet_create_fail)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_create");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3652,14 +3652,14 @@ TEST (rpc, wallet_ledger)
 	rai::open_block open (send.hash (), rai::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (rai::process_result::progress, system.nodes[0]->process (open).code);
 	auto time (rai::seconds_since_epoch ());
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_ledger");
 	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
 	request.put ("sorting", "1");
 	request.put ("count", "1");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3692,7 +3692,7 @@ TEST (rpc, wallet_ledger)
 	request.put ("weight", "true");
 	request.put ("pending", "1");
 	request.put ("representative", "false");
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response2.status == 0)
 	{
@@ -3714,7 +3714,7 @@ TEST (rpc, wallet_ledger)
 TEST (rpc, wallet_add_watch)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	std::string wallet;
@@ -3726,7 +3726,7 @@ TEST (rpc, wallet_add_watch)
 	entry.put ("", rai::test_genesis_key.pub.to_account ());
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", peers_l);
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3749,11 +3749,11 @@ TEST (rpc, online_reps)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	rai::rpc rpc (system.service, *system.nodes[1], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[1], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "representatives_online");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	system.deadline_set (5s);
 	while (response.status == 0)
@@ -3769,7 +3769,7 @@ TEST (rpc, online_reps)
 	ASSERT_FALSE (weight.is_initialized ());
 	//Test weight option
 	request.put ("weight", "true");
-	test_response response2 (request, rpc, system.service);
+	test_response response2 (request, rpc, system.io_ctx);
 	while (response2.status == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
@@ -3799,7 +3799,7 @@ TEST (rpc, online_reps)
 	boost::property_tree::ptree filtered_accounts;
 	filtered_accounts.push_back (std::make_pair ("", child_rep));
 	request.add_child ("accounts", filtered_accounts);
-	test_response response3 (request, rpc, system.service);
+	test_response response3 (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response3.status == 0)
 	{
@@ -3824,11 +3824,11 @@ TEST (rpc, confirmation_history)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "confirmation_history");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3858,12 +3858,12 @@ TEST (rpc, block_confirm)
 		auto transaction (system.nodes[0]->store.tx_begin (true));
 		ASSERT_EQ (rai::process_result::progress, system.nodes[0]->ledger.process (transaction, *send1).code);
 	}
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "block_confirm");
 	request.put ("hash", send1->hash ().to_string ());
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3877,12 +3877,12 @@ TEST (rpc, block_confirm_absent)
 {
 	rai::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "block_confirm");
 	request.put ("hash", "0");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3895,11 +3895,11 @@ TEST (rpc, block_confirm_absent)
 TEST (rpc, node_id)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "node_id");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
@@ -3915,7 +3915,7 @@ TEST (rpc, node_id)
 TEST (rpc, node_id_delete)
 {
 	rai::system system (24000, 1);
-	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
+	rai::rpc rpc (system.io_ctx, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_write ());
@@ -3924,7 +3924,7 @@ TEST (rpc, node_id_delete)
 	}
 	boost::property_tree::ptree request;
 	request.put ("action", "node_id_delete");
-	test_response response (request, rpc, system.service);
+	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{

--- a/rai/core_test/wallet.cpp
+++ b/rai/core_test/wallet.cpp
@@ -880,7 +880,7 @@ TEST (wallet, send_race)
 TEST (wallet, password_race)
 {
 	rai::system system (24000, 1);
-	rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
+	rai::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	auto wallet = system.wallet (0);
 	system.nodes[0]->background ([&wallet]() {
 		for (int i = 0; i < 100; i++)
@@ -907,7 +907,7 @@ TEST (wallet, password_race)
 TEST (wallet, password_race_corrupt_seed)
 {
 	rai::system system (24000, 1);
-	rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
+	rai::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	auto wallet = system.wallet (0);
 	rai::raw_key seed;
 	{

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -15,7 +15,7 @@ constexpr unsigned bootstrap_max_new_connections = 10;
 constexpr unsigned bulk_push_cost_limit = 200;
 
 rai::socket::socket (std::shared_ptr<rai::node> node_a) :
-socket_m (node_a->service),
+socket_m (node_a->io_ctx),
 cutoff (std::numeric_limits<uint64_t>::max ()),
 node (node_a)
 {
@@ -809,7 +809,7 @@ bool rai::bootstrap_attempt::request_frontier (std::unique_lock<std::mutex> & lo
 			future = client->promise.get_future ();
 		}
 		lock_a.unlock ();
-		result = consume_future (future); // This is out of scope of `client' so when the last reference via boost::asio::io_service is lost and the client is destroyed, the future throws an exception.
+		result = consume_future (future); // This is out of scope of `client' so when the last reference via boost::asio::io_context is lost and the client is destroyed, the future throws an exception.
 		lock_a.lock ();
 		if (result)
 		{
@@ -870,7 +870,7 @@ void rai::bootstrap_attempt::request_push (std::unique_lock<std::mutex> & lock_a
 			future = client->promise.get_future ();
 		}
 		lock_a.unlock ();
-		error = consume_future (future); // This is out of scope of `client' so when the last reference via boost::asio::io_service is lost and the client is destroyed, the future throws an exception.
+		error = consume_future (future); // This is out of scope of `client' so when the last reference via boost::asio::io_context is lost and the client is destroyed, the future throws an exception.
 		lock_a.lock ();
 	}
 	if (node->config.logging.network_logging ())
@@ -1618,10 +1618,10 @@ void rai::bootstrap_initiator::notify_listeners (bool in_progress_a)
 	}
 }
 
-rai::bootstrap_listener::bootstrap_listener (boost::asio::io_service & service_a, uint16_t port_a, rai::node & node_a) :
-acceptor (service_a),
+rai::bootstrap_listener::bootstrap_listener (boost::asio::io_context & io_ctx_a, uint16_t port_a, rai::node & node_a) :
+acceptor (io_ctx_a),
 local (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::any (), port_a)),
-service (service_a),
+io_ctx (io_ctx_a),
 node (node_a)
 {
 }

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -219,7 +219,7 @@ class bootstrap_server;
 class bootstrap_listener
 {
 public:
-	bootstrap_listener (boost::asio::io_service &, uint16_t, rai::node &);
+	bootstrap_listener (boost::asio::io_context &, uint16_t, rai::node &);
 	void start ();
 	void stop ();
 	void accept_connection ();
@@ -229,7 +229,7 @@ public:
 	rai::tcp_endpoint endpoint ();
 	boost::asio::ip::tcp::acceptor acceptor;
 	rai::tcp_endpoint local;
-	boost::asio::io_service & service;
+	boost::asio::io_context & io_ctx;
 	rai::node & node;
 	bool on;
 };

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -147,11 +147,11 @@ public:
 class alarm
 {
 public:
-	alarm (boost::asio::io_service &);
+	alarm (boost::asio::io_context &);
 	~alarm ();
 	void add (std::chrono::steady_clock::time_point const &, std::function<void()> const &);
 	void run ();
-	boost::asio::io_service & service;
+	boost::asio::io_context & io_ctx;
 	std::mutex mutex;
 	std::condition_variable condition;
 	std::priority_queue<operation, std::vector<operation>, std::greater<operation>> operations;
@@ -446,13 +446,13 @@ private:
 class node : public std::enable_shared_from_this<rai::node>
 {
 public:
-	node (rai::node_init &, boost::asio::io_service &, uint16_t, boost::filesystem::path const &, rai::alarm &, rai::logging const &, rai::work_pool &);
-	node (rai::node_init &, boost::asio::io_service &, boost::filesystem::path const &, rai::alarm &, rai::node_config const &, rai::work_pool &);
+	node (rai::node_init &, boost::asio::io_context &, uint16_t, boost::filesystem::path const &, rai::alarm &, rai::logging const &, rai::work_pool &);
+	node (rai::node_init &, boost::asio::io_context &, boost::filesystem::path const &, rai::alarm &, rai::node_config const &, rai::work_pool &);
 	~node ();
 	template <typename T>
 	void background (T action_a)
 	{
-		alarm.service.post (action_a);
+		alarm.io_ctx.post (action_a);
 	}
 	void send_keepalive (rai::endpoint const &);
 	bool copy_with_compaction (boost::filesystem::path const &);
@@ -489,7 +489,7 @@ public:
 	void process_fork (rai::transaction const &, std::shared_ptr<rai::block>);
 	bool validate_block_by_previous (rai::transaction const &, std::shared_ptr<rai::block>);
 	rai::uint128_t delta ();
-	boost::asio::io_service & service;
+	boost::asio::io_context & io_ctx;
 	rai::node_config config;
 	rai::node_flags flags;
 	rai::alarm & alarm;
@@ -531,7 +531,7 @@ public:
 class thread_runner
 {
 public:
-	thread_runner (boost::asio::io_service &, unsigned);
+	thread_runner (boost::asio::io_context &, unsigned);
 	~thread_runner ();
 	void join ();
 	std::vector<boost::thread> threads;
@@ -542,7 +542,7 @@ public:
 	inactive_node (boost::filesystem::path const & path = rai::working_path ());
 	~inactive_node ();
 	boost::filesystem::path path;
-	std::shared_ptr<boost::asio::io_service> service;
+	std::shared_ptr<boost::asio::io_context> io_context;
 	rai::alarm alarm;
 	rai::logging logging;
 	rai::node_init init;

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -122,8 +122,8 @@ bool rai::rpc_config::deserialize_json (boost::property_tree::ptree const & tree
 	return result;
 }
 
-rai::rpc::rpc (boost::asio::io_service & service_a, rai::node & node_a, rai::rpc_config const & config_a) :
-acceptor (service_a),
+rai::rpc::rpc (boost::asio::io_context & io_ctx_a, rai::node & node_a, rai::rpc_config const & config_a) :
+acceptor (io_ctx_a),
 config (config_a),
 node (node_a)
 {
@@ -3713,7 +3713,7 @@ void rai::rpc_handler::work_peers_clear ()
 rai::rpc_connection::rpc_connection (rai::node & node_a, rai::rpc & rpc_a) :
 node (node_a.shared ()),
 rpc (rpc_a),
-socket (node_a.service)
+socket (node_a.io_ctx)
 {
 	responded.clear ();
 }
@@ -4391,21 +4391,21 @@ void rai::payment_observer::complete (rai::payment_status status)
 	}
 }
 
-std::unique_ptr<rai::rpc> rai::get_rpc (boost::asio::io_service & service_a, rai::node & node_a, rai::rpc_config const & config_a)
+std::unique_ptr<rai::rpc> rai::get_rpc (boost::asio::io_context & io_ctx_a, rai::node & node_a, rai::rpc_config const & config_a)
 {
 	std::unique_ptr<rpc> impl;
 
 	if (config_a.secure.enable)
 	{
 #ifdef RAIBLOCKS_SECURE_RPC
-		impl.reset (new rpc_secure (service_a, node_a, config_a));
+		impl.reset (new rpc_secure (io_ctx_a, node_a, config_a));
 #else
 		std::cerr << "RPC configured for TLS, but the node is not compiled with TLS support" << std::endl;
 #endif
 	}
 	else
 	{
-		impl.reset (new rpc (service_a, node_a, config_a));
+		impl.reset (new rpc (io_ctx_a, node_a, config_a));
 	}
 
 	return impl;

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -65,7 +65,7 @@ class payment_observer;
 class rpc
 {
 public:
-	rpc (boost::asio::io_service &, rai::node &, rai::rpc_config const &);
+	rpc (boost::asio::io_context &, rai::node &, rai::rpc_config const &);
 	virtual ~rpc () = default;
 	void start ();
 	virtual void accept ();
@@ -241,5 +241,5 @@ public:
 	bool rpc_control_impl ();
 };
 /** Returns the correct RPC implementation based on TLS configuration */
-std::unique_ptr<rai::rpc> get_rpc (boost::asio::io_service & service_a, rai::node & node_a, rai::rpc_config const & config_a);
+std::unique_ptr<rai::rpc> get_rpc (boost::asio::io_context & io_ctx_a, rai::node & node_a, rai::rpc_config const & config_a);
 }

--- a/rai/node/testing.cpp
+++ b/rai/node/testing.cpp
@@ -18,7 +18,7 @@ std::string rai::error_system_messages::message (int ev) const
 }
 
 rai::system::system (uint16_t port_a, size_t count_a) :
-alarm (service),
+alarm (io_ctx),
 work (1, nullptr)
 {
 	auto scale_str = std::getenv ("DEADLINE_SCALE_FACTOR");
@@ -32,7 +32,7 @@ work (1, nullptr)
 	{
 		rai::node_init init;
 		rai::node_config config (port_a + i, logging);
-		auto node (std::make_shared<rai::node> (init, service, rai::unique_path (), alarm, config, work));
+		auto node (std::make_shared<rai::node> (init, io_ctx, rai::unique_path (), alarm, config, work));
 		assert (!init.error ());
 		node->start ();
 		rai::uint256_union wallet;
@@ -105,7 +105,7 @@ void rai::system::deadline_set (std::chrono::duration<double, std::nano> const &
 std::error_code rai::system::poll (std::chrono::nanoseconds const & wait_time)
 {
 	std::error_code ec;
-	service.run_one_for (wait_time);
+	io_ctx.run_one_for (wait_time);
 
 	if (std::chrono::steady_clock::now () > deadline)
 	{

--- a/rai/node/testing.hpp
+++ b/rai/node/testing.hpp
@@ -38,7 +38,7 @@ public:
 	std::error_code poll (const std::chrono::nanoseconds & sleep_time = std::chrono::milliseconds (50));
 	void stop ();
 	void deadline_set (const std::chrono::duration<double, std::nano> & delta);
-	boost::asio::io_service service;
+	boost::asio::io_context io_ctx;
 	rai::alarm alarm;
 	std::vector<std::shared_ptr<rai::node>> nodes;
 	rai::logging logging;

--- a/rai/qt_system/entry.cpp
+++ b/rai/qt_system/entry.cpp
@@ -25,7 +25,7 @@ int main (int argc, char ** argv)
 		client_tabs->addTab (guis.back ()->client_window, boost::str (boost::format ("Wallet %1%") % i).c_str ());
 	}
 	client_tabs->show ();
-	rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
+	rai::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	QObject::connect (&application, &QApplication::aboutToQuit, [&]() {
 		system.stop ();
 	});

--- a/rai/rai_node/entry.cpp
+++ b/rai/rai_node/entry.cpp
@@ -369,7 +369,7 @@ int main (int argc, char * const * argv)
 				rai::logging logging;
 				auto path (rai::unique_path ());
 				logging.init (path);
-				auto node (std::make_shared<rai::node> (init, system.service, 24001, path, system.alarm, logging, work));
+				auto node (std::make_shared<rai::node> (init, system.io_ctx, 24001, path, system.alarm, logging, work));
 				rai::block_hash genesis_latest (node->latest (rai::test_genesis_key.pub));
 				rai::uint128_t genesis_balance (std::numeric_limits<rai::uint128_t>::max ());
 				// Generating keys
@@ -445,7 +445,7 @@ int main (int argc, char * const * argv)
 				rai::logging logging;
 				auto path (rai::unique_path ());
 				logging.init (path);
-				auto node (std::make_shared<rai::node> (init, system.service, 24001, path, system.alarm, logging, work));
+				auto node (std::make_shared<rai::node> (init, system.io_ctx, 24001, path, system.alarm, logging, work));
 				rai::block_hash genesis_latest (node->latest (rai::test_genesis_key.pub));
 				rai::uint128_t genesis_balance (std::numeric_limits<rai::uint128_t>::max ());
 				// Generating keys

--- a/rai/slow_test/node.cpp
+++ b/rai/slow_test/node.cpp
@@ -20,7 +20,7 @@ TEST (system, generate_mass_activity)
 TEST (system, generate_mass_activity_long)
 {
 	rai::system system (24000, 1);
-	rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
+	rai::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	size_t count (1000000000);
 	system.generate_mass_activity (count, *system.nodes[0]);
@@ -39,13 +39,13 @@ TEST (system, receive_while_synchronizing)
 	std::vector<boost::thread> threads;
 	{
 		rai::system system (24000, 1);
-		rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
+		rai::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 		system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 		size_t count (1000);
 		system.generate_mass_activity (count, *system.nodes[0]);
 		rai::keypair key;
 		rai::node_init init1;
-		auto node1 (std::make_shared<rai::node> (init1, system.service, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
+		auto node1 (std::make_shared<rai::node> (init1, system.io_ctx, 24001, rai::unique_path (), system.alarm, system.logging, system.work));
 		ASSERT_FALSE (init1.error ());
 		node1->network.send_keepalive (system.nodes[0]->network.endpoint ());
 		auto wallet (node1->wallets.create (1));


### PR DESCRIPTION
Also proposes using `io_ctx` instead of `service` for variable/field names; seems to make more sense after the change.