### PR TITLE
Migrate existing data from ~/RaiBlocks to ~/Nano

### DIFF
--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -58,6 +58,18 @@ int main (int argc, char * const * argv)
 	}
 	boost::program_options::notify (vm);
 	int result (0);
+
+	if (!vm.count ("data_path"))
+	{
+		std::string error_string;
+		if (!nano::migrate_working_path (error_string))
+		{
+			std::cerr << error_string << std::endl;
+
+			return 1;
+		}
+	}
+
 	boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 	auto ec = nano::handle_node_options (vm);
 

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -302,6 +302,16 @@ int main (int argc, char * const * argv)
 		boost::program_options::store (boost::program_options::command_line_parser (argc, argv).options (description).allow_unregistered ().run (), vm);
 		boost::program_options::notify (vm);
 		int result (0);
+
+		if (!vm.count ("data_path"))
+		{
+			std::string error_string;
+			if (!nano::migrate_working_path (error_string))
+			{
+				throw std::runtime_error (error_string);
+			}
+		}
+
 		auto ec = nano::handle_node_options (vm);
 		if (ec == nano::error_cli::unknown_command)
 		{

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -5,21 +5,78 @@
 
 static std::vector<boost::filesystem::path> all_unique_paths;
 
-boost::filesystem::path nano::working_path ()
+boost::filesystem::path nano::working_path (bool legacy)
 {
 	auto result (nano::app_path ());
 	switch (nano::nano_network)
 	{
 		case nano::nano_networks::nano_test_network:
-			result /= "NanoTest";
+			if (!legacy)
+			{
+				result /= "NanoTest";
+			}
+			else
+			{
+				result /= "RaiBlocksTest";
+			}
 			break;
 		case nano::nano_networks::nano_beta_network:
-			result /= "NanoBeta";
+			if (!legacy)
+			{
+				result /= "NanoBeta";
+			}
+			else
+			{
+				result /= "RaiBlocksBeta";
+			}
 			break;
 		case nano::nano_networks::nano_live_network:
-			result /= "Nano";
+			if (!legacy)
+			{
+				result /= "Nano";
+			}
+			else
+			{
+				result /= "RaiBlocks";
+			}
 			break;
 	}
+	return result;
+}
+
+bool nano::migrate_working_path (std::string & error_string)
+{
+	bool result (true);
+	auto old_path (nano::working_path (true));
+	auto new_path (nano::working_path ());
+
+	if (old_path != new_path)
+	{
+		boost::system::error_code status_error;
+
+		auto old_path_status (boost::filesystem::status (old_path, status_error));
+		if (status_error == boost::system::errc::success && boost::filesystem::exists (old_path_status) && boost::filesystem::is_directory (old_path_status))
+		{
+			auto new_path_status (boost::filesystem::status (new_path, status_error));
+			if (!boost::filesystem::exists (new_path_status))
+			{
+				boost::system::error_code rename_error;
+
+				boost::filesystem::rename (old_path, new_path, rename_error);
+				if (rename_error != boost::system::errc::success)
+				{
+					std::stringstream error_string_stream;
+
+					error_string_stream << "Unable to migrate data from " << old_path << " to " << new_path;
+
+					error_string = error_string_stream.str ();
+
+					result = false;
+				}
+			}
+		}
+	}
+
 	return result;
 }
 

--- a/nano/secure/utility.hpp
+++ b/nano/secure/utility.hpp
@@ -21,7 +21,9 @@ namespace nano
 using bufferstream = boost::iostreams::stream_buffer<boost::iostreams::basic_array_source<uint8_t>>;
 using vectorstream = boost::iostreams::stream_buffer<boost::iostreams::back_insert_device<std::vector<uint8_t>>>;
 // OS-specific way of finding a path to a home directory.
-boost::filesystem::path working_path ();
+boost::filesystem::path working_path (bool = false);
+// Function to migrate working_path() from above from RaiBlocks to Nano
+bool migrate_working_path (std::string &);
 // Get a unique path within the home directory, used for testing.
 // Any directories created at this location will be removed when a test finishes.
 boost::filesystem::path unique_path ();


### PR DESCRIPTION
As a part of the rename from RaiBlocks to Nano (#1504), we now default to a different data path.

This adds a migration from the old/legacy path to the new path.