### PR TITLE
UI feedback when changing seed

### DIFF
--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -394,6 +394,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						nano::raw_key key;
 						if (!key.data.decode_hex (vm["key"].as<std::string> ()))
 						{
+							std::cout << "Changing seed and caching work. Please wait..." << std::endl;
 							wallet->change_seed (transaction, key);
 						}
 						else


### PR DESCRIPTION
Closes https://github.com/nanocurrency/raiblocks/issues/1340
On weak cpu's, changing seed can take a few minutes due to work generation (determinstic_insert caches work for the first four accounts) and users may think the command is stuck. This prints a bit of info about what's going on.