### PR TITLE
Reduce UI lockups

### DIFF
--- a/rai/qt/qt.hpp
+++ b/rai/qt/qt.hpp
@@ -151,7 +151,7 @@ class self_pane
 {
 public:
 	self_pane (rai_qt::wallet &, rai::account const &);
-	void refresh_balance ();
+	void set_balance_text (std::pair<rai::uint128_t, rai::uint128_t>);
 	QWidget * window;
 	QVBoxLayout * layout;
 	QHBoxLayout * self_layout;
@@ -351,5 +351,7 @@ public:
 	rai_qt::status active_status;
 	void pop_main_stack ();
 	void push_main_stack (QWidget *);
+	void ongoing_refresh ();
+	std::atomic<bool> needs_balance_refresh;
 };
 }


### PR DESCRIPTION
Several second lockups on beta on my account with tons of pending due to observers trigging pending balance calculations. This seems to fix it, as well as lockups when user initiates searching for pending and bootstrap.