### PR TITLE
Fix crash when announcing votes

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3325,6 +3325,12 @@ void rai::active_transactions::announce_votes (std::unique_lock<std::mutex> & lo
 					}
 					if (rep_votes.find (rep_acct) != rep_votes.end ())
 					{
+						if (j + 1 == reps->end())
+						{
+							reps->pop_back();
+							break;
+						}
+
 						std::swap (*j, reps->back ());
 						reps->pop_back ();
 						m = reps->end ();

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3325,9 +3325,9 @@ void rai::active_transactions::announce_votes (std::unique_lock<std::mutex> & lo
 					}
 					if (rep_votes.find (rep_acct) != rep_votes.end ())
 					{
-						if (j + 1 == reps->end())
+						if (j + 1 == reps->end ())
 						{
-							reps->pop_back();
+							reps->pop_back ();
 							break;
 						}
 


### PR DESCRIPTION
This was found using MSVC 2017 in a debug build; it's possible it happens with others.

When votes are being announced, there is a loop which traverses all the representatives. While iterating it checks if the current representative is inside rep_votes, if it is then it takes the last element of the representative vector and swaps it with the current one being iterated; the last element is then discarded. It then continues iterating using the newly swapped representative. This works fine until we are unfortunate enough to be iterating over the last element of the vector which also happens to be inside rep_votes. It gets popped off and our current iterator (j) becomes invalidated. The node then falls over when the next (j != m) condition statement is reached. I now check whether we are at the end of the vector and break out early if so.

I'm not familiar enough with the codebase to be able to reproduce this easily or create a suitable test for it (if someone is then feel free!). I just delete the Raiblocks user folder and start a fresh node from the live network, wait and hope for the best (or worst in this case).