### PR TITLE
Remove random items from the uniquer sets

### DIFF
--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -1,10 +1,10 @@
 #include <rai/lib/blocks.hpp>
+#include <rai/lib/numbers.hpp>
 
 #include <boost/endian/conversion.hpp>
 
 #include <xxhash/xxhash.h>
 
-#include <cstdlib>
 
 /** Compare blocks, first by type, then content. This is an optimization over dynamic_cast, which is very slow on some platforms. */
 namespace
@@ -1566,11 +1566,9 @@ std::shared_ptr<rai::block> rai::block_uniquer::unique (std::shared_ptr<rai::blo
 		{
 			existing = block_a;
 		}
-
-		unsigned random_offset;
 		for (auto i (0); i < cleanup_count && blocks.size () > 0; ++i)
 		{
-			random_offset = std::rand () % blocks.size ();
+			auto random_offset (rai::random_pool.GenerateWord32(0, blocks.size () - 1));
 			auto existing (std::next (blocks.begin (), random_offset));
 			if (existing == blocks.end ())
 			{

--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -5,7 +5,6 @@
 
 #include <xxhash/xxhash.h>
 
-
 /** Compare blocks, first by type, then content. This is an optimization over dynamic_cast, which is very slow on some platforms. */
 namespace
 {

--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -1567,7 +1567,7 @@ std::shared_ptr<rai::block> rai::block_uniquer::unique (std::shared_ptr<rai::blo
 		}
 		for (auto i (0); i < cleanup_count && blocks.size () > 0; ++i)
 		{
-			auto random_offset (rai::random_pool.GenerateWord32(0, blocks.size () - 1));
+			auto random_offset (rai::random_pool.GenerateWord32 (0, blocks.size () - 1));
 			auto existing (std::next (blocks.begin (), random_offset));
 			if (existing == blocks.end ())
 			{

--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -4,6 +4,8 @@
 
 #include <xxhash/xxhash.h>
 
+#include <cstdlib>
+
 /** Compare blocks, first by type, then content. This is an optimization over dynamic_cast, which is very slow on some platforms. */
 namespace
 {
@@ -1564,11 +1566,12 @@ std::shared_ptr<rai::block> rai::block_uniquer::unique (std::shared_ptr<rai::blo
 		{
 			existing = block_a;
 		}
-		for (auto i (0); i < cleanup_count; ++i)
+
+		unsigned random_offset;
+		for (auto i (0); i < cleanup_count && blocks.size () > 0; ++i)
 		{
-			rai::uint256_union random;
-			rai::random_pool.GenerateBlock (random.bytes.data (), random.bytes.size ());
-			auto existing (blocks.find (random));
+			random_offset = std::rand () % blocks.size ();
+			auto existing (std::next (blocks.begin (), random_offset));
 			if (existing == blocks.end ())
 			{
 				existing = blocks.begin ();

--- a/rai/secure/common.cpp
+++ b/rai/secure/common.cpp
@@ -1,13 +1,13 @@
 #include <rai/secure/common.hpp>
 
 #include <rai/lib/interface.h>
+#include <rai/lib/numbers.hpp>
 #include <rai/node/common.hpp>
 #include <rai/secure/blockstore.hpp>
 #include <rai/secure/versioning.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 
-#include <cstdlib>
 #include <queue>
 
 #include <ed25519-donna/ed25519.h>
@@ -674,11 +674,9 @@ std::shared_ptr<rai::vote> rai::vote_uniquer::unique (std::shared_ptr<rai::vote>
 		{
 			existing = vote_a;
 		}
-
-		unsigned random_offset;
 		for (auto i (0); i < cleanup_count && votes.size () > 0; ++i)
 		{
-			random_offset = std::rand () % votes.size ();
+			auto random_offset (rai::random_pool.GenerateWord32(0, votes.size () - 1));
 			auto existing (std::next (votes.begin (), random_offset));
 			if (existing == votes.end ())
 			{

--- a/rai/secure/common.cpp
+++ b/rai/secure/common.cpp
@@ -7,6 +7,7 @@
 
 #include <boost/property_tree/json_parser.hpp>
 
+#include <cstdlib>
 #include <queue>
 
 #include <ed25519-donna/ed25519.h>
@@ -673,11 +674,12 @@ std::shared_ptr<rai::vote> rai::vote_uniquer::unique (std::shared_ptr<rai::vote>
 		{
 			existing = vote_a;
 		}
-		for (auto i (0); i < cleanup_count; ++i)
+
+		unsigned random_offset;
+		for (auto i (0); i < cleanup_count && votes.size () > 0; ++i)
 		{
-			rai::uint256_union random;
-			rai::random_pool.GenerateBlock (random.bytes.data (), random.bytes.size ());
-			auto existing (votes.find (random));
+			random_offset = std::rand () % votes.size ();
+			auto existing (std::next (votes.begin (), random_offset));
 			if (existing == votes.end ())
 			{
 				existing = votes.begin ();

--- a/rai/secure/common.cpp
+++ b/rai/secure/common.cpp
@@ -676,7 +676,7 @@ std::shared_ptr<rai::vote> rai::vote_uniquer::unique (std::shared_ptr<rai::vote>
 		}
 		for (auto i (0); i < cleanup_count && votes.size () > 0; ++i)
 		{
-			auto random_offset (rai::random_pool.GenerateWord32(0, votes.size () - 1));
+			auto random_offset (rai::random_pool.GenerateWord32 (0, votes.size () - 1));
 			auto existing (std::next (votes.begin (), random_offset));
 			if (existing == votes.end ())
 			{


### PR DESCRIPTION
When removing items from the vote uniquer `votes` set, use a random item rather than always the first item

Fixes #1471 

This change will also include the fix for the block uniquer