### PR TITLE
Extend test retry

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -44,7 +44,7 @@ run_tests() {
         TIMEOUT_TIME_ARG=""
     fi
 
-    if [ "$(date +%s)" -lt 1545350400 ]; then
+    if [ "$(date +%s)" -lt 1555718400 ]; then
         tries=(1 2 3 4 5 6 7 8 9)
     else
         tries=()

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -45,12 +45,12 @@ run_tests() {
     fi
 
     if [ "$(date +%s)" -lt 1555718400 ]; then
-        tries=(1 2 3 4 5 6 7 8 9)
+        tries=(_initial_ 1 2 3 4 5 6 7 8 9)
     else
-        tries=()
+        tries=(_initial_)
     fi
 
-    for try in _initial_ "${tries[@]}"; do
+    for try in "${tries[@]}"; do
         if [ "${try}" != '_initial_' ]; then
             echo "core_test failed: ${core_test_res}, retrying (try=${try})"
 


### PR DESCRIPTION
Two related changes:

1. The retry timer we set expired on December 20, 2018 -- before we had a chance to fix all the intermittently failing tests (originally set in #1218)
2. The bash specification contains a bug where empty arrays are treated as unbound, this works around that