### PR TITLE
Improve requesting frontier performance

### DIFF
--- a/rai/core_test/uint256_union.cpp
+++ b/rai/core_test/uint256_union.cpp
@@ -532,7 +532,7 @@ namespace
 template <typename Union, typename Bound>
 void assert_union_types ()
 {
-	static_assert ((std::is_same_v<Union, rai::uint128_union> && std::is_same_v<Bound, rai::uint128_t>) || (std::is_same_v<Union, rai::uint256_union> && std::is_same_v<Bound, rai::uint256_t>) || (std::is_same_v<Union, rai::uint512_union> && std::is_same_v<Bound, rai::uint512_t>),
+	static_assert ((std::is_same<Union, rai::uint128_union>::value && std::is_same<Bound, rai::uint128_t>::value) || (std::is_same<Union, rai::uint256_union>::value && std::is_same<Bound, rai::uint256_t>::value) || (std::is_same<Union, rai::uint512_union>::value && std::is_same<Bound, rai::uint512_t>::value),
 	"Union type needs to be consistent with the lower/upper Bound type");
 }
 

--- a/rai/core_test/uint256_union.cpp
+++ b/rai/core_test/uint256_union.cpp
@@ -3,6 +3,24 @@
 #include <rai/lib/interface.h>
 #include <rai/secure/common.hpp>
 
+namespace
+{
+template <typename Union, typename Bound>
+void assert_union_types ();
+
+template <typename Union, typename Bound>
+void test_union_operator_less_than ();
+
+template <typename Num>
+void check_operator_less_than (Num lhs, Num rhs);
+
+template <typename Union, typename Bound>
+void test_union_operator_greater_than ();
+
+template <typename Num>
+void check_operator_greater_than (Num lhs, Num rhs);
+}
+
 TEST (uint128_union, decode_dec)
 {
 	rai::uint128_union value;
@@ -41,6 +59,16 @@ TEST (uint128_union, decode_dec_overflow)
 	std::string text ("340282366920938463463374607431768211456");
 	auto error (value.decode_dec (text));
 	ASSERT_TRUE (error);
+}
+
+TEST (uint128_union, operator_less_than)
+{
+	test_union_operator_less_than<rai::uint128_union, rai::uint128_t> ();
+}
+
+TEST (uint128_union, operator_greater_than)
+{
+	test_union_operator_greater_than<rai::uint128_union, rai::uint128_t> ();
 }
 
 struct test_punct : std::moneypunct<char>
@@ -394,6 +422,11 @@ TEST (uint256_union, bounds)
 	ASSERT_TRUE (key.decode_account (bad2));
 }
 
+TEST (uint256_union, operator_less_than)
+{
+	test_union_operator_less_than<rai::uint256_union, rai::uint256_t> ();
+}
+
 class json_upgrade_test
 {
 public:
@@ -492,4 +525,72 @@ TEST (uint64_t, parse)
 	ASSERT_TRUE (rai::from_string_hex ("ffffffffffffffff0", value3));
 	uint64_t value4 (1);
 	ASSERT_TRUE (rai::from_string_hex ("", value4));
+}
+
+namespace
+{
+template <typename Union, typename Bound>
+void assert_union_types ()
+{
+	static_assert ((std::is_same_v<Union, rai::uint128_union> && std::is_same_v<Bound, rai::uint128_t>) || (std::is_same_v<Union, rai::uint256_union> && std::is_same_v<Bound, rai::uint256_t>) || (std::is_same_v<Union, rai::uint512_union> && std::is_same_v<Bound, rai::uint512_t>),
+	"Union type needs to be consistent with the lower/upper Bound type");
+}
+
+template <typename Union, typename Bound>
+void test_union_operator_less_than ()
+{
+	assert_union_types<Union, Bound> ();
+
+	// Small
+	check_operator_less_than (Union (123), Union (124));
+	check_operator_less_than (Union (124), Union (125));
+
+	// Medium
+	check_operator_less_than (Union (std::numeric_limits<uint16_t>::max () - 1), Union (std::numeric_limits<uint16_t>::max () + 1));
+	check_operator_less_than (Union (std::numeric_limits<uint32_t>::max () - 12345678), Union (std::numeric_limits<uint32_t>::max () - 123456));
+
+	// Large
+	check_operator_less_than (Union (std::numeric_limits<uint64_t>::max () - 555555555555), Union (std::numeric_limits<uint64_t>::max () - 1));
+
+	// Boundary values
+	check_operator_less_than (Union (std::numeric_limits<Bound>::min ()), Union (std::numeric_limits<Bound>::max ()));
+}
+
+template <typename Num>
+void check_operator_less_than (Num lhs, Num rhs)
+{
+	ASSERT_TRUE (lhs < rhs);
+	ASSERT_FALSE (rhs < lhs);
+	ASSERT_FALSE (lhs < lhs);
+	ASSERT_FALSE (rhs < rhs);
+}
+
+template <typename Union, typename Bound>
+void test_union_operator_greater_than ()
+{
+	assert_union_types<Union, Bound> ();
+
+	// Small
+	check_operator_greater_than (Union (124), Union (123));
+	check_operator_greater_than (Union (125), Union (124));
+
+	// Medium
+	check_operator_greater_than (Union (std::numeric_limits<uint16_t>::max () + 1), Union (std::numeric_limits<uint16_t>::max () - 1));
+	check_operator_greater_than (Union (std::numeric_limits<uint32_t>::max () - 123456), Union (std::numeric_limits<uint32_t>::max () - 12345678));
+
+	// Large
+	check_operator_greater_than (Union (std::numeric_limits<uint64_t>::max () - 1), Union (std::numeric_limits<uint64_t>::max () - 555555555555));
+
+	// Boundary values
+	check_operator_greater_than (Union (std::numeric_limits<Bound>::max ()), Union (std::numeric_limits<Bound>::min ()));
+}
+
+template <typename Num>
+void check_operator_greater_than (Num lhs, Num rhs)
+{
+	ASSERT_TRUE (lhs > rhs);
+	ASSERT_FALSE (rhs > lhs);
+	ASSERT_FALSE (lhs > lhs);
+	ASSERT_FALSE (rhs > rhs);
+}
 }

--- a/rai/lib/numbers.cpp
+++ b/rai/lib/numbers.cpp
@@ -290,10 +290,10 @@ bool rai::uint512_union::operator== (rai::uint512_union const & other_a) const
 	return bytes == other_a.bytes;
 }
 
-rai::uint512_union::uint512_union(rai::uint512_t const & number_a)
+rai::uint512_union::uint512_union (rai::uint512_t const & number_a)
 {
-	bytes.fill(0);
-	boost::multiprecision::export_bits (number_a, bytes.rbegin(), 8, false);
+	bytes.fill (0);
+	boost::multiprecision::export_bits (number_a, bytes.rbegin (), 8, false);
 }
 
 void rai::uint512_union::clear ()
@@ -304,7 +304,7 @@ void rai::uint512_union::clear ()
 rai::uint512_t rai::uint512_union::number () const
 {
 	rai::uint512_t result;
-	boost::multiprecision::import_bits(result, bytes.begin(), bytes.end(), false);
+	boost::multiprecision::import_bits (result, bytes.begin (), bytes.end (), false);
 	return result;
 }
 
@@ -434,8 +434,8 @@ rai::uint128_union::uint128_union (uint64_t value_a)
 
 rai::uint128_union::uint128_union (rai::uint128_t const & number_a)
 {
-	bytes.fill(0);
-	boost::multiprecision::export_bits(number_a, bytes.rbegin(), 8, false);
+	bytes.fill (0);
+	boost::multiprecision::export_bits (number_a, bytes.rbegin (), 8, false);
 }
 
 bool rai::uint128_union::operator== (rai::uint128_union const & other_a) const

--- a/rai/lib/numbers.cpp
+++ b/rai/lib/numbers.cpp
@@ -129,12 +129,8 @@ bool rai::uint256_union::decode_account (std::string const & source_a)
 
 rai::uint256_union::uint256_union (rai::uint256_t const & number_a)
 {
-	rai::uint256_t number_l (number_a);
-	for (auto i (bytes.rbegin ()), n (bytes.rend ()); i != n; ++i)
-	{
-		*i = static_cast<uint8_t> (number_l & static_cast<uint8_t> (0xff));
-		number_l >>= 8;
-	}
+	bytes.fill (0);
+	boost::multiprecision::export_bits (number_a, bytes.rbegin (), 8, false);
 }
 
 bool rai::uint256_union::operator== (rai::uint256_union const & other_a) const
@@ -164,7 +160,7 @@ std::string rai::uint256_union::to_string () const
 
 bool rai::uint256_union::operator< (rai::uint256_union const & other_a) const
 {
-	return number () < other_a.number ();
+	return std::memcmp (bytes.data (), other_a.bytes.data (), 32) < 0;
 }
 
 rai::uint256_union & rai::uint256_union::operator^= (rai::uint256_union const & other_a)
@@ -203,13 +199,7 @@ void rai::uint256_union::clear ()
 rai::uint256_t rai::uint256_union::number () const
 {
 	rai::uint256_t result;
-	auto shift (0);
-	for (auto i (bytes.begin ()), n (bytes.end ()); i != n; ++i)
-	{
-		result <<= shift;
-		result |= *i;
-		shift = 8;
-	}
+	boost::multiprecision::import_bits (result, bytes.begin (), bytes.end (), false);
 	return result;
 }
 
@@ -300,14 +290,10 @@ bool rai::uint512_union::operator== (rai::uint512_union const & other_a) const
 	return bytes == other_a.bytes;
 }
 
-rai::uint512_union::uint512_union (rai::uint512_t const & number_a)
+rai::uint512_union::uint512_union(rai::uint512_t const & number_a)
 {
-	rai::uint512_t number_l (number_a);
-	for (auto i (bytes.rbegin ()), n (bytes.rend ()); i != n; ++i)
-	{
-		*i = static_cast<uint8_t> (number_l & static_cast<uint8_t> (0xff));
-		number_l >>= 8;
-	}
+	bytes.fill(0);
+	boost::multiprecision::export_bits (number_a, bytes.rbegin(), 8, false);
 }
 
 void rai::uint512_union::clear ()
@@ -318,13 +304,7 @@ void rai::uint512_union::clear ()
 rai::uint512_t rai::uint512_union::number () const
 {
 	rai::uint512_t result;
-	auto shift (0);
-	for (auto i (bytes.begin ()), n (bytes.end ()); i != n; ++i)
-	{
-		result <<= shift;
-		result |= *i;
-		shift = 8;
-	}
+	boost::multiprecision::import_bits(result, bytes.begin(), bytes.end(), false);
 	return result;
 }
 
@@ -452,14 +432,10 @@ rai::uint128_union::uint128_union (uint64_t value_a)
 	*this = rai::uint128_t (value_a);
 }
 
-rai::uint128_union::uint128_union (rai::uint128_t const & value_a)
+rai::uint128_union::uint128_union (rai::uint128_t const & number_a)
 {
-	rai::uint128_t number_l (value_a);
-	for (auto i (bytes.rbegin ()), n (bytes.rend ()); i != n; ++i)
-	{
-		*i = static_cast<uint8_t> (number_l & static_cast<uint8_t> (0xff));
-		number_l >>= 8;
-	}
+	bytes.fill(0);
+	boost::multiprecision::export_bits(number_a, bytes.rbegin(), 8, false);
 }
 
 bool rai::uint128_union::operator== (rai::uint128_union const & other_a) const
@@ -474,24 +450,18 @@ bool rai::uint128_union::operator!= (rai::uint128_union const & other_a) const
 
 bool rai::uint128_union::operator< (rai::uint128_union const & other_a) const
 {
-	return number () < other_a.number ();
+	return std::memcmp (bytes.data (), other_a.bytes.data (), 16) < 0;
 }
 
 bool rai::uint128_union::operator> (rai::uint128_union const & other_a) const
 {
-	return number () > other_a.number ();
+	return std::memcmp (bytes.data (), other_a.bytes.data (), 16) > 0;
 }
 
 rai::uint128_t rai::uint128_union::number () const
 {
 	rai::uint128_t result;
-	auto shift (0);
-	for (auto i (bytes.begin ()), n (bytes.end ()); i != n; ++i)
-	{
-		result <<= shift;
-		result |= *i;
-		shift = 8;
-	}
+	boost::multiprecision::import_bits (result, bytes.begin (), bytes.end (), false);
 	return result;
 }
 


### PR DESCRIPTION
On an MSVC Release build I profiled bootstrapping a fresh node for 30 seconds (chosen arbitrarily) to see if there was anything obvious which easily be improved. I found that 7% of the time was spent inside rai::uint256_union::number() when requesting frontiers.

There is a boost function boost::multiprecision::import_bits() which takes a sequence of bytes and constructs the appropriate multiprecision number (and conversely export_bits() to do the opposite). I tried using this instead and there was a small performance improvement. Next I looked at the callers and the majority were from the less than operator rai::uint256_union::operator<. Inside it, it calls number() on each operand and does the comparison with the result. However I think this step is unnecessary, and the bytes can be compared directly with std::memcmp. Results shown below (time spent inside operator<):

Original: **7%**
Using boost::import_bits() inside number (): **3.18%**
Replacing number () with memcmp: **0.3%**

The numbers are even greater on a debug build (sometimes as high as 20% in the current build). While the import_bits() function change no longer affects this specific result, I have left it in as it is still beneficial. I also modified the *_union constructors to call export_bits to modify the bytes array with the passed in number. Some tests have been added to cover the changes to operator<.