### PR TITLE
Faster block existence check when the block type is known

### DIFF
--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -159,6 +159,7 @@ public:
 	std::shared_ptr<rai::block> block_random (rai::transaction const &) override;
 	void block_del (rai::transaction const &, rai::block_hash const &) override;
 	bool block_exists (rai::transaction const &, rai::block_hash const &) override;
+	bool block_exists (rai::transaction const &, rai::block_type, rai::block_hash const &) override;
 	rai::block_counts block_count (rai::transaction const &) override;
 	bool root_exists (rai::transaction const &, rai::uint256_union const &) override;
 

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1804,7 +1804,7 @@ void rai::node::send_keepalive (rai::endpoint const & endpoint_a)
 void rai::node::process_fork (rai::transaction const & transaction_a, std::shared_ptr<rai::block> block_a)
 {
 	auto root (block_a->root ());
-	if (!store.block_exists (transaction_a, block_a->hash ()) && store.root_exists (transaction_a, block_a->root ()))
+	if (!store.block_exists (transaction_a, block_a->type (), block_a->hash ()) && store.root_exists (transaction_a, block_a->root ()))
 	{
 		std::shared_ptr<rai::block> ledger_block (ledger.forked_block (transaction_a, *block_a));
 		if (ledger_block)
@@ -2583,13 +2583,13 @@ public:
 void rai::node::process_confirmed (std::shared_ptr<rai::block> block_a)
 {
 	auto hash (block_a->hash ());
-	bool exists (ledger.block_exists (hash));
+	bool exists (ledger.block_exists (block_a->type (), hash));
 	// Attempt to process confirmed block if it's not in ledger yet
 	if (!exists)
 	{
 		auto transaction (store.tx_begin_write ());
 		block_processor.process_receive_one (transaction, block_a);
-		exists = store.block_exists (transaction, hash);
+		exists = store.block_exists (transaction, block_a->type (), hash);
 	}
 	if (exists)
 	{

--- a/rai/secure/blockstore.hpp
+++ b/rai/secure/blockstore.hpp
@@ -200,6 +200,7 @@ public:
 	virtual std::shared_ptr<rai::block> block_random (rai::transaction const &) = 0;
 	virtual void block_del (rai::transaction const &, rai::block_hash const &) = 0;
 	virtual bool block_exists (rai::transaction const &, rai::block_hash const &) = 0;
+	virtual bool block_exists (rai::transaction const &, rai::block_type, rai::block_hash const &) = 0;
 	virtual rai::block_counts block_count (rai::transaction const &) = 0;
 	virtual bool root_exists (rai::transaction const &, rai::uint256_union const &) = 0;
 

--- a/rai/secure/ledger.cpp
+++ b/rai/secure/ledger.cpp
@@ -217,7 +217,7 @@ void ledger_processor::state_block (rai::state_block const & block_a)
 void ledger_processor::state_block_impl (rai::state_block const & block_a)
 {
 	auto hash (block_a.hash ());
-	auto existing (ledger.store.block_exists (transaction, hash));
+	auto existing (ledger.store.block_exists (transaction, block_a.type (), hash));
 	result.code = existing ? rai::process_result::old : rai::process_result::progress; // Have we seen this block before? (Unambiguous)
 	if (result.code == rai::process_result::progress)
 	{
@@ -328,7 +328,7 @@ void ledger_processor::state_block_impl (rai::state_block const & block_a)
 void ledger_processor::epoch_block_impl (rai::state_block const & block_a)
 {
 	auto hash (block_a.hash ());
-	auto existing (ledger.store.block_exists (transaction, hash));
+	auto existing (ledger.store.block_exists (transaction, block_a.type (), hash));
 	result.code = existing ? rai::process_result::old : rai::process_result::progress; // Have we seen this block before? (Unambiguous)
 	if (result.code == rai::process_result::progress)
 	{
@@ -391,7 +391,7 @@ void ledger_processor::epoch_block_impl (rai::state_block const & block_a)
 void ledger_processor::change_block (rai::change_block const & block_a)
 {
 	auto hash (block_a.hash ());
-	auto existing (ledger.store.block_exists (transaction, hash));
+	auto existing (ledger.store.block_exists (transaction, block_a.type (), hash));
 	result.code = existing ? rai::process_result::old : rai::process_result::progress; // Have we seen this block before? (Harmless)
 	if (result.code == rai::process_result::progress)
 	{
@@ -433,7 +433,7 @@ void ledger_processor::change_block (rai::change_block const & block_a)
 void ledger_processor::send_block (rai::send_block const & block_a)
 {
 	auto hash (block_a.hash ());
-	auto existing (ledger.store.block_exists (transaction, hash));
+	auto existing (ledger.store.block_exists (transaction, block_a.type (), hash));
 	result.code = existing ? rai::process_result::old : rai::process_result::progress; // Have we seen this block before? (Harmless)
 	if (result.code == rai::process_result::progress)
 	{
@@ -480,7 +480,7 @@ void ledger_processor::send_block (rai::send_block const & block_a)
 void ledger_processor::receive_block (rai::receive_block const & block_a)
 {
 	auto hash (block_a.hash ());
-	auto existing (ledger.store.block_exists (transaction, hash));
+	auto existing (ledger.store.block_exists (transaction, block_a.type (), hash));
 	result.code = existing ? rai::process_result::old : rai::process_result::progress; // Have we seen this block already?  (Harmless)
 	if (result.code == rai::process_result::progress)
 	{
@@ -545,7 +545,7 @@ void ledger_processor::receive_block (rai::receive_block const & block_a)
 void ledger_processor::open_block (rai::open_block const & block_a)
 {
 	auto hash (block_a.hash ());
-	auto existing (ledger.store.block_exists (transaction, hash));
+	auto existing (ledger.store.block_exists (transaction, block_a.type (), hash));
 	result.code = existing ? rai::process_result::old : rai::process_result::progress; // Have we seen this block already? (Harmless)
 	if (result.code == rai::process_result::progress)
 	{
@@ -682,6 +682,13 @@ bool rai::ledger::block_exists (rai::block_hash const & hash_a)
 {
 	auto transaction (store.tx_begin_read ());
 	auto result (store.block_exists (transaction, hash_a));
+	return result;
+}
+
+bool rai::ledger::block_exists (rai::block_type type, rai::block_hash const & hash_a)
+{
+	auto transaction (store.tx_begin_read ());
+	auto result (store.block_exists (transaction, type, hash_a));
 	return result;
 }
 
@@ -1005,7 +1012,7 @@ std::shared_ptr<rai::block> rai::ledger::successor (rai::transaction const & tra
 
 std::shared_ptr<rai::block> rai::ledger::forked_block (rai::transaction const & transaction_a, rai::block const & block_a)
 {
-	assert (!store.block_exists (transaction_a, block_a.hash ()));
+	assert (!store.block_exists (transaction_a, block_a.type (), block_a.hash ()));
 	auto root (block_a.root ());
 	assert (store.block_exists (transaction_a, root) || store.account_exists (transaction_a, root));
 	auto result (store.block_get (transaction_a, store.block_successor (transaction_a, root)));

--- a/rai/secure/ledger.hpp
+++ b/rai/secure/ledger.hpp
@@ -31,6 +31,7 @@ public:
 	rai::block_hash representative (rai::transaction const &, rai::block_hash const &);
 	rai::block_hash representative_calculated (rai::transaction const &, rai::block_hash const &);
 	bool block_exists (rai::block_hash const &);
+	bool block_exists (rai::block_type, rai::block_hash const &);
 	std::string block_text (char const *);
 	std::string block_text (rai::block_hash const &);
 	bool is_send (rai::transaction const &, rai::state_block const &);


### PR DESCRIPTION
After https://github.com/nanocurrency/raiblocks/pull/1483, `block_exists (stateblock)` is the next function that shows up in the profiling of `process_receive_one`. Currently when checking state blocks, four other tables are checked first. With this, the correct table is checked directly if the block type is known. In current `block_exists` (where the block type is unknown) is reimplemented in terms of the new one.