### PR TITLE
Add recursive_mutex to foreach_representative

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -363,7 +363,10 @@ TEST (node, unlock_search)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	system.wallet (0)->insert_adhoc (key2.prv);
-	system.wallet (0)->store.password.value_set (nano::keypair ().prv);
+	{
+		std::lock_guard<std::recursive_mutex> lock (system.wallet (0)->store.mutex);
+		system.wallet (0)->store.password.value_set (nano::keypair ().prv);
+	}
 	auto node (system.nodes[0]);
 	{
 		auto transaction (system.wallet (0)->wallets.tx_begin (true));

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1395,6 +1395,7 @@ void nano::wallets::foreach_representative (nano::transaction const & transactio
 	for (auto i (items.begin ()), n (items.end ()); i != n; ++i)
 	{
 		auto & wallet (*i->second);
+		std::lock_guard<std::recursive_mutex> lock (wallet.store.mutex);
 		for (auto j (wallet.store.begin (transaction_a)), m (wallet.store.end ()); j != m; ++j)
 		{
 			nano::account account (j->first);


### PR DESCRIPTION
To prevent node.unlock_search assert

Initially part of v17 https://github.com/nanocurrency/raiblocks/pull/1409